### PR TITLE
Logging: Fix "std_file_fd" fd leak.

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -547,11 +547,12 @@ void cc_oci_setup_hypervisor_logs (struct cc_oci_config *config)
 		}
 
 		/* redirecting stdout/stderr to a file */
-		if (dup2(std_file_fd, i->std_fd) >= 0) {
-			close (std_file_fd);   /* Close unused file descriptor */
-		} else {
+		if (dup2(std_file_fd, i->std_fd) < 0) {
 			g_critical("failed to dup %s : %s", std_file_path, strerror(errno));
 		}
+
+		/* Close unused file descriptor */
+		close (std_file_fd);
 	}
 }
 


### PR DESCRIPTION
This fd needs to be closed on success and failure; the former because
it has been dup(2)'d, and the latter because the dup(2) failed but the
fd is still open from the original creat(2).

Signed-off-by: James Hunt <james.o.hunt@intel.com>