### PR TITLE
Logging: remove enable_debug from main file

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -56,8 +56,6 @@
 #define CC_OCI_ERROR(...) \
 	cc_oci_error (__FILE__, __LINE__, __func__, __VA_ARGS__)
 
-extern gboolean enable_debug;
-
 /*!
  * Last-ditch logging routine which sends an error
  * message to syslog.
@@ -330,7 +328,7 @@ cc_oci_log_handler (const gchar *log_domain,
 		return;
 	}
 
-	if (log_level == G_LOG_LEVEL_DEBUG && (!enable_debug) &&
+	if (log_level == G_LOG_LEVEL_DEBUG && (!options->enable_debug) &&
 			! options->global_logfile) {
 
 		/* By default, g_debug() messages are disabled. However,
@@ -403,7 +401,7 @@ cc_oci_log_handler (const gchar *log_domain,
 		fprintf (stderr, "%s\n", final);
 	}
 
-	if ((log_level == G_LOG_LEVEL_DEBUG) && (!enable_debug)) {
+	if ((log_level == G_LOG_LEVEL_DEBUG) && (!options->enable_debug)) {
 		/* Debug calls are always added to the global log, but
 		 * only added to the main log if debug is enabled.
 		 */

--- a/src/logging.h
+++ b/src/logging.h
@@ -27,6 +27,9 @@
 /** Options to pass to cc_oci_log_handler(). */
 struct cc_log_options
 {
+	/* if \c true, enable debug logging, else disable it */
+	gboolean enable_debug;
+
     /* Full path to logfile to use. */
     char     *filename;
 

--- a/src/main.c
+++ b/src/main.c
@@ -43,9 +43,6 @@ static gboolean show_version;
 static gboolean show_help;
 static gboolean systemd_cgroup;
 
-/** If \c true, enable \c g_debug() output */
-gboolean enable_debug;
-
 /** Path to create state under */
 static gchar *root_dir;
 
@@ -62,7 +59,7 @@ static GOptionEntry options_global[] =
 	},
 	{
 		"debug", 'd', G_OPTION_FLAG_NONE,
-		G_OPTION_ARG_NONE, &enable_debug,
+		G_OPTION_ARG_NONE, &cc_log_options.enable_debug,
 		"enable debug output",
 		NULL
 	},
@@ -360,7 +357,7 @@ handle_arguments (int argc, char **argv)
 		goto out;
 	}
 
