### PR TITLE
Config: configure must not resolve kernel and container image paths.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -206,7 +206,7 @@ AC_ARG_WITH([cc-kernel],
         [clear container kernel path])
     ],
     [
-        CONTAINER_KERNEL=$(realpath $with_cc_kernel)
+        CONTAINER_KERNEL=$with_cc_kernel
         AC_SUBST([CONTAINER_KERNEL])
     ],
     [
@@ -221,7 +221,7 @@ AC_ARG_WITH([cc-image],
         [clear container image path])
     ],
     [
-        CONTAINERS_IMG=$(realpath $with_cc_image)
+        CONTAINERS_IMG=$with_cc_image
         AC_SUBST([CONTAINERS_IMG])
     ],
     [


### PR DESCRIPTION
To avoid having to regenerate the "vm.json" configuration file,
"--with-cc-image=" is often provided with a symlink path [1]. This allows
other mechanisms to update the image and "re-point" the symlink to the
latest image, which avoids having to regenerate "vm.json".

However, configure was resolving kernel and container paths, meaning
that the runtime would not be using the latest image (as specified by
the symlink) and would fail if the release hard-coded in "vm.json" was
removed when it became stale.

Note that the runtime full resolves all paths so that it can log
full details of the artifacts being used for a particular container.

--

[1] - The same logic applies to "--with-cc-kernel=" but note that
     "--with-qemu-path=" is not resolved.

Signed-off-by: James Hunt <james.o.hunt@intel.com>