### PR TITLE
Simplify hypervisor tag processing code by tabulating data

### DIFF
--- a/src/hypervisor.c
+++ b/src/hypervisor.c
@@ -147,6 +147,23 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 
 	procsock_device = g_strdup_printf ("socket,id=procsock,path=%s,server,nowait", config->state.procsock_path);
 
+	struct special_tag {
+		const gchar* name;
+		const gchar* value;
+	} special_tags[] = {
+		{ "@WORKLOAD_DIR@"  , config->oci.root.path      },
+		{ "@KERNEL@"        , config->vm->kernel_path    },
+		{ "@KERNEL_PARAMS@" , config->vm->kernel_params  },
+		{ "@IMAGE@"         , config->vm->image_path     },
+		{ "@SIZE@"          , bytes                      },
+		{ "@COMMS_SOCKET@"  , config->state.comms_path   },
+		{ "@PROCESS_SOCKET@", procsock_device            },
+		{ "@CONSOLE_DEVICE@", console_device             },
+		{ "@NAME@"          , g_strrstr(uuid_str, "-")+1 },
+		{ "@UUID@"          , uuid_str                   },
+		{ NULL }
+	};
+
 	for (arg = args, count = 0; arg && *arg; arg++, count++) {
 		if (! count) {
 			/* command must be the first entry */
@@ -160,62 +177,10 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 			}
 		}
 
-		ret = cc_oci_replace_string (arg, "@WORKLOAD_DIR@",
-				config->oci.root.path);
-		if (! ret) {
-			goto out;
-		}
-
-		ret = cc_oci_replace_string (arg, "@KERNEL@",
-				config->vm->kernel_path);
-		if (! ret) {
-			goto out;
-		}
-
-		ret = cc_oci_replace_string (arg, "@KERNEL_PARAMS@",
-				config->vm->kernel_params);
-		if (! ret) {
-			goto out;
-		}
-
-		ret = cc_oci_replace_string (arg, "@IMAGE@",
-				config->vm->image_path);
-		if (! ret) {
-			goto out;
-		}
-
-		ret = cc_oci_replace_string (arg, "@SIZE@", bytes);
-		if (! ret) {
-			goto out;
-		}
-
-		ret = cc_oci_replace_string (arg, "@COMMS_SOCKET@",
-				config->state.comms_path);
-		if (! ret) {
-			goto out;
-		}
-
-		ret = cc_oci_replace_string (arg, "@PROCESS_SOCKET@",
-				procsock_device);
-		if (! ret) {
-			goto out;
-		}
-
-		ret = cc_oci_replace_string (arg, "@CONSOLE_DEVICE@",
-				console_device);
-		if (! ret) {
-			goto out;
-		}
-
-		ret = cc_oci_replace_string (arg, "@NAME@",
-				g_strrstr(uuid_str, "-")+1);
-		if (! ret) {
-			goto out;
-		}
-
-		ret = cc_oci_replace_string (arg, "@UUID@", uuid_str);
-		if (! ret) {
-			goto out;
+		for (struct special_tag* tag=special_tags; tag && tag->name; tag++) {
+			if (! cc_oci_replace_string(arg, tag->name, tag->value)) {
+				goto out;
+			}
 		}
 	}
 


### PR DESCRIPTION
This patch reduces code lines and makes code simpler and readable.
This patch won't decrease the calls to cc_oci_replace_string.

Signed-off-by: Julio Montes <julio.montes@intel.com>