### PR TITLE
Networking: Explicitly set the network device to virtio-net-pci

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,7 @@ Requirements
 ------------
 
 - A Qemu_ hypervisor that supports the ``pc-lite`` machine type (see qemu-lite_).
+- CONFIG_VHOST_NET enabled in the host kernel
 
 Platform Support
 ----------------

--- a/src/hypervisor.c
+++ b/src/hypervisor.c
@@ -85,7 +85,7 @@ cc_oci_expand_netdev_cmdline(struct cc_oci_config *config) {
 		config->net.tap_device);
 }
 
-#define QEMU_FMT_DEVICE "driver=virtio-net,netdev=%s"
+#define QEMU_FMT_DEVICE "driver=virtio-net-pci,netdev=%s"
 #define QEMU_FMT_DEVICE_MAC QEMU_FMT_DEVICE ",mac=%s"
 
 static gchar *


### PR DESCRIPTION
Explicitly set the network device to virtio-net-pci.

Note: On the host you need a kernel with CONFIG_VHOST_NET=y and
in the guest you need a kernel with CONFIG_PCI_MSI=y

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>