### PR TITLE
tests: Fix the cc_oci_expand_cmdline() test

### DIFF
--- a/tests/hypervisor_test.c
+++ b/tests/hypervisor_test.c
@@ -65,7 +65,12 @@ check_full_expansion (struct cc_oci_config *config,
 	if (g_strcmp0 (args[5], "comms-path")) {
 		return false;
 	}
-	if (g_strcmp0 (args[6], "stdio,id=charconsole0,signal=off")) {
+
+	gchar *console = g_strdup_printf ("serial,id=charconsole0,path=%s",
+					  config->console);
+	gboolean ok = g_strcmp0 (args[6], console) == 0;
+	g_free (console);
+	if (!ok) {
 		return false;
 	}
 


### PR DESCRIPTION
In commit:

    commit 396ff49a635916c784b95c49e53cd6e408fd9321
    Author: Archana Shinde <archana.m.shinde@intel.com>
    Date:   Fri Jul 29 17:40:23 2016 +0000

        Redirect stdio to the containerd provided pseudoterminal for console
        case.

The console device was changed, but not the corresponding unit test. Fix
that.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>