-	if (enable_debug) {
+	if (cc_log_options.enable_debug) {
 		/* Record how runtime was invoked in log */
 		gchar *str = g_strjoinv (" ", argv);
 		g_debug ("called as: %s %s", program_name, str);
@@ -406,7 +403,7 @@ main (int argc, char **argv)
 	gboolean ret;
 
 	// FIXME: --debug currently forcibly enabled
-	enable_debug = true;
+	cc_log_options.enable_debug = true;
 
 	ret = handle_arguments (argc, argv);
 

--- a/tests/annotation_test.c
+++ b/tests/annotation_test.c
@@ -80,14 +80,13 @@ Suite* make_annotation_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main (void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("annotation_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/hypervisor_test.c
+++ b/tests/hypervisor_test.c
@@ -644,14 +644,13 @@ Suite* make_hypervisor_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main (void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("hypervisor_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/json_test.c
+++ b/tests/json_test.c
@@ -64,14 +64,13 @@ Suite* make_json_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("json_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/logging_test.c
+++ b/tests/logging_test.c
@@ -31,8 +31,6 @@
 #include "logging.h"
 #include "oci.h"
 
-gboolean enable_debug = true;
-
 void
 cc_oci_error (const char *file,
 		int line_number,
@@ -51,6 +49,8 @@ START_TEST(test_cc_oci_log_init) {
 	JsonParser *parser = NULL;
 	JsonReader *reader = NULL;
 	const gchar *value;
+
+	options.enable_debug = true;
 
 	options.use_json = false;
 
@@ -113,14 +113,14 @@ START_TEST(test_cc_oci_log_init) {
 	/* Now, test g_debug() handling */
 
 	/* Disable g_debug () messages */
-	enable_debug = false;
+	options.enable_debug = false;
 
 	g_debug ("WILL NOT BE LOGGED");
 
 	ck_assert (! g_file_test (options.filename, G_FILE_TEST_EXISTS));
 
 	/* re-enable debug messages */
-	enable_debug = true;
+	options.enable_debug = true;
 
 	g_debug ("G_LOG_LEVEL_DEBUG: %s (int=%d)", "!de bug, da bug!", 13);
 

--- a/tests/mount_test.c
+++ b/tests/mount_test.c
@@ -120,14 +120,13 @@ Suite* make_mount_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("mount_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/namespace_test.c
+++ b/tests/namespace_test.c
@@ -33,7 +33,6 @@
 #include "../src/logging.h"
 #include "test_common.h"
 
-gboolean enable_debug = true;
 
 START_TEST(test_cc_oci_ns_to_str) {
 	const char *str;
@@ -190,6 +189,7 @@ int main (void) {
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("namespace_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/oci-config_test.c
+++ b/tests/oci-config_test.c
@@ -74,14 +74,13 @@ Suite* make_runtime_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 
 	/* use underscore rather than dash as that's

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -984,14 +984,13 @@ Suite* make_oci_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main (void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("oci_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/priv_test.c
+++ b/tests/priv_test.c
@@ -135,14 +135,13 @@ Suite* make_priv_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("priv_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/process_test.c
+++ b/tests/process_test.c
@@ -81,14 +81,13 @@ Suite* make_process_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("process_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/runtime_test.c
+++ b/tests/runtime_test.c
@@ -140,14 +140,13 @@ Suite* make_runtime_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("runtime_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/spec_handlers/annotations_test.c
+++ b/tests/spec_handlers/annotations_test.c
@@ -51,8 +51,6 @@ Suite* make_annotation_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
@@ -60,6 +58,7 @@ int main(void) {
 	struct cc_log_options options = { 0 };
 	gchar *cwd = g_get_current_dir();
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_build_path ("/",
             cwd,

--- a/tests/spec_handlers/hooks_test.c
+++ b/tests/spec_handlers/hooks_test.c
@@ -58,14 +58,13 @@ Suite* make_hooks_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("hooks_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/spec_handlers/linux_test.c
+++ b/tests/spec_handlers/linux_test.c
@@ -50,14 +50,13 @@ Suite* make_linux_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("linux_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/spec_handlers/mounts_test.c
+++ b/tests/spec_handlers/mounts_test.c
@@ -58,14 +58,13 @@ Suite* make_vm_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("mounts_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/spec_handlers/platform_test.c
+++ b/tests/spec_handlers/platform_test.c
@@ -56,8 +56,6 @@ Suite* make_platform_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
@@ -65,6 +63,7 @@ int main(void) {
 	struct cc_log_options options = { 0 };
 	gchar *cwd = g_get_current_dir();
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_build_path ("/",
             cwd,

--- a/tests/spec_handlers/process_test.c
+++ b/tests/spec_handlers/process_test.c
@@ -52,8 +52,6 @@ Suite* make_process_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
@@ -61,6 +59,7 @@ int main(void) {
 	struct cc_log_options options = { 0 };
 	gchar *cwd = g_get_current_dir();
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_build_path ("/",
 			cwd,

--- a/tests/spec_handlers/root_test.c
+++ b/tests/spec_handlers/root_test.c
@@ -93,8 +93,6 @@ Suite* make_root_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
@@ -102,6 +100,7 @@ int main(void) {
 	struct cc_log_options options = { 0 };
 	gchar *cwd = g_get_current_dir();
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_build_path ("/",
             cwd,

--- a/tests/spec_handlers/vm_test.c
+++ b/tests/spec_handlers/vm_test.c
@@ -58,14 +58,13 @@ Suite* make_vm_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("vm_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/state_test.c
+++ b/tests/state_test.c
@@ -326,14 +326,13 @@ Suite* make_state_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("state_test_debug.log");
 	(void)cc_oci_log_init(&options);

--- a/tests/util_test.c
+++ b/tests/util_test.c
@@ -528,14 +528,13 @@ Suite* make_util_suite(void) {
 	return s;
 }
 
-gboolean enable_debug = true;
-
 int main(void) {
 	int number_failed;
 	Suite* s;
 	SRunner* sr;
 	struct cc_log_options options = { 0 };
 
+	options.enable_debug = true;
 	options.use_json = false;
 	options.filename = g_strdup ("util_test_debug.log");
 	(void)cc_oci_log_init(&options);


### PR DESCRIPTION
with this patch enable_debug will be encapsulated
in cc_log_options struct, now enable and disable
debug logging is easier and extern references to
enable_debug are not more needed

Signed-off-by: Julio Montes <julio.montes@intel.com>