### PR TITLE
Config: Remove bug report email address.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [0.1], [dev@clearlinux.org])
+AC_INIT([cc-oci-runtime], [0.1])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
The address specified in "configure.ac" is not that useful given that
there is now a mailing list that could be used instead, as specified in
CONTRIBUTING.md. However, that document already explains how we want
bug reports to be handled (github issues) so a bug report address is
redundant.

Signed-off-by: James Hunt <james.o.hunt@intel.com>