### PR TITLE
Arguments: Fail if privilege checks fail.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -350,6 +350,7 @@ handle_arguments (int argc, char **argv)
 	priv_level = cc_oci_get_priv_level (argc, argv, sub, &config);
 	if (priv_level == 1 && getuid ()) {
 		g_critical ("must run as root");
+		ret = false;
 		goto out;
 	}
 


### PR DESCRIPTION
handle_arguments() was calling cc_oci_get_priv_level() but not returning
false in the failure scenario as it should have.

Signed-off-by: James Hunt <james.o.hunt@intel.com>