### PR TITLE
Networking: Remove netlink dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -136,10 +136,10 @@ AC_ARG_WITH([qemu-path],
 )
 
 # Check for netlink from iproute2
-AC_CHECK_HEADERS(libnetlink.h,  dummy=yes,
-    AC_MSG_ERROR(libnetlink header file from iproute2 is required))
-AC_SEARCH_LIBS(rtnl_close, netlink, dummy=yes,
-    AC_MSG_ERROR(netlink library support from iproute2 is required))
+#AC_CHECK_HEADERS(libnetlink.h,  dummy=yes,
+#    AC_MSG_ERROR(libnetlink header file from iproute2 is required))
+#AC_SEARCH_LIBS(rtnl_close, netlink, dummy=yes,
+#    AC_MSG_ERROR(netlink library support from iproute2 is required))
 
 AC_CACHE_CHECK(
     [for qemu that supports pc-lite machine], [ac_cv_path_QEMU],


### PR DESCRIPTION
Latest ubuntu and hence travis does not support libnetlink.
Remove the libnetlink dependency for now

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>