### PR TITLE
Tests: Fix failures caused by running hypervisor_test.c under mock(1).

### DIFF
--- a/src/hypervisor.c
+++ b/src/hypervisor.c
@@ -146,6 +146,11 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 		goto out;
 	}
 
+	if (! config->bundle_path) {
+		g_critical ("No bundle path");
+		goto out;
+	}
+
 	/* We're about to launch the hypervisor so validate paths.*/
 
 	if ((!config->vm->image_path[0])


### PR DESCRIPTION
mock(1) sets up stdin as a non-terminal device which triggers the runtime
to change its behaviour slightly (see commit 7899f891). This causes the
hypervisor tests to fail under mock, but not when run interactively.

Signed-off-by: James Hunt <james.o.hunt@intel.com>