### PR TITLE
Networking: Fix missing break in prefix logic

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -363,8 +363,13 @@ subnet_to_prefix(const gint family, const void *const sin_addr) {
 	switch(family) {
 	case AF_INET6:
 		pfix = prefix(addr, 16);
+		break;
 	case AF_INET:
 		pfix = prefix(addr, 4);
+		break;
+	default:
+		g_warning("invalid prefix family %d", family);
+		pfix = 0;
 	}
 
 	return g_strdup_printf("%d", pfix);


### PR DESCRIPTION
Fix missing break in case statement which causes IPv6 prefix
generation failure.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>