### PR TITLE
Process: Add basic "+1" to pullapprove config.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,5 +1,5 @@
 approve_by_comment: true
-approve_regex: '^(LGTM|lgtm|Approve|:\+1:)'
+approve_regex: '^(LGTM|lgtm|Approve|\+1|:\+1:)'
 reset_on_push: true
 reset_on_reopened: true
 author_approval: ignored


### PR DESCRIPTION
The current regular expression only includes the "emoji" version of
"+1", so add a non-emoji equivalent.

Signed-off-by: James Hunt <james.o.hunt@intel.com>