### PR TITLE
CI: Run Travis build with clang as well as gcc.

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -22,6 +22,11 @@ set -e -x
 cwd=$(cd `dirname "$0"`; pwd -P)
 source $cwd/versions.txt
 
+# Ensure "make install" as root can find clang
+#
+# See: https://github.com/travis-ci/travis-ci/issues/2607
+export CC=$(which "$CC")
+
 gnome_dl=https://download.gnome.org/sources
 
 # Install required dependencies to build

--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -43,7 +43,7 @@ glib_minor=`echo $glib_version | cut -d. -f2`
 curl -L -O "$gnome_dl/glib/${glib_major}.${glib_minor}/glib-${glib_version}.tar.xz"
 tar -xvf "glib-${glib_version}.tar.xz"
 pushd "glib-${glib_version}"
-./configure
+./configure --disable-silent-rules
 make
 sudo make install
 popd
@@ -54,7 +54,7 @@ json_minor=`echo $json_glib_version | cut -d. -f2`
 curl -L -O "$gnome_dl/json-glib/${json_major}.${json_minor}/json-glib-${json_glib_version}.tar.xz"
 tar -xvf "json-glib-${json_glib_version}.tar.xz"
 pushd "json-glib-${json_glib_version}"
-./configure
+./configure --disable-silent-rules
 make
 sudo make install
 popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: required
 dist: trusty
 
 language: c
-compiler: gcc
+compiler:
+  - gcc
+  - clang
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 - ./.travis-setup.sh
 
 script:
-- ./autogen.sh --enable-cppcheck --enable-valgrind
+- ./autogen.sh --enable-cppcheck --enable-valgrind --disable-silent-rules
 - make
 
 notifications:


### PR DESCRIPTION
Clang often does a better job of finding issues compared to gcc.
Further, not all distros will be using gcc so attempt to build for
both compilers to ensure we support both.

Signed-off-by: James Hunt <james.o.hunt@intel.com>