### PR TITLE
Docs: Remove out-of-date global-log details.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -358,21 +358,12 @@ since it is always written to in ASCII format and includes Process ID
 details. Also note that all instances of the runtime will append to
 the global log.
 
-The global log file is named ``cc-oci-runtime.log``, and will be
-written into the directory specified by "``--root``".  The default
-runtime state directory is ``/run/opencontainer/containers/`` if no
-"``--root``" argument is supplied.
-
 Additionally exist the possibility to log hypervisor's stderr and stdout into
 ``$hypervisorLogDir/$containerId-hypervisor.stderr`` and
 ``$hypervisorLogDir/$containerId-hypervisor.stdout`` respectively if the
 ``--hypervisor-log-dir`` option is specified. Note that ``$hypervisorLogDir``
 and ``$containerId`` are variables provided by user through
 ``--hypervisor-log-dir`` option and ``create`` command respectively.
-
-Note: Global logging is presently always enabled in the runtime,
-as ``containerd`` does not always invoke the runtime with the ``--log``
-argument, and enabling the global log in this case helps with debugging.
 
 Command-line Interface
 ----------------------


### PR DESCRIPTION
The "--global-log" option used to be enabled by default. However, this
is no longer the case (see commit 63549d5), so update "README.rst" to
reflect the current behaviour.

Signed-off-by: James Hunt <james.o.hunt@intel.com>