### PR TITLE
build: Use AM_V_GEN when generating the commit_id file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,7 @@ CHECK_DEPS =
 GIT_COMMIT := $(shell git rev-parse HEAD 2>/dev/null)
 
 commit_id:
-	if [ "x$(GIT_COMMIT)" != "x" ]; then \
+	$(AM_V_GEN)if [ "x$(GIT_COMMIT)" != "x" ]; then \
 		echo "Writing commit id"; \
 		echo $(GIT_COMMIT) > commit_id; \
 	else \


### PR DESCRIPTION
Nicer builds are all the rage.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>