### PR TITLE
WIP: RFC: Enable exec

### DIFF
--- a/src/command.h
+++ b/src/command.h
@@ -74,6 +74,7 @@ struct start_data {
 	gchar *bundle;
 	gchar *console;
 	gchar *pid_file;
+	gchar *process_json;
 	gboolean detach;
 	gboolean dry_run_mode;
 };

--- a/src/commands/exec.c
+++ b/src/commands/exec.c
@@ -65,7 +65,7 @@ handler_exec (const struct subcommand *sub,
 	g_assert (config);
 
 	if (handle_default_usage (argc, argv, sub->name,
-				&ret, 2, "<cmd> [args]")) {
+				&ret, 1, "<cmd> [args]")) {
 		return ret;
 	}
 
@@ -74,6 +74,13 @@ handler_exec (const struct subcommand *sub,
 
 	/* Jump over the container name */
 	argv++; argc--;
+
+	if ( argc == 0  && ! start_data.process_json) {
+		g_print ("Usage: %s <container-id> <cmd> [args]\n",
+			sub->name);
+		return false;
+
+	}
 
 	ret = cc_oci_get_config_and_state (&config_file, config, &state);
 	if (! ret) {

--- a/src/commands/exec.c
+++ b/src/commands/exec.c
@@ -20,6 +20,38 @@
 
 #include "command.h"
 
+extern struct start_data start_data;
+
+static GOptionEntry options_exec[] =
+{
+	{
+		"console", 0, G_OPTION_FLAG_OPTIONAL_ARG,
+		G_OPTION_ARG_CALLBACK, handle_option_console,
+		"set pty console that will be used in the container",
+		NULL
+	},
+	{
+		"process", 'p' , G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_STRING, &start_data.process_json,
+		"specify path to process.json",
+		NULL
+	},
+	{
+		"detach", 'd' , G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_NONE, &start_data.detach,
+		"exec process in detach mode",
+		NULL
+	},
+	{
+		"pid-file", 0, G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_STRING, &start_data.pid_file,
+		"the file to write the process ID of the new "
+		"process executed in the container",
+		NULL
+	},
+	{NULL}
+};
+
 static gboolean
 handler_exec (const struct subcommand *sub,
 		struct cc_oci_config *config,
@@ -65,6 +97,7 @@ out:
 struct subcommand command_exec =
 {
 	.name        = "exec",
+	.options     = options_exec,
 	.handler     = handler_exec,
 	.description = "execute a new task inside an existing container",
 };

--- a/src/oci.c
+++ b/src/oci.c
@@ -178,6 +178,7 @@ cc_oci_get_config_and_state (gchar **config_file,
 	config->bundle_path = g_strdup ((*state)->bundle_path);
 	config->state.workload_pid = (*state)->pid;
 	config->state.status = (*state)->status;
+	config->net.ip_address = g_strdup((*state)->net.ip_address);
 
 	g_strlcpy (config->state.comms_path, (*state)->comms_path,
 			sizeof (config->state.comms_path));
@@ -664,6 +665,71 @@ cc_oci_cleanup (struct cc_oci_config *config)
 	}
 
 	return true;
+}
+
+/*!
+ * Parse the \c GNode representation of process.json
+ * and save in the provided \ref cc_oci_process_exec.
+ *
+ * \param process json file
+ * \param args[out] command arguments vector
+ *
+ * \return \c true on success, else \c false.
+ */
+static gboolean
+cc_oci_process_file_parse (char* process_json, struct  cc_oci_process_exec *exec_process)
+{
+	GNode    *root = NULL;
+	GNode    *node = NULL;
+	gboolean  ret = false;
+
+	if(! (process_json && exec_process) ) {
+		goto out;
+	}
+
+	g_debug ("using process file %s", process_json);
+
+	if (! cc_oci_json_parse (&root, process_json)) {
+		goto out;
+	}
+
+#ifdef DEBUG
+	cc_oci_node_dump (root);
+#endif /*DEBUG*/
+
+	for (node = g_node_first_child(root); node;
+		node = g_node_next_sibling(node)) {
+
+		if (! node->data) {
+			continue;
+		}
+		if (node->children) {
+			if (g_strcmp0 (node->data, "args") == 0) {
+				exec_process->process.args = node_to_strv(node);
+				ret = true;
+				break;
+			}else if (g_strcmp0 (node->data, "containerdStdin") == 0) {
+				exec_process->stdin_file = g_strdup (node->children->data);
+			}else if (g_strcmp0 (node->data, "containerdStdout") == 0) {
+				exec_process->stdout_file = g_strdup (node->children->data);
+			}else if (g_strcmp0 (node->data, "containerdStderr") == 0) {
+				exec_process->stderr_file = g_strdup (node->children->data);
+			}if (g_strcmp0(root->data, "cwd") == 0) {
+				if (snprintf(exec_process->process.cwd,
+					sizeof(exec_process->process.cwd),
+					"%s", (char*)node->children->data) < 0) {
+
+					g_critical("failed to copy process cwd");
+					ret = false;
+					goto out;
+				}
+			}
+		}
+	}
+
+out:
+	g_free_node (root);
+	return ret;
 }
 
 /*!
@@ -1313,17 +1379,57 @@ cc_oci_exec (struct cc_oci_config *config,
 		int argc,
 		char *const argv[])
 {
-	g_assert (config);
-	g_assert (state);
-	g_assert (argc);
-	g_assert (argv);
-
-	if (! cc_oci_vm_connect (config, argc, argv)) {
-		g_critical ("failed to connect to VM");
-		return false;
+	struct  cc_oci_process_exec exec_process = {0};
+	int     i;
+	gboolean ret = false;;
+	if (! config) {
+		goto out;
 	}
 
-	return true;
+	if (! state) {
+		goto out;
+	}
+
+	if (state->status != OCI_STATUS_RUNNING) {
+		g_critical("container is not running");
+		goto out;
+	}
+
+	/* copy exec args to cc_oci_exec_process struct */
+	if (argc && argv) {
+		exec_process.process.args = g_new0 (gchar *, (gsize)argc + 1);
+		if (! exec_process.process.args) {
+			goto out;
+		}
+		for (i = 0; i < argc; ++i) {
+			exec_process.process.args[i] = g_strdup (argv[i]);
+		}
+		exec_process.detach = start_data.detach;
+		exec_process.pid_file = g_strdup(start_data.pid_file);
+		exec_process.console = g_strdup(start_data.console);
+	}else {
+		/*No args provided in exec command, lets parse process.json file*/
+		ret = cc_oci_process_file_parse (start_data.process_json, &exec_process);
+		if (! ret) {
+			goto out;
+		}
+	}
+
+	if (! cc_oci_vm_connect (config, &exec_process)) {
+		g_critical ("failed to connect to VM");
+		ret = false;
+	}
+
+	ret = true;
+out:
+	g_strfreev (exec_process.process.args);
+	g_free_if_set (exec_process.console);
+	g_free_if_set (exec_process.pid_file);
+	g_free_if_set (exec_process.stdin_file);
+	g_free_if_set (exec_process.stdout_file);
+	g_free_if_set (exec_process.stderr_file);
+
+	return ret;
 }
 
 /*!

--- a/src/oci.h
+++ b/src/oci.h
@@ -101,6 +101,12 @@
 /** Command to use to allow "exec" to connect to the container. */
 #define CC_OCI_EXEC_CMD               "ssh"
 
+/** User to use to connect to the container. */
+#define CC_OCI_EXEC_USER               "root"
+
+/** container rootfs path in mini-os */
+#define CC_OCI_ROOTFS_PATH               "/opt/rootfs"
+
 /** File that contains vm spec configuration, used if vm node
  * in CC_OCI_CONFIG_FILE bundle file
 */
@@ -356,6 +362,8 @@ struct oci_state {
 	gboolean         use_socket_console;
 
 	struct cc_oci_vm_cfg *vm;
+
+	struct cc_oci_net_cfg net;
 };
 
 /** clr-specific state fields. */
@@ -454,6 +462,17 @@ struct cc_oci_config {
 
 	/** If \c true, don't wait for hypervisor process to finish. */
 	gboolean detached_mode;
+};
+
+/** clr-specific process exec details. */
+struct cc_oci_process_exec {
+	struct oci_cfg_process process;
+	gchar *pid_file;
+	gchar *console;
+	gchar *stdin_file;
+	gchar *stdout_file;
+	gchar *stderr_file;
+	gboolean detach;
 };
 
 gboolean cc_oci_attach(struct cc_oci_config *config,

--- a/src/process.h
+++ b/src/process.h
@@ -27,6 +27,6 @@ gboolean cc_run_hooks(GSList* hooks, const gchar* state_file_path,
                        gboolean stop_on_failure);
 
 gboolean cc_oci_vm_connect (struct cc_oci_config *config,
-		int argc, char *const argv[]);
+		struct  cc_oci_process_exec *process);
 
 #endif /* _CC_OCI_PROCESS_H */


### PR DESCRIPTION
This patch adds basic functionality for exec command.

- 3 sub command options are added: --console, --process --,detach, --pid-file (options used by docker exec).

- The ip address is saved in statefile (ip address is required to execute commands by ssh).
- Require a container with network (docker run --net=none wont work)

Current implementation does not work with docker exec (need to debug more pipes), but directly by cc-oci-runtime. To test current implmentation is required a mini-os image with openssh-server bundle (clear-containers.img +9610) with ssh key access (ssh-copy-id) and root (permitrootlogin yes).

```
docker-upstream run -ti debian sh
cc-oci-runtime exec $CONTAINER_ID bash
```
Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>