### PR TITLE
Tests: newly-added integration tests are not distributed.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -171,7 +171,8 @@ EXTRA_DIST = \
 	versions.txt \
 	$(defaults_DATA) \
 	data/cc-oci-runtime.sh.in \
-	$(bats_test_sources)
+	$(bats_test_sources) \
+	tests/integration
 
 if CPPCHECK
 CHECK_DEPS += cppcheck


### PR DESCRIPTION
Add files under tests/integration/ to distribution tarballs.

Signed-off-by: James Hunt <james.o.hunt@intel.com>