### PR TITLE
configure.ac: add libnetlink check from iproute2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,7 +135,11 @@ AC_ARG_WITH([qemu-path],
     [with_qemu_path=no]
 )
 
-
+# Check for netlink from iproute2
+AC_CHECK_HEADERS(libnetlink.h,  dummy=yes,
+    AC_MSG_ERROR(libnetlink header file from iproute2 is required))
+AC_SEARCH_LIBS(rtnl_close, netlink, dummy=yes,
+    AC_MSG_ERROR(netlink library support from iproute2 is required))
 
 AC_CACHE_CHECK(
     [for qemu that supports pc-lite machine], [ac_cv_path_QEMU],


### PR DESCRIPTION
Check for libnetlink header and library in configure.ac.
This library is shipped by iproute2 and is needed to
compile network module.

Signed-off-by: Miguel Bernal Marin <miguel.bernal.marin@linux.intel.com>