### PR TITLE
Networking: Add support for discovery of multiple interfaces

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -16,6 +16,37 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *	Copyright (c) 1983, 1993
+ *		The Regents of the University of California.  All rights reserved.
+ *
+ *	Redistribution and use in source and binary forms, with or without
+ *	modification, are permitted provided that the following conditions
+ *	are met:
+ *	1. Redistributions of source code must retain the above copyright
+ *	notice, this list of conditions and the following disclaimer.
+ *	2. Redistributions in binary form must reproduce the above copyright
+ *	notice, this list of conditions and the following disclaimer in the
+ *	documentation and/or other materials provided with the distribution.
+ *	4. Neither the name of the University nor the names of its contributors
+ *	may be used to endorse or promote products derived from this software
+ *	without specific prior written permission.
+ *
+ *	THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ *	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *	IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *	ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ *	FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *	DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *	OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *	LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ *	OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ *	SUCH DAMAGE.
+ *
  */
 
 /** \file
@@ -47,12 +78,75 @@
 #define TUNDEV "/dev/net/tun"
 
 /* Using unqualified path to enable it to be picked
- * up from the users enviornment. May be overidden
+ * up from the users environment. May be overridden
  * at build time with fully qualified path
  */
 #ifndef CC_OCI_IPROUTE2_BIN
 #define CC_OCI_IPROUTE2_BIN "ip"
 #endif
