### PR TITLE
Logging: Capture hypervisor's stdout and stderr to a file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -362,6 +362,13 @@ written into the directory specified by "``--root``".  The default
 runtime state directory is ``/run/opencontainer/containers/`` if no
 "``--root``" argument is supplied.
 
+Additionally exist the possibility to log hypervisor's stderr and stdout into
+``$hypervisorLogDir/$containerId-hypervisor.stderr`` and
+``$hypervisorLogDir/$containerId-hypervisor.stdout`` respectively if the
+``--hypervisor-log-dir`` option is specified. Note that ``$hypervisorLogDir``
+and ``$containerId`` are variables provided by user through
+``--hypervisor-log-dir`` option and ``create`` command respectively.
+
 Note: Global logging is presently always enabled in the runtime,
 as ``containerd`` does not always invoke the runtime with the ``--log``
 argument, and enabling the global log in this case helps with debugging.
@@ -381,7 +388,7 @@ the OCI_ CLI and the runc_ CLI interfaces.
 
 Details of the runc_ command line options can be found in the `runc manpage`_.
 
-Note: The ``--global-log`` argument is unique to the runtime at present.
+Note: The ``--global-log`` and ``--hypervisor-log-dir`` arguments are unique to the runtime at present.
 
 Extensions
 ~~~~~~~~~~
@@ -429,6 +436,7 @@ Debugging
         --debug \
         --root /tmp/cor/ \
         --global-log /tmp/global.log \
+        --hypervisor-log-dir /tmp/ \
         start --console $(tty) $container $bundle_path
 
 - Consult the global Log (see Logging_).

--- a/src/logging.h
+++ b/src/logging.h
@@ -24,6 +24,8 @@
 /** Mode for logfiles. */
 #define CC_OCI_LOGFILE_MODE		0640
 
+#include "oci-config.h"
+
 /** Options to pass to cc_oci_log_handler(). */
 struct cc_log_options
 {
@@ -36,11 +38,15 @@ struct cc_log_options
     /* Full path to global logfile to append to. */
     char     *global_logfile;
 
+    /* Full path to hypervisor log dir. */
+    char     *hypervisor_log_dir;
+
     /* If \c true, log in JSON, else ASCII. */
     gboolean  use_json;
 };
 
 gboolean cc_oci_log_init (const struct cc_log_options *options);
 void cc_oci_log_free (struct cc_log_options *options);
+void cc_oci_setup_hypervisor_logs (struct cc_oci_config *config);
 
 #endif /* _CC_OCI_LOGGING_H */

--- a/src/main.c
+++ b/src/main.c
@@ -71,6 +71,13 @@ static GOptionEntry options_global[] =
 		NULL
 	},
 	{
+		"hypervisor-log-dir", 0, G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_STRING,
+		&cc_log_options.hypervisor_log_dir,
+		"specify directory path to output hypervisor log",
+		NULL
+	},
+	{
 		"log", 0, G_OPTION_FLAG_NONE,
 		G_OPTION_ARG_STRING,
 		&cc_log_options.filename,

--- a/src/process.c
+++ b/src/process.c
@@ -57,6 +57,7 @@
 #include "namespace.h"
 #include "networking.h"
 #include "common.h"
+#include "logging.h"
 
 static GMainLoop* main_loop = NULL;
 static GMainLoop* hook_loop = NULL;
@@ -185,6 +186,8 @@ cc_oci_setup_child (struct cc_oci_config *config)
 	if (! config->detached_mode) {
 		cc_oci_close_fds ();
 	}
+
+	cc_oci_setup_hypervisor_logs(config);
 
 	return true;
 }


### PR DESCRIPTION
Currently hypervisor's stdout and stderr are ignored. This makes
hard to debug a hypervisor.
This patch adds --hypervisor-log-dir option that can be used to enable
hypervisor logging and specify the directory where hypervisor logs
will be created.
With this patch hypervisor's stdout and stderr will be saved into
${hypervisorLogDir}/${containerId}-hypervisor.stdout and
${hypervisorLogDir}/${containerId}-hypervisor.stderr respectively.

fixes #71

Signed-off-by: Julio Montes <julio.montes@intel.com>