### PR TITLE
data: Distribute container image init services

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,6 +62,18 @@ AM_CPPFLAGS = -I $(top_srcdir)/src -DG_LOG_DOMAIN=\"$(PACKAGE_NAME)\" \
 defaultsdir = $(datadir)/defaults/$(PACKAGE_NAME)
 defaults_DATA = data/vm.json data/hypervisor.args data/kernel-cmdline
 
+cc_image_systemd_files = \
+	data/container.target \
+	data/opt-rootfs.mount \
+	data/opt-rootfs-proc.mount \
+	data/opt-rootfs-sys.mount \
+	data/container-workload.service
+
+if CC_IMAGE_SYSTEMDSYSTEMUNIT
+ccimage_systemdfilesdir= @CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH@
+ccimage_systemdfiles_DATA = $(cc_image_systemd_files)
+endif
+
 AM_CFLAGS = -std=gnu99 -fstack-protector -Wall -pedantic \
 	-Wstrict-prototypes -Wundef -fno-common \
 	-Werror-implicit-function-declaration \
@@ -164,6 +176,7 @@ EXTRA_DIST = \
 	commit_id \
 	versions.txt \
 	$(defaults_DATA) \
+	$(cc_image_systemd_files) \
 	data/cc-oci-runtime.sh.in \
 	$(bats_test_sources)
 

--- a/configure.ac
+++ b/configure.ac
@@ -123,6 +123,18 @@ AS_IF([test $FUNCTIONAL_TEST = 1],
    AC_SUBST(BATS_PATH)]
 )
 
+#path to install systemd files used to boot by cc-image
+AC_ARG_WITH([cc-image-systemdsystemunitdir],
+	AS_HELP_STRING([--with-cc-image-systemdsystemunitdir=DIR],[path to systemd service directory for cc-image]),
+	[
+		CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH=${withval}
+		AC_SUBST(CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH)
+	],
+	[CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH=no]
+)
+AM_CONDITIONAL([CC_IMAGE_SYSTEMDSYSTEMUNIT],[test x"$CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH" != xno])
+
+		AC_SUBST([CC_IMAGE_SYSTEMDSYSTEMUNIT], [1])
 #Check for qemu
 DEFAULT_QEMU_PATH=/usr/bin/qemu-system-x86_64
 
@@ -246,11 +258,12 @@ cc-oci-runtime - $VERSION
 
  • General:
 
-       QEMU             : $ac_cv_path_QEMU
-       QEMU pc-lite     : $has_pc_lite
-       Container kernel : $CONTAINER_KERNEL
-       Container image  : $CONTAINERS_IMG
-       Debug build      : $enable_debug
+       QEMU                     : $ac_cv_path_QEMU
+       QEMU pc-lite             : $has_pc_lite
+       Container kernel         : $CONTAINER_KERNEL
+       Container image          : $CONTAINERS_IMG
+       Container image services : $CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH
+       Debug build              : $enable_debug
 
  • Tests:
 

--- a/data/container-workload.service
+++ b/data/container-workload.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Container Workload
+After=opt-rootfs-resolv.service
+After=opt-rootfs-proc.mount
+
+[Service]
+RootDirectory=/opt/rootfs
+RootDirectoryStartOnly=yes
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+EnvironmentFile=-/opt/rootfs/.containerenv
+StandardInput=tty
+StandardOutput=tty
+PrivateDevices=yes
+Type=simple
+ExecStart=/.containerexec
+ExecStop=/usr/bin/systemctl --force poweroff
+FailureAction=poweroff

--- a/data/container.target
+++ b/data/container.target
@@ -1,0 +1,12 @@
+[Unit]
+Description=Containers Target
+Requires=basic.target
+Conflicts=rescue.service rescue.target
+After=basic.target rescue.service rescue.target
+AllowIsolate=yes
+Wants=systemd-logind.service
+Wants=container-workload.service
+Wants=systemd-networkd.service
+Wants=systemd-resolved.service
+Wants=opt-rootfs.mount
+Wants=opt-rootfs-proc.mount

--- a/data/opt-rootfs-proc.mount
+++ b/data/opt-rootfs-proc.mount
@@ -1,0 +1,7 @@
+[Unit]
+After=opt-rootfs.mount
+
+[Mount]
+What=proc
+Where=/opt/rootfs/proc
+Type=proc

--- a/data/opt-rootfs-sys.mount
+++ b/data/opt-rootfs-sys.mount
@@ -1,0 +1,7 @@
+[Unit]
+After=opt-rootfs.mount
+
+[Mount]
+What=sys
+Where=/opt/rootfs/sys
+Type=proc

--- a/data/opt-rootfs.mount
+++ b/data/opt-rootfs.mount
@@ -1,0 +1,5 @@
+[Mount]
+What=rootfs
+Where=/opt/rootfs
+Type=9p
+Options=trans=virtio,version=9p2000.L,msize=131072

--- a/src/oci.h
+++ b/src/oci.h
@@ -90,10 +90,8 @@
 
 /** Name of file containing environment variables that will be set
  * inside the VM.
- *
- * Note: name is historical.
  */
-#define CC_OCI_ENV_FILE		"/.dockerenv"
+#define CC_OCI_ENV_FILE		"/.containerenv"
 
 /** Shell to use for \ref CC_OCI_WORKLOAD_FILE. */
 #define CC_OCI_WORKLOAD_SHELL		"/bin/sh"

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -846,7 +846,7 @@ START_TEST(test_cc_oci_create_container_workload) {
 
 	execfile = g_build_path ("/", tmpdir, ".containerexec", NULL);
 	ck_assert (execfile);
-	envfile = g_build_path ("/", tmpdir, ".dockerenv", NULL);
+	envfile = g_build_path ("/", tmpdir, ".containerenv", NULL);
 	ck_assert (envfile);
 
 	ck_assert (cc_oci_create_container_workload (&config));


### PR DESCRIPTION
Fixes #170 
Clear containers internal behivor is configured by systemd
services. This patch adds the systemd services that must
be intalled in a container image.

Added configuation units:

container.target           : unit that groups and sync all task to be done at
                             clear container boot time.

container-workload.service : unit that execute initial container
                             workload in a shared rootfs.

opt-rootfs.mount           : mount shared rootfs to be used in the
                             container workload

opt-rootfs-proc.mount      : mount /proc guest in shared rootfs

opt-rootfs-sys.mount       : mount /sys guest in shared rootfs

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>