### PR TITLE
DOCS: custom docker systemd, cc-image download

### DIFF
--- a/INSTALL_DOCKER.rst
+++ b/INSTALL_DOCKER.rst
@@ -209,12 +209,16 @@ Locate where your OCI runtime got installed
       which cc-oci-runtime
       #typically /usr/bin/cc-oci-runtime
 
-Then edit the Docker_ systemd unit file ExecStart to make `Clear Containers`_ the default runtime.
+Then create a custom Docker_ systemd unit file to make `Clear Containers`_ the default runtime.
 
   ::
 
-    Edit: /usr/lib/systemd/system/docker-upstream.service
-    ExecStart=/usr/bin/dockerd-upstream --add-runtime cor=/usr/bin/cc-oci-runtime --default-runtime=cor -H fd://
+    sudo mkdir -p /etc/systemd/system/docker-upstream.service.d
+    cat << EOF | sudo tee -a /etc/systemd/system/docker-upstream.service.d/driver.conf
+    [Service]
+    ExecStart=
+    ExecStart=/usr/bin/dockerd-upstream --add-runtime cor=/usr/bin/cc-oci-runtime  --default-runtime=cor -H fd:// --storage-driver=overlay
+    EOF
 
 
 Install the Clear Container container kernel image
@@ -226,9 +230,10 @@ Install the Clear Container container kernel image
 
     sudo mkdir -p /var/lib/cc-oci-runtime/data/{image,kernel}
     cd /var/lib/cc-oci-runtime/data/image/
-    sudo curl -O https://download.clearlinux.org/releases/8900/clear/clear-8900-containers.img.xz
-    sudo unxz clear-8900-containers.img.xz
-    sudo cp -s clear-8900-containers.img clear-containers.img
+    latest=`curl -s https://download.clearlinux.org/latest`
+    sudo curl -O https://download.clearlinux.org/releases/${latest}/clear/clear-${latest}-containers.img.xz
+    sudo unxz clear-${latest}-containers.img.xz
+    sudo cp -s clear-${latest}-containers.img clear-containers.img
     sudo cp -s /usr/lib/kernel/vmlinux-4.5-9.container.testing /var/lib/cc-oci-runtime/data/kernel/vmlinux.container
 
 Restart Docker Again


### PR DESCRIPTION
* In order make cc available and not lose configuration settings in the
next upgrade of docker, we must create "our" systemd driver.conf to
overwrite default configuration shipped by the package.

* Downloading images of clearcontainers should always point to the latest
image released, with the change introduced here we make sure the user
download the latest cc image.