### PR TITLE
CI: Show tests logs on Travis failure.

### DIFF
--- a/.travis-teardown.sh
+++ b/.travis-teardown.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+set -e
+
+printf "=== Build failed ===\n"
+
+for f in $(ls *_test*.log)
+do
+    printf "\n=== Log file: '$f' ===\n\n"
+    cat "$f"
+done

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ script:
 - ./autogen.sh --enable-cppcheck --enable-valgrind --disable-silent-rules
 - make -j5 CFLAGS=-Werror check
 
+after_failure:
+- ./.travis-teardown.sh
+
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Added an "after_failure" script to display all testsuite-generated log
files on build failure.

Signed-off-by: James Hunt <james.o.hunt@intel.com>