### PR TITLE
Add support for comments in hypervisor.args

### DIFF
--- a/tests/hypervisor_test.c
+++ b/tests/hypervisor_test.c
@@ -473,13 +473,71 @@ START_TEST(test_cc_oci_vm_args_get) {
 	ck_assert (! cc_oci_vm_args_get (&config, &args));
 
 	/* recreate the args file */
-	ret = g_file_set_contents (args_file, "\n", -1, NULL);
+	ret = g_file_set_contents (args_file, "hello # comment\n", -1, NULL);
 	ck_assert (ret);
 
 	ck_assert (cc_oci_vm_args_get (&config, &args));
 
-	ck_assert (! g_strcmp0 (args[0], ""));
+	ck_assert (! g_strcmp0 (args[0], "hello"));
 	ck_assert (! args[1]);
+	g_strfreev (args);
+
+	/* recreate the args file */
+	ret = g_file_set_contents (args_file, "hello# comment\n", -1, NULL);
+	ck_assert (ret);
+
+	ck_assert (cc_oci_vm_args_get (&config, &args));
+
+	ck_assert (! g_strcmp0 (args[0], "hello# comment"));
+	ck_assert (! args[1]);
+	g_strfreev (args);
+
+	/* recreate the args file */
+	ret = g_file_set_contents (args_file, "hello\# comment\n", -1, NULL);
+	ck_assert (ret);
+
+	ck_assert (cc_oci_vm_args_get (&config, &args));
+
+	ck_assert (! g_strcmp0 (args[0], "hello\# comment"));
+	ck_assert (! args[1]);
+	g_strfreev (args);
+
+	/* recreate the args file */
+	ret = g_file_set_contents (args_file, "hello\t # comment\n", -1, NULL);
+	ck_assert (ret);
+
+	ck_assert (cc_oci_vm_args_get (&config, &args));
+
+	ck_assert (! g_strcmp0 (args[0], "hello"));
+	ck_assert (! args[1]);
+	g_strfreev (args);
+
+	/* recreate the args file */
+	ret = g_file_set_contents (args_file, "hello#comment\n", -1, NULL);
+	ck_assert (ret);
+
+	ck_assert (cc_oci_vm_args_get (&config, &args));
+
+	ck_assert (! g_strcmp0 (args[0], "hello#comment"));
+	ck_assert (! args[1]);
+	g_strfreev (args);
+
+	/* recreate the args file */
+	ret = g_file_set_contents (args_file, "# comment\n", -1, NULL);
+	ck_assert (ret);
+
+	ck_assert (cc_oci_vm_args_get (&config, &args));
+
+	ck_assert(! args[0]);
+	g_strfreev (args);
+
+	/* recreate the args file */
+	ret = g_file_set_contents (args_file, "# comment", -1, NULL);
+	ck_assert (ret);
+
+	ck_assert (cc_oci_vm_args_get (&config, &args));
+
+	ck_assert(! args[0]);
 	g_strfreev (args);
 
 	/* recreate the args file */


### PR DESCRIPTION
When a word begins with '#' that word and all remaining characters
will be treated as comments (will be ignored)

example:
input text:
```
line #comment
#comment
line#
line#text
line\#text
line #
line # comment
line \# #comment
```
Result:
```
line

line#
line#text
line\#text
line
line
line \#
```

Fixes #35

Signed-off-by: Julio Montes <julio.montes@intel.com>