### PR TITLE
oci: Use process.terminal to check for interactive runs

### DIFF
--- a/src/hypervisor.c
+++ b/src/hypervisor.c
@@ -235,7 +235,7 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 		 *
 		 * Eventually move to using "stdio,id=charconsole0,signal=off"
 		 */
-		if (! isatty (STDIN_FILENO)) {
+		if (! config->oci.process.terminal ) {
 
 			config->console = g_build_path ("/",
 					config->bundle_path,

--- a/src/oci.c
+++ b/src/oci.c
@@ -1045,12 +1045,9 @@ cc_oci_start (struct cc_oci_config *config,
 	 * A simple way to determine if we're being called
 	 * under containerd is to check if stdin is closed.
 	 *
-	 * FIXME: a better way is to check if config->process.terminal
-	 * is set.
-	 *
 	 * Do not wait when console is empty.
 	 */
-	if ((isatty (STDIN_FILENO) && ! config->detached_mode) &&
+	if ((config->oci.process.terminal && ! config->detached_mode) &&
 	    !config->use_socket_console) {
 		wait = true;
 	}

--- a/tests/hypervisor_test.c
+++ b/tests/hypervisor_test.c
@@ -388,7 +388,7 @@ START_TEST(test_cc_oci_expand_cmdline) {
 	ck_assert (! g_remove (config.vm->kernel_path));
 	ck_assert (! g_remove (config.oci.root.path));
 
-	if (! isatty (STDIN_FILENO)) {
+	if (! config.oci.process.terminal) {
 		ck_assert (! g_remove (cc_stdin));
 		ck_assert (! g_remove (cc_stdout));
 	}
@@ -621,7 +621,7 @@ START_TEST(test_cc_oci_vm_args_get) {
 	ck_assert (! g_remove (config.vm->kernel_path));
 	ck_assert (! g_remove (config.oci.root.path));
 
-	if (! isatty (STDIN_FILENO)) {
+	if (! config.oci.process.terminal) {
 		ck_assert (! g_remove (cc_stdin));
 		ck_assert (! g_remove (cc_stdout));
 	}


### PR DESCRIPTION
Currently we check if stdin refers to a terminal using isatty()
Use the process.terminal value from config.json instead.
Docker sets this value to true when run interactively.

Fixes 183

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>