### PR TITLE
Process: Fix pullapprove config.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,5 +1,5 @@
 approve_by_comment: true
-approve_regex: ^(LGTM|lgtm|+1|Approve)
+approve_regex: '^(LGTM|lgtm|Approve|:\+1:)'
 reset_on_push: true
 reset_on_reopened: true
 author_approval: ignored


### PR DESCRIPTION
The pullapprove.com "approve_regex" value must be a single-quoted
string.

Signed-off-by: James Hunt <james.o.hunt@intel.com>