### PR TITLE
Process: Fix running standalone.

### DIFF
--- a/src/oci.c
+++ b/src/oci.c
@@ -1719,6 +1719,11 @@ cc_oci_config_update (struct cc_oci_config *config,
 
 	config->use_socket_console = state->use_socket_console;
 
+	if (config->console && ! config->use_socket_console && isatty (STDIN_FILENO)) {
+		g_debug ("enabling terminal for standalone mode");
+		config->oci.process.terminal = true;
+	}
+
 	if (state->vm) {
 		config->vm = state->vm;
 		state->vm = NULL;

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -618,6 +618,7 @@ START_TEST(test_cc_oci_config_update) {
 	ck_assert (! config.oci.mounts);
 	ck_assert (! config.console);
 	ck_assert (! config.use_socket_console);
+	ck_assert (! config.oci.process.terminal);
 	ck_assert (! config.vm);
 
 	/**************************/
@@ -660,6 +661,14 @@ START_TEST(test_cc_oci_config_update) {
 	ck_assert (config.oci.mounts);
 	ck_assert (config.console);
 	ck_assert (config.use_socket_console);
+
+	if (isatty (STDIN_FILENO)) {
+		if (config.console && ! config.use_socket_console) {
+			ck_assert (config.oci.process.terminal);
+		}
+
+	}
+
 	ck_assert (config.vm);
 
 	ck_assert (g_slist_length (config.oci.mounts) == 1);


### PR DESCRIPTION
An unintended side-effect of commit 26559c5 was that it broke running
standalone. Although running stand-alone still requires "config.json" to
specify "process.terminal=true", cc_oci_start() was not waiting for the
hypervisor.

This minimal fix [1] is better than what we had before 26559c5 since it
moves the heuristic to the generic cc_oci_config_update() rather than
hard-coding it in cc_oci_start().

---

[1] - An alternative solution would be to add "process.terminal"
      to the state file.

Signed-off-by: James Hunt <james.o.hunt@intel.com>