### PR TITLE
Tests: add connectivity test between two containers

### DIFF
--- a/tests/integration/docker/network.bats
+++ b/tests/integration/docker/network.bats
@@ -7,10 +7,10 @@
 #
 #  This program is free software; you can redistribute it and/or
 #  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2 
+#  as published by the Free Software Foundation; either version 2
 #  of the License, or (at your option) any later version.
 #
-#  This program is distributed in the hope that it will be useful, 
+#  This program is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
@@ -30,4 +30,11 @@ setup() {
 @test "HostName is passed to the container" {
 	hostName=clr-container
 	$DOCKER_EXE run -h $hostName -i ubuntu hostname | grep $hostName
+}
+
+@test "Verify connectivity between 2 containers" {
+	contName='pingTest'
+	$DOCKER_EXE run -tid --name "$contName" ubuntu bash
+	ip_addr=$($DOCKER_EXE inspect --format '{{ .NetworkSettings.IPAddress }}' "$contName")
+	$DOCKER_EXE run -i debian ping -c 1 "$ip_addr" | grep -q '1 packets received'
 }


### PR DESCRIPTION
This test runs a simple ping from one Container to another
to verify connectivity.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>