+
+/*!
+ * Free the specified \ref cc_oci_net_ipv4_cfg
+ *
+ * \param if_cfg \ref cc_oci_net_ipv4_cfg
+ */
+static void
+cc_oci_net_ipv4_free (struct cc_oci_net_ipv4_cfg *ipv4_cfg)
+{
+	if (!ipv4_cfg) {
+		return;
+	}
+
+	g_free_if_set (ipv4_cfg->ip_address);
+	g_free_if_set (ipv4_cfg->subnet_mask);
+	g_free (ipv4_cfg);
+}
+
+/*!
+ * Free the specified \ref cc_oci_net_ipv6_cfg
+ *
+ * \param if_cfg \ref cc_oci_net_ipv6_cfg
+ */
+static void
+cc_oci_net_ipv6_free (struct cc_oci_net_ipv6_cfg *ipv6_cfg)
+{
+	if (!ipv6_cfg) {
+		return;
+	}
+
+	g_free_if_set (ipv6_cfg->ipv6_address);
+	g_free (ipv6_cfg);
+}
+
+/*!
+ * Free the specified \ref cc_oci_net_if_cfg
+ *
+ * \param if_cfg \ref cc_oci_net_if_cfg
+ */
+void
+cc_oci_net_interface_free (struct cc_oci_net_if_cfg *if_cfg)
+{
+	if (!if_cfg) {
+		return;
+	}
+
+	g_free_if_set (if_cfg->mac_address);
+	g_free_if_set (if_cfg->ifname);
+	g_free_if_set (if_cfg->bridge);
+	g_free_if_set (if_cfg->tap_device);
+
+	if (if_cfg->ipv4_addrs) {
+		g_slist_free_full(if_cfg->ipv4_addrs,
+                (GDestroyNotify)cc_oci_net_ipv4_free);
+	}
+
+	if (if_cfg->ipv6_addrs) {
+		g_slist_free_full(if_cfg->ipv6_addrs,
+                (GDestroyNotify)cc_oci_net_ipv6_free);
+	}
+
+	g_free (if_cfg);
+}
 
 
 /*!
@@ -171,88 +265,68 @@ cc_oci_netlink_run(const gchar *cmd_line) {
  */
 gboolean
 cc_oci_network_create(const struct cc_oci_config *const config) {
+	struct cc_oci_net_if_cfg *if_cfg = NULL;
 	gchar cmd_line[1024];
+	guint index = 0;
 
-	if (config == NULL){
-		g_critical("invalid network configuration");
+	if (config == NULL) {
 		return false;
 	}
 
-	/* No networking enabled */
-	if (config->net.ifname == NULL) {
-		return true;
-	}
+	for (index=0; index<g_slist_length(config->net.interfaces); index++) {
+		if_cfg = (struct cc_oci_net_if_cfg *)
+			g_slist_nth_data(config->net.interfaces, index);
 
-	if (!cc_oci_tap_create(config->net.tap_device)) {
-		return false;
-	}
+		if (!cc_oci_tap_create(if_cfg->tap_device)) {
+			return false;
+		}
 
-	/* Place holder till we create these using appropriate
-	* netlink commands
-	*/
+		#define NETLINK_CREATE_BRIDGE "link add name %s type bridge"
+		g_snprintf(cmd_line, sizeof(cmd_line), NETLINK_CREATE_BRIDGE,
+			if_cfg->bridge);
+		if (!cc_oci_netlink_run(cmd_line)) {
+			return false;
+		}
 
-#define NETLINK_CREATE_BRIDGE "link add name %s type bridge"
-	g_snprintf(cmd_line, sizeof(cmd_line),
-		NETLINK_CREATE_BRIDGE,
-		config->net.bridge);
+		#define NETLINK_SET_MAC	"link set dev %s address 02:00:CA:FE:00:%.2x"
+		/* TODO: Derive non conflicting mac from interface */
+		g_snprintf(cmd_line, sizeof(cmd_line), NETLINK_SET_MAC,
+			   if_cfg->ifname, index);
+		if (!cc_oci_netlink_run(cmd_line)) {
+			return false;
+		}
 
-	if (!cc_oci_netlink_run(cmd_line)) {
-		return false;
-	}
+		#define NETLINK_ADD_LINK_BR "link set dev %s master %s"
+		g_snprintf(cmd_line, sizeof(cmd_line), NETLINK_ADD_LINK_BR,
+			   if_cfg->ifname, if_cfg->bridge);
+		if (!cc_oci_netlink_run(cmd_line)) {
+			return false;
+		}
 
-#define NETLINK_SET_MAC	"link set dev %s address %s"
-	/* TODO: Derive non conflicting mac from interface */
-	g_snprintf(cmd_line, sizeof(cmd_line),
-		NETLINK_SET_MAC,
-		config->net.ifname,
-		"02:00:CA:FE:00:01");
+		g_snprintf(cmd_line, sizeof(cmd_line), NETLINK_ADD_LINK_BR,
+			if_cfg->tap_device, if_cfg->bridge);
+		if (!cc_oci_netlink_run(cmd_line)) {
+			return false;
+		}
 
-	if (!cc_oci_netlink_run(cmd_line)) {
-		return false;
-	}
+		#define NETLINK_LINK_EN	"link set dev %s up"
+		g_snprintf(cmd_line, sizeof(cmd_line), NETLINK_LINK_EN,
+			   if_cfg->tap_device);
+		if (!cc_oci_netlink_run(cmd_line)) {
+			return false;
+		}
 
-#define NETLINK_ADD_LINK_BR "link set dev %s master %s"
-	g_snprintf(cmd_line, sizeof(cmd_line),
-		NETLINK_ADD_LINK_BR,
-		config->net.ifname,
-		config->net.bridge);
+		g_snprintf(cmd_line, sizeof(cmd_line), NETLINK_LINK_EN,
+			if_cfg->ifname);
+		if (!cc_oci_netlink_run(cmd_line)) {
+			return false;
+		}
 
-	if (!cc_oci_netlink_run(cmd_line)) {
-		return false;
-	}
-
-	g_snprintf(cmd_line, sizeof(cmd_line),
-		NETLINK_ADD_LINK_BR,
-		config->net.tap_device,
-		config->net.bridge);
-
-	if (!cc_oci_netlink_run(cmd_line)) {
-		return false;
-	}
-
-#define NETLINK_LINK_EN	"link set dev %s up"
-	g_snprintf(cmd_line, sizeof(cmd_line),
-		NETLINK_LINK_EN,
-		config->net.tap_device);
-
-	if (!cc_oci_netlink_run(cmd_line)) {
-		return false;
-	}
-
-	g_snprintf(cmd_line, sizeof(cmd_line),
-		NETLINK_LINK_EN,
-		config->net.ifname);
-
-	if (!cc_oci_netlink_run(cmd_line)) {
-		return false;
-	}
-
-	g_snprintf(cmd_line, sizeof(cmd_line),
-		NETLINK_LINK_EN,
-		config->net.bridge);
-
-	if (!cc_oci_netlink_run(cmd_line)) {
-		return false;
+		g_snprintf(cmd_line, sizeof(cmd_line), NETLINK_LINK_EN,
+			if_cfg->bridge);
+		if (!cc_oci_netlink_run(cmd_line)) {
+			return false;
+		}
 	}
 
 	return true;
@@ -286,10 +360,83 @@ get_address(const gint family, const void *const sin_addr)
 }
 
 /*!
+ * Count the number of valid bits in the subnet prefix
+ * Copied over from BSD
+ *
+ * \param val \c the subnet
+ * \param size \c size of the subnet value in bytes
+ *
+ * \return \c prefix length if valid else \c 0
+ */
+static guint
+prefix(guchar *val, guint size)
+{
+        guchar *addr = val;
+        guint byte, bit, plen = 0;
+
+        for (byte = 0; byte < size; byte++, plen += 8) {
+                if (addr[byte] != 0xff) {
+                        break;
+		}
+	}
+
+	if (byte == size) {
+		return (plen);
+	}
+
+	for (bit = 7; bit != 0; bit--, plen++) {
+                if (!(addr[byte] & (1 << bit))) {
+                        break;
+		}
+	}
+
+	/* Handle errors */
+        for (; bit != 0; bit--) {
+                if (addr[byte] & (1 << bit)) {
+                        return(0);
+		}
+	}
+        byte++;
+        for (; byte < size; byte++) {
+                if (addr[byte]) {
+                        return(0);
+		}
+	}
+        return (plen);
+}
+
+/*!
+ * Obtain the Subnet prefix from subnet address
+ *
+ * \param family \c inetfamily
+ * \param sin_addr \c inet address
+ *
+ * \return \c string containing subnet prefix
+ */
+static gchar *
+subnet_to_prefix(const gint family, const void *const sin_addr) {
+	guint pfix = 0;
+	guchar *addr = (guchar *)sin_addr;
+
+	if (!addr) {
+		return g_strdup_printf("%d", pfix);
+	}
+
+	switch(family) {
+	case AF_INET6:
+		pfix = prefix(addr, 16);
+	case AF_INET:
+		pfix = prefix(addr, 4);
+	}
+
+	return g_strdup_printf("%d", pfix);
+}
+
+/*!
  * Obtain the string representation of the mac address
  * of an interface
  *
- * \param ifname \c inetface name
+ * \param ifname \c interface name
  *
  * \return \c string containing MAC address, else \c ""
  */
@@ -351,7 +498,7 @@ out:
  *
  * \param ifname \c interface name
  *
- * \return \c string containing default gw on that interface, else \c ""
+ * \return \c string containing default gw on that interface, else NULL \c ""
  */
 static gchar *
 get_default_gw(const gchar *const ifname)
@@ -402,7 +549,7 @@ get_default_gw(const gchar *const ifname)
 	}
 
 	if (token_count < 3) {
-		g_critical("unable to discover gateway [%s]", output);
+		g_debug("unable to discover gateway on [%s] [%s]", ifname, output);
 		goto out;
 	}
 
@@ -412,18 +559,36 @@ get_default_gw(const gchar *const ifname)
 	}
 
 	gw = g_strdup(output_tokens[2]);
