### PR TITLE
DOCS: Add more details to the CONTRIBUTING document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,12 +40,14 @@ used by the Linux kernel project.
 Beside the signed-off-by footer, we expect each patch to comply with the following format:
 
 ```
-       Change summary
+       Subsystem: Change summary (no longer than 75 characters)
 
        More detailed explanation of your changes: Why and how.
        Wrap it to 72 characters.
-       See [here] (http://chris.beams.io/posts/git-commit/)
-       for some more good advices.
+       See:
+           http://chris.beams.io/posts/git-commit/
+       for some more good advice, and the Linux Kernel document:
+           https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/SubmittingPatches
 
        Signed-off-by: <contributor@foo.com>
 ```
@@ -53,23 +55,46 @@ Beside the signed-off-by footer, we expect each patch to comply with the followi
 For example:
 
 ```
-	Annotations spec handler test fix.
-    
-	json-glib is clever enough to know that an object cannot
-	have a null key, but seemingly has a bug where it doesn't
-	release some memory in that scenario (which causes the
-	runtimes valgrind test to fail).
-    
-	Signed-off-by: James Hunt <james.o.hunt@intel.com>
+       OCI: Ensure state is updated when kill fails.
+
+       Killing a container involves a number of steps. If any of these fail,
+       the container state should be reverted to it's previous value.
+
+       Signed-off-by: James Hunt <james.o.hunt@intel.com>
 ```
+
+Note, that the body of the message should not just be a continuation of the subject line, and is not used to extend the subject line beyond its length limit. They should stand alone as complete sentence and paragraphs.
+
+It is recommended that each of your patches fixes one thing. Smaller patches are easier to review, and are thus more likely to be accepted and merged, and problems are more likely to be picked up during review.
 
 ## Pull requests
 
-We accept [github pull requests](https://github.com/01org/cc-oci-runtime/pulls).
+We accept [github pull requests] (https://github.com/01org/cc-oci-runtime/pulls).
+
+Github has a basic introduction to the process [here] (https://help.github.com/articles/using-pull-requests/).
+
+When submitting your Pull Request (PR), treat the Pull Request message the same you would a patch message, including pre-fixing the title with a subsystem name. Github by default seems to copy the message from your first patch, which many times is appropriate, but please ensure your message is accurate and complete for the whole Pull Request, as it ends up in the git log as the merge message.
+
+Your pull request may get some feedback and comments, and require some rework. The recommended procedure for reworking is to rework your branch to a new clean state and 'force push' it to your github. GitHub understands this action, and does sensible things in the online comment history. Do not pile patches on patches to rework your branch. Any relevant information from the github comments section should be re-worked into your patch set, as the ultimate place where your patches are documented is in the git log, and not in the github comments section.
+
+For more information on github 'force push' workflows see [here] (http://blog.adamspiers.org/2015/03/24/why-and-how-to-correctly-amend-github-pull-requests/).
+
+It is perfectly fine for your Pull Request to contain more than one patch - use as many patches as you need to implement the Request (see the previously mentioned 'small patch' thoughts). Each Pull Request should only cover one topic - if you mix up different items in your patches or pull requests then you will most likely be asked to rework them.
+
+## Reviews
+
+Before your Pull Requests are merged into the main code base, they will be reviewed. Anybody can review any Pull Request and leave feedback (in fact, it is encouraged), but this project runs a rotational GateKeeper schedule for who is ultimately responsible for merging the Pull Requests into the main code base. See [here] (https://github.com/01org/cc-oci-runtime/wiki/GateKeeper-Schedule).
+
+We use an 'acknowledge' system for people to note if they agree, or disagree, with a Pull Request. We utilise some automated systems that can spot common acknowledge patterns, which include placing any of these at the beginning of a comment line:
+
+ - LGTM
+ - lgtm
+ - +1
+ - Approve
 
 ## Contact
 
-The Clear Containers community can be reached out through its IRC channel and a
+The Clear Containers community can be reached through its IRC channel and a
 dedicated mailing list:
 
 * IRC: `#clearcontainers @ freenode.net`.


### PR DESCRIPTION
Make some expansions and additions to the CONTRIBUTING document,
including:
 - subject: prefixes on patches
 - Add a link to the Linux Kernel SubmittingPatches doc
 - Note about PRs, reviews, updates and force pushing

Signed-off-by: Graham Whaley <graham.whaley@intel.com>