### PR TITLE
Networking: Enable vhost_net support

### DIFF
--- a/src/hypervisor.c
+++ b/src/hypervisor.c
@@ -75,7 +75,7 @@ cc_oci_expand_net_cmdline(struct cc_oci_config *config) {
 	return g_strdup("");
 }
 
-#define QEMU_FMT_NETDEV "tap,ifname=%s,script=no,downscript=no,id=%s"
+#define QEMU_FMT_NETDEV "tap,ifname=%s,script=no,downscript=no,id=%s,vhost=on"
 
 static gchar *
 cc_oci_expand_netdev_cmdline(struct cc_oci_config *config) {


### PR DESCRIPTION
Enable vhost_net support to increase the networking performance.
vhost_net moves part of the Virtio driver from the userspace into the
kernel. This reduces copy operations, lowers latency and CPU usage.

This closes https://github.com/01org/cc-oci-runtime/issues/161

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>