### PR TITLE
Revert "CI: Only run Travis on the master branch."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 sudo: required
 dist: trusty
-branches:
-  only:
-    - master
 
 language: c
 compiler: gcc


### PR DESCRIPTION
This reverts commit 96e9174b3ab1132ef807e35be8e7445aba109aca.

We didn't envision something obvious in retrospect: when forking this
git repo and pushing branches for testing, travis doesn't trigger
anymore. Not very handy.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>