### PR TITLE
Add qemu-lite 01.org github url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ information.
 Requirements
 ------------
 
-- A Qemu_ hypervisor that supports the ``pc-lite`` machine type.
+- A Qemu_ hypervisor that supports the ``pc-lite`` machine type. (qemu-lite_)
 
 Platform Support
 ----------------
@@ -416,6 +416,8 @@ Links
 .. _`Clear Linux`: https://clearlinux.org/
 
 .. _`Qemu`: http://qemu.org
+
+.. _`qemu-lite`: https://github.com/01org/qemu-lite
 
 .. _OCI: https://www.opencontainers.org/
 


### PR DESCRIPTION
This commit adds the link to the source code of a qemu with pc-lite
support. While qemu upstream is being updated and patches merged.