+	g_debug("default gw [%s]", gw);
 
 out:
 	if (output_tokens != NULL) {
 		g_strfreev(output_tokens);
 	}
+
 	if (output != NULL) {
 		g_free(output);
 	}
-	if (gw == NULL) {
-		return g_strdup("");
-	}
+
 	return gw;
+}
+
+/*!
+ * GCompareFunc for searching through the list 
+ * of existing network interfaces
+ *
+ * \param[in] a \c a element from the list
+ * \param[in] b \c a value to compare with
+ *
+ * \return negative value if a < b ; zero if a = b ; positive value if a > b
+ */
+gint static
+compare_interface(gconstpointer a,
+		  gconstpointer b) {
+	const struct cc_oci_net_if_cfg *if_cfg = a;
+	const gchar *ifname = b;
+
+	return g_strcmp0(ifname, if_cfg->ifname);
 }
 
 /*!
@@ -431,11 +596,6 @@ out:
  * Currently done by by scanned the namespace
  * Ideally the OCI spec should be modified such that
  * these parameters are sent to the runtime
- *
- * The current implementation attempts to find the
- * first interface with a valid IPv4 address.
- *
- * TODO: Support multiple interfaces and IPv6
  *
  * \param[in,out] config \ref cc_oci_config.
  *
@@ -446,12 +606,16 @@ cc_oci_network_discover(struct cc_oci_config *const config)
 {
 	struct ifaddrs *ifa = NULL;
 	struct ifaddrs *ifaddrs = NULL;
+	struct cc_oci_net_if_cfg *if_cfg = NULL;
+	struct cc_oci_net_cfg *net = NULL;
 	gint family;
 	gchar *ifname;
 
 	if (!config) {
 		return false;
 	}
+
+	net = &(config->net);
 
 	if (getifaddrs(&ifaddrs) == -1) {
 		g_critical("getifaddrs() failed with errno =  %d %s\n",
@@ -461,8 +625,10 @@ cc_oci_network_discover(struct cc_oci_config *const config)
 
 	g_debug("Discovering container interfaces");
 
-	/* For now pick the first interface with a valid IP address */
+	/* For now add the interfaces with a valid IPv4 address */
 	for (ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
+		GSList *elem;
+
 		if (!ifa->ifa_addr) {
 			continue;
 		}
@@ -470,7 +636,7 @@ cc_oci_network_discover(struct cc_oci_config *const config)
 		g_debug("Interface := [%s]", ifa->ifa_name);
 
 		family = ifa->ifa_addr->sa_family;
-		if (family != AF_INET) {
+		if (!((family == AF_INET) || (family == AF_INET6)))  {
 			continue;
 		}
 
@@ -479,37 +645,67 @@ cc_oci_network_discover(struct cc_oci_config *const config)
 		}
 
 		ifname = ifa->ifa_name;
-		config->net.ifname = g_strdup(ifname);
-		config->net.mac_address = get_mac_address(ifname);
-		config->net.tap_device = g_strdup_printf("c%s", ifname);
-		config->net.bridge = g_strdup_printf("b%s", ifname);
-		config->net.ip_address = get_address(family,
-			&((struct sockaddr_in *)ifa->ifa_addr)->sin_addr);
-		config->net.subnet_mask = get_address(family,
-			&((struct sockaddr_in *)ifa->ifa_netmask)->sin_addr);
-		config->net.gateway = get_default_gw(ifname);
-		break;
+		elem = g_slist_find_custom(net->interfaces,
+					   ifname,
+					   compare_interface);
+
+		if (elem == NULL) {
+			if_cfg = g_malloc0(sizeof(*if_cfg));
+			if_cfg->ifname = g_strdup(ifname);
+			if_cfg->mac_address = get_mac_address(ifname);
+			if_cfg->tap_device = g_strdup_printf("c%s", ifname);
+			if_cfg->bridge = g_strdup_printf("b%s", ifname);
+			net->interfaces = g_slist_append(net->interfaces, if_cfg);
+		} else {
+			if_cfg = (struct cc_oci_net_if_cfg  *) elem->data;
+		}
+
+		if (family == AF_INET) {
+			struct cc_oci_net_ipv4_cfg *ipv4_cfg;
+			ipv4_cfg = g_malloc0(sizeof(*ipv4_cfg));
+
+			if_cfg->ipv4_addrs = g_slist_append(
+				if_cfg->ipv4_addrs, ipv4_cfg);
+
+			ipv4_cfg->ip_address = get_address(family,
+				&((struct sockaddr_in *)ifa->ifa_addr)->sin_addr);
+			ipv4_cfg->subnet_mask = get_address(family,
+				&((struct sockaddr_in *)ifa->ifa_netmask)->sin_addr);
+
+			if (net->gateway == NULL) {
+				net->gateway = get_default_gw(ifname);
+			}
+
+		} else if (family == AF_INET6) {
+			struct cc_oci_net_ipv6_cfg *ipv6_cfg;
+			ipv6_cfg = g_malloc0(sizeof(*ipv6_cfg));
+			if_cfg->ipv6_addrs = g_slist_append(
+				if_cfg->ipv6_addrs, ipv6_cfg);
+
+			ipv6_cfg->ipv6_address = get_address(family,
+				&((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr);
+			ipv6_cfg->ipv6_prefix = subnet_to_prefix(family,
+				&((struct sockaddr_in6 *)ifa->ifa_netmask)->sin6_addr);
+		}
 	}
 
 	freeifaddrs(ifaddrs);
 
-	if (config->oci.hostname) {
-		config->net.hostname = g_strdup(config->oci.hostname);
+	if (config->oci.hostname){
+		net->hostname = g_strdup(config->oci.hostname);
 	} else {
-		config->net.hostname = g_strdup("");
+		net->hostname = g_strdup("");
 	}
 
-	if (config->net.gateway == NULL) {
-		config->net.gateway = g_strdup("");
+	if (net->gateway == NULL) {
+		net->gateway = g_strdup("");
 	}
 
 	/* TODO: Need to see if this needed, does resolv.conf handle this */
-	config->net.dns_ip1 = g_strdup("");
-	config->net.dns_ip2 = g_strdup("");
+	net->dns_ip1 = g_strdup("");
+	net->dns_ip2 = g_strdup("");
 
-	if (!config->net.ifname) {
-		g_debug("No container networks discovered, networking disabled");
-	}
+	g_debug("[%d] networks discovered", g_slist_length(net->interfaces));
 
 	return true;
 }

--- a/src/networking.h
+++ b/src/networking.h
@@ -23,5 +23,6 @@
 
 gboolean cc_oci_network_create(const struct cc_oci_config *const config);
 gboolean cc_oci_network_discover(struct cc_oci_config *const config);
+void cc_oci_net_interface_free (struct cc_oci_net_if_cfg *if_cfg);
 
 #endif /* _CC_OCI_NETWORKING_H */

--- a/src/oci-config.c
+++ b/src/oci-config.c
@@ -32,6 +32,7 @@
 #include "oci.h"
 #include "semver.h"
 #include "oci-config.h"
+#include "networking.h"
 
 /*!
  * Free all resources associated with \p h hook object.
@@ -161,15 +162,13 @@ cc_oci_config_free (struct cc_oci_config *config)
 
 	g_free_if_set (config->net.hostname);
 	g_free_if_set (config->net.gateway);
-	g_free_if_set (config->net.mac_address);
-	g_free_if_set (config->net.ip_address);
-	g_free_if_set (config->net.subnet_mask);
-	g_free_if_set (config->net.ipv6_address);
-	g_free_if_set (config->net.ifname);
-	g_free_if_set (config->net.bridge);
-	g_free_if_set (config->net.tap_device);
 	g_free_if_set (config->net.dns_ip1);
 	g_free_if_set (config->net.dns_ip2);
+
+	if (config->net.interfaces) {
+		g_slist_free_full(config->net.interfaces,
+                (GDestroyNotify)cc_oci_net_interface_free);
+	}
 }
 
 /*!

--- a/src/oci.h
+++ b/src/oci.h
@@ -274,19 +274,18 @@ struct cc_oci_net_cfg {
 	/** DNS IP (xxx.xxx.xxx.xxx). */
 	gchar  *dns_ip2;
 
-	/* TODO: Need to support multiple networks
-	 * The parameters below are per network
-	 * interface and we will multiple
-	 */
+	/** Network interfaces. */
+	GSList  *interfaces;
+
+	/** TODO: Add support for routes */
+};
+
+
+/** cc-specific network interface configuration data. */
+struct cc_oci_net_if_cfg {
 
 	/** MAC address with colon separators (xx:xx:xx:xx:xx:xx). */
 	gchar  *mac_address;
-
-	/** IPv4 address (xxx.xxx.xxx.xxx). */
-	gchar  *ip_address;
-
-	/** IPv4 subnet mask (xxx.xxx.xxx.xxx). */
-	gchar  *subnet_mask;
 
 	/** Name of network interface (veth) within the namespace
 	 * This should also be the name of the interface within the VM */
@@ -298,10 +297,30 @@ struct cc_oci_net_cfg {
 	/** Name of the QEMU tap device */
 	gchar  *tap_device;
 
-	/** IPv6 address */
-	gchar  *ipv6_address;
+	/** List of IPv4 addresses on the interface */
+	GSList  *ipv4_addrs;
+
+	/** List of IPv6 addresses on the interface */
+	GSList  *ipv6_addrs;
 
 	/** TODO: Add support for routes */
+};
+
+/** cc-specific IPv4 configuration data. */
+struct cc_oci_net_ipv4_cfg {
+	/** IPv4 address (xxx.xxx.xxx.xxx). */
+	gchar  *ip_address;
+
+	/** IPv4 subnet mask (xxx.xxx.xxx.xxx). */
+	gchar  *subnet_mask;
+};
+
+/** cc-specific IPv6 configuration data. */
+struct cc_oci_net_ipv6_cfg {
+	/** IPv6 address (x:y::a:z). */
+	gchar  *ipv6_address;
+	/** IPv6 prefix */
+	gchar  *ipv6_prefix;
 };
 
 /**
@@ -486,5 +505,7 @@ gboolean cc_oci_kill (struct cc_oci_config *config,
 
 gboolean cc_oci_config_update (struct cc_oci_config *config,
 		struct oci_state *state);
+gboolean
+cc_oci_create_container_networking_workload (struct cc_oci_config *config);
 
 #endif /* _CC_OCI_H */


### PR DESCRIPTION
Discover all the interfaces and their associated IP addresses
within the container name space. Connect each interface to the
a integration bridge and create an associated tap interface
for qemu.

Pick the first interface discovered and configure its IP address.

Note: This IP configuration is currently incorrect when there are
multiple interfaces.

This is partial support for issue https://github.com/01org/cc-oci-runtime/issues/95

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>