### PR TITLE
[OCI] Support running workload as a different user/group

### DIFF
--- a/src/oci-config.c
+++ b/src/oci-config.c
@@ -132,6 +132,9 @@ cc_oci_config_free (struct cc_oci_config *config)
 		g_strfreev (config->oci.process.args);
 	}
 
+	g_free_if_set (config->oci.process.user.username);
+	g_free_if_set (config->oci.process.user.groupname);
+
 	if (config->oci.process.env) {
 		g_strfreev (config->oci.process.env);
 	}

--- a/src/oci.h
+++ b/src/oci.h
@@ -144,6 +144,8 @@ struct oci_cfg_user {
 	uid_t    uid; /*!< User ID to run workload as. */
 	gid_t    gid; /*!< Group ID to run workload as. */
 	gid_t  **additionalGids; /*!< extra Group IDs to set workload as a member of */
+	gchar   *username;
+	gchar   *groupname;
 };
 
 struct oci_cfg_hook {


### PR DESCRIPTION
The uid/gid passed to the runtime was being ignored. The workload was
being run as root user and group.Use the gid/uid in config.json to lookup
username/groupname and pass that to the workload to run with appropriate
user permissions.

Fixes #20

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>