### PR TITLE
Enable make check (unit tests only) and check for warnings in travis

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -32,7 +32,7 @@ gnome_dl=https://download.gnome.org/sources
 # Install required dependencies to build
 # glib, json-glib, check and cc-oci-runtime
 sudo apt-get -qq install valgrind lcov uuid-dev pkg-config \
-  zlib1g-dev libffi-dev gettext libpcre3-dev cppcheck check
+  zlib1g-dev libffi-dev gettext libpcre3-dev cppcheck
 
 mkdir cor-dependencies
 pushd cor-dependencies
@@ -58,6 +58,18 @@ pushd "json-glib-${json_glib_version}"
 make
 sudo make install
 popd
+
+# Build check
+# We need to build check as the check version in the OS used by travis isn't
+# -pedantic safe.
+curl -L -O "https://github.com/libcheck/check/releases/download/${check_version}/check-${check_version}.tar.gz"
+tar -xvf "check-${check_version}.tar.gz"
+pushd "check-${check_version}"
+./configure
+make
+sudo make install
+popd
+
 
 # Install bats
 git clone https://github.com/sstephenson/bats.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
 
 script:
 - ./autogen.sh --enable-cppcheck --enable-valgrind --disable-silent-rules
-- make -j5
+- make -j5 CFLAGS=-Werror
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
 
 script:
 - ./autogen.sh --enable-cppcheck --enable-valgrind --disable-silent-rules
-- make -j5 CFLAGS=-Werror
+- make -j5 CFLAGS=-Werror check
 
 notifications:
   email:

--- a/Makefile.am
+++ b/Makefile.am
@@ -172,7 +172,7 @@ endif
 
 if FUNCTIONAL_TEST
 CHECK_DEPS += functional-test
-functional-test:
+functional-test: cc-oci-runtime
 	@$(BATS_PATH) $(srcdir)/tests/functional/
 endif
 

--- a/src/commands/create.c
+++ b/src/commands/create.c
@@ -22,6 +22,10 @@
 
 extern struct start_data start_data;
 
+/* ignore -pedantic to cast handle_option_console, a function pointer, to a
+ * void* */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 static GOptionEntry options_create[] =
 {
 	{
@@ -52,6 +56,7 @@ static GOptionEntry options_create[] =
 
 	{NULL}
 };
+#pragma GCC diagnostic pop
 
 static gboolean
 handler_create (const struct subcommand *sub,

--- a/src/commands/ps.c
+++ b/src/commands/ps.c
@@ -27,8 +27,6 @@ handler_ps (const struct subcommand *sub,
 		struct cc_oci_config *config,
 		int argc, char *argv[])
 {
-	// default ps options
-	gchar     *ps_options = "-ef";
 	gboolean   ret;
 
 	g_assert (sub);
@@ -40,12 +38,6 @@ handler_ps (const struct subcommand *sub,
 	}
 
 	config->optarg_container_id = argv[0];
-
-	if (argc > 1) {
-		ps_options = argv[1];
-	} else {
-
-	}
 
 	if (! cc_oci_state_file_exists(config)) {
 		g_warning ("state file does not exist for container %s",

--- a/src/commands/run.c
+++ b/src/commands/run.c
@@ -30,6 +30,10 @@
 
 extern struct start_data start_data;
 
+/* ignore -pedantic to cast handle_option_console, a function pointer, to a
+ * void* */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 static GOptionEntry options_run[] =
 {
 	{
@@ -78,6 +82,7 @@ static GOptionEntry options_run[] =
 
 	{NULL}
 };
+#pragma GCC diagnostic pop
 
 static gboolean
 handler_run (const struct subcommand *sub,

--- a/src/oci.h
+++ b/src/oci.h
@@ -125,7 +125,7 @@ enum oci_namespace {
 	OCI_NS_USER    = CLONE_NEWUSER,
 	OCI_NS_CGROUP  = CLONE_NEWCGROUP,
 
-	OCI_NS_INVALID = 0x0,
+	OCI_NS_INVALID = -1,
 };
 
 struct oci_cfg_platform {

--- a/src/process.c
+++ b/src/process.c
@@ -199,6 +199,7 @@ cc_oci_setup_child (struct cc_oci_config *config)
  * \note \p exit_code may be \c NULL to avoid returning the
  * child exit code.
  */
+#if 0
 static void
 cc_oci_child_watcher (GPid pid, gint status,
 		gpointer exit_code) {
@@ -212,6 +213,7 @@ cc_oci_child_watcher (GPid pid, gint status,
 
 	g_main_loop_quit (main_loop);
 }
+#endif
 
 /*!
  * Close spawned hook and stop the hook loop.
@@ -999,17 +1001,19 @@ cc_oci_vm_connect (struct cc_oci_config *config,
 		int argc,
 		char *const argv[]) {
 	gchar     **args = NULL;
-	GError     *err = NULL;
 	gboolean    ret = false;
-	GPid        pid;
 	guint       args_len = 0;
-	gint        exit_code = -1;
 	gboolean    cmd_is_just_shell = false;
+#if 0
+	GError     *err = NULL;
+	GPid        pid;
+	gint        exit_code = -1;
 	GSpawnFlags flags = (G_SPAWN_CHILD_INHERITS_STDIN |
 			     /* XXX: required for g_child_watch_add! */
 			     G_SPAWN_DO_NOT_REAP_CHILD |
 			     G_SPAWN_SEARCH_PATH);
 	guint i;
+#endif
 
 	g_assert (config);
 	g_assert (argc);
@@ -1070,11 +1074,6 @@ cc_oci_vm_connect (struct cc_oci_config *config,
 	// FIXME: replace with proper connection string once networking details available.
 #if 0
 	args[1] = g_strdup_printf (ip_address);
-#else
-	g_critical ("not implemented yet");
-	ret = false;
-	goto out;
-#endif
 
 	/* append argv to the end of args */
 	if (argc) {
@@ -1131,6 +1130,10 @@ cc_oci_vm_connect (struct cc_oci_config *config,
 	}
 
 	ret = true;
+#else
+	g_critical ("not implemented yet");
+	ret = false;
+#endif
 
 out:
 	if (args) {

--- a/tests/hypervisor_test.c
+++ b/tests/hypervisor_test.c
@@ -524,12 +524,12 @@ START_TEST(test_cc_oci_vm_args_get) {
 	g_strfreev (args);
 
 	/* recreate the args file */
-	ret = g_file_set_contents (args_file, "hello\# comment\n", -1, NULL);
+	ret = g_file_set_contents (args_file, "hello\\# comment\n", -1, NULL);
 	ck_assert (ret);
 
 	ck_assert (cc_oci_vm_args_get (&config, &args));
 
-	ck_assert (! g_strcmp0 (args[0], "hello\# comment"));
+	ck_assert (! g_strcmp0 (args[0], "hello\\# comment"));
 	ck_assert (! args[1]);
 	g_strfreev (args);
 

--- a/versions.txt
+++ b/versions.txt
@@ -1,2 +1,3 @@
 glib_version=2.46.2
 json_glib_version=1.2.2
+check_version=0.10.0


### PR DESCRIPTION
Another step towards better CI:

- Get rid of warnings and make sure we don't introduce any later on
- Run make check

What's still to do is documented in https://github.com/01org/cc-oci-runtime/issues/69