### PR TITLE
travis: resolved dependencies to build cc-oci-runtime

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+glib_version=2.49.4
+json_glib_version=1.2.2
+check_version=0.10.0
+
+# Install required dependencies to build
+# glib, json-glib, check and cc-oci-runtime
+sudo apt-get -qq install valgrind lcov uuid-dev pkg-config \
+  zlib1g-dev libffi-dev gettext libpcre3-dev texinfo gtk-doc-tools cppcheck
+
+mkdir cor-dependencies
+pushd cor-dependencies
+
+# Build glib
+curl -L -O "https://github.com/GNOME/glib/archive/${glib_version}.tar.gz"
+tar -xvf "${glib_version}.tar.gz"
+pushd "glib-${glib_version}"
+bash autogen.sh --prefix=/usr
+make
+sudo make install
+popd
+
+# Build json-glib
+curl -L -O "https://github.com/GNOME/json-glib/archive/${json_glib_version}.tar.gz"
+tar -xvf "${json_glib_version}.tar.gz"
+pushd "json-glib-${json_glib_version}"
+bash autogen.sh --prefix=/usr
+make
+sudo make install
+popd
+
+# Build check
+curl -L -O "https://github.com/libcheck/check/archive/${check_version}.tar.gz"
+tar -xvf "${check_version}.tar.gz"
+pushd "check-${check_version}"
+autoreconf --install
+./configure --prefix=/usr
+make
+sudo make install
+popd
+
+# Install bats
+git clone https://github.com/sstephenson/bats.git
+pushd bats
+sudo ./install.sh /usr/local
+popd
+
+sudo ldconfig
+popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,39 +5,8 @@ language: c
 compiler: gcc
 
 before_script:
-- sudo apt-get -qq install valgrind lcov uuid-dev pkg-config zlib1g-dev libffi-dev gettext libpcre3-dev texinfo gtk-doc-tools cppcheck
-- mkdir cor-dependencies
-- pushd cor-dependencies
-- curl -L -O https://github.com/GNOME/glib/archive/2.49.4.tar.gz
-- tar -xvf 2.49.4.tar.gz
-- pushd glib-2.49.4
-- bash autogen.sh --prefix=/usr
-- make
-- sudo make install
-- popd
-- curl -L -O https://github.com/GNOME/json-glib/archive/1.2.2.tar.gz
-- tar -xvf 1.2.2.tar.gz
-- pushd json-glib-1.2.2
-- bash autogen.sh --prefix=/usr
-- make
-- sudo make install
-- popd
-- curl -L -O https://github.com/libcheck/check/archive/0.10.0.tar.gz
-- tar -xvf 0.10.0.tar.gz
-- pushd check-0.10.0
-- autoreconf --install
-- ./configure --prefix=/usr
-- make
-- sudo make install
-- popd
-- git clone https://github.com/sstephenson/bats.git
-- pushd bats
-- sudo ./install.sh /usr/local
-- popd
-- sudo ldconfig
-- popd
+- ./.travis-setup.sh
 
 script:
 - ./autogen.sh --enable-cppcheck --enable-valgrind
 - make
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,43 @@
+sudo: required
+dist: trusty
+
 language: c
 compiler: gcc
 
+before_script:
+- sudo apt-get -qq install valgrind lcov uuid-dev pkg-config zlib1g-dev libffi-dev gettext libpcre3-dev texinfo gtk-doc-tools cppcheck
+- mkdir cor-dependencies
+- pushd cor-dependencies
+- curl -L -O https://github.com/GNOME/glib/archive/2.49.4.tar.gz
+- tar -xvf 2.49.4.tar.gz
+- pushd glib-2.49.4
+- bash autogen.sh --prefix=/usr
+- make
+- sudo make install
+- popd
+- curl -L -O https://github.com/GNOME/json-glib/archive/1.2.2.tar.gz
+- tar -xvf 1.2.2.tar.gz
+- pushd json-glib-1.2.2
+- bash autogen.sh --prefix=/usr
+- make
+- sudo make install
+- popd
+- curl -L -O https://github.com/libcheck/check/archive/0.10.0.tar.gz
+- tar -xvf 0.10.0.tar.gz
+- pushd check-0.10.0
+- autoreconf --install
+- ./configure --prefix=/usr
+- make
+- sudo make install
+- popd
+- git clone https://github.com/sstephenson/bats.git
+- pushd bats
+- sudo ./install.sh /usr/local
+- popd
+- sudo ldconfig
+- popd
+
 script:
-- echo "Empty for now"
+- ./autogen.sh --enable-cppcheck --enable-valgrind
+- make
+


### PR DESCRIPTION
travis: resolved dependencies to build cc-oci-runtime

needed to build glib, json-glib and libcheck from sources
still have some issues with unit tests that need to investigate
and resolve before adding those checks to travis.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>