### PR TITLE
Process: Re-take on fixing running hooks with no arguments.

### DIFF
--- a/tests/process_test.c
+++ b/tests/process_test.c
@@ -137,7 +137,7 @@ START_TEST(test_cc_run_hook) {
 	cc_oci_hook_free (hook);
 
 	/*******************************/
-	/* full path, 1 arg */
+	/* full path specified, cmd arg */
 
 	hook_loop = g_main_loop_new (NULL, 0);
 	ck_assert (hook_loop);
@@ -149,7 +149,7 @@ START_TEST(test_cc_run_hook) {
 
 	hook->args = g_new0 (gchar *, 2);
 	ck_assert (hook->args);
-	hook->args[0] = g_strdup ("bs=1");
+	hook->args[0] = g_strdup (cmd);
 
 	ck_assert (cc_run_hook (hook, "", 1));
 
@@ -157,7 +157,28 @@ START_TEST(test_cc_run_hook) {
 	cc_oci_hook_free (hook);
 
 	/*******************************/
-	/* full path, 3 args */
+	/* full path, cmd arg + 1 arg */
+
+	hook_loop = g_main_loop_new (NULL, 0);
+	ck_assert (hook_loop);
+
+	hook = g_new0 (struct oci_cfg_hook, 1);
+	ck_assert (hook);
+
+	g_strlcpy (hook->path, cmd, sizeof (hook->path));
+
+	hook->args = g_new0 (gchar *, 3);
+	ck_assert (hook->args);
+	hook->args[0] = g_strdup (cmd);
+	hook->args[1] = g_strdup ("bs=1");
+
+	ck_assert (cc_run_hook (hook, "", 1));
+
+	g_main_loop_unref (hook_loop);
+	cc_oci_hook_free (hook);
+
+	/*******************************/
+	/* full path, cmd arg + 2 args */
 
 	hook_loop = g_main_loop_new (NULL, 0);
 	ck_assert (hook_loop);
@@ -169,9 +190,32 @@ START_TEST(test_cc_run_hook) {
 
 	hook->args = g_new0 (gchar *, 4);
 	ck_assert (hook->args);
-	hook->args[0] = g_strdup ("bs=1");
+	hook->args[0] = g_strdup (cmd);
 	hook->args[1] = g_strdup ("bs=1");
 	hook->args[2] = g_strdup ("bs=1");
+
+	ck_assert (cc_run_hook (hook, "", 1));
+
+	g_main_loop_unref (hook_loop);
+	cc_oci_hook_free (hook);
+
+	/*******************************/
+	/* full path, cmd arg + 3 args */
+
+	hook_loop = g_main_loop_new (NULL, 0);
+	ck_assert (hook_loop);
+
+	hook = g_new0 (struct oci_cfg_hook, 1);
+	ck_assert (hook);
+
+	g_strlcpy (hook->path, cmd, sizeof (hook->path));
+
+	hook->args = g_new0 (gchar *, 5);
+	ck_assert (hook->args);
+	hook->args[0] = g_strdup (cmd);
+	hook->args[1] = g_strdup ("bs=1");
+	hook->args[2] = g_strdup ("bs=1");
+	hook->args[3] = g_strdup ("bs=1");
 
 	ck_assert (cc_run_hook (hook, "", 1));
 


### PR DESCRIPTION
The fix introduced on 3d8911d since although it supported no-arg hooks,
it did not support running hooks where the argv[0] passed to the hook
was different to the hook path. This is used by docker to handle network
setup where dockerd is exec'd as "libnetwork-setkey".

The correct fix is to re-introduce the use of
G_SPAWN_FILE_AND_ARGV_ZERO and handle the "no-arg" case specially (along
with adding better comments around arg handling and the use of
G_SPAWN_FILE_AND_ARGV_ZERO).

Updated tests to reflect re-introduction of G_SPAWN_FILE_AND_ARGV_ZERO.
Note that these tests are still commented out since they fail under
valgrind's helgrind tool. See github issue #214.

Signed-off-by: James Hunt <james.o.hunt@intel.com>