### PR TITLE
Config: Explain why specific glib version required.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,11 @@ AS_IF([test x"$disable_functional_test" = "xno"],
 AM_CONDITIONAL([FUNCTIONAL_TEST], [test x$disable_functional_test = x"no"])
 
 # Checks for libraries.
-PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.44])
+
+required_glib_version=2.44
+PKG_CHECK_MODULES([GLIB], [glib-2.0 >= "$required_glib_version"], have_required_glib=yes, have_required_glib=no)
+AS_IF([test "$have_required_glib" != "yes"], AC_MSG_ERROR([ERROR: need glib ${required_glib_version}+ for `g_option_context_set_strict_posix' function]))
+
 PKG_CHECK_MODULES([GIO], [gio-unix-2.0])
 PKG_CHECK_MODULES([JSON_GLIB], [json-glib-1.0])
 PKG_CHECK_MODULES([UUID], [uuid])

--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,7 @@ AM_CONDITIONAL([FUNCTIONAL_TEST], [test x$disable_functional_test = x"no"])
 
 required_glib_version=2.44
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= "$required_glib_version"], have_required_glib=yes, have_required_glib=no)
-AS_IF([test "$have_required_glib" != "yes"], AC_MSG_ERROR([ERROR: need glib ${required_glib_version}+ for `g_option_context_set_strict_posix' function]))
+AS_IF([test "$have_required_glib" != "yes"], AC_MSG_ERROR([ERROR: need glib ${required_glib_version}+ for the `g_option_context_set_strict_posix' function]))
 
 PKG_CHECK_MODULES([GIO], [gio-unix-2.0])
 PKG_CHECK_MODULES([JSON_GLIB], [json-glib-1.0])


### PR DESCRIPTION
We need glib 2.44+ for g_option_context_set_strict_posix(), so state
that if the glib pkg-config configure check fails.

Signed-off-by: James Hunt <james.o.hunt@intel.com>