### PR TITLE
Mount: leave rootfs as it was found

### DIFF
--- a/src/oci.h
+++ b/src/oci.h
@@ -420,6 +420,13 @@ struct cc_oci_mount {
 
 	/** \c true if mount should not be honoured. */
 	gboolean       ignore_mount;
+
+	/** Full path to first parent directory created to mount dest
+	 * this path will be deleted after umount dest in order to
+	 * left the rootfs in its original state.
+	 * NULL if no directory was created to mount dest
+	 */
+	gchar          *directory_created;
 };
 
 /** The main object holding all configuration data.

--- a/src/state.c
+++ b/src/state.c
@@ -253,14 +253,27 @@ handle_state_created_section(GNode* node, struct handler_data* data) {
  */
 static void
 handle_state_mounts_section(GNode* node, struct handler_data* data) {
+	struct cc_oci_mount* m;
 
-	if (node && node->data) {
-		struct cc_oci_mount* m = g_new0 (struct cc_oci_mount, 1);
-		g_strlcpy (m->dest, (char*)node->data, sizeof (m->dest));
+	if (! (node && node->data)) {
+		return;
+	}
+	if (! (node->children && node->children->data)) {
+		g_critical("%s missing value", (char*)node->data);
+		return;
+	}
+
+	if (! g_strcmp0(node->data, "destination")) {
+		m = g_new0 (struct cc_oci_mount, 1);
+		g_strlcpy (m->dest, (char*)node->children->data, sizeof (m->dest));
 		m->ignore_mount = false;
-
-		data->state->mounts =
-		    g_slist_append(data->state->mounts, m);
+		data->state->mounts = g_slist_append(data->state->mounts, m);
+	} else if (! g_strcmp0(node->data, "directory_created")) {
+		GSList *l = g_slist_last(data->state->mounts);
+		if (l) {
+			m = (struct cc_oci_mount*)l->data;
+			m->directory_created = g_strdup((char*)node->children->data);
+		}
 	}
 }
 

--- a/tests/data/mounts.json
+++ b/tests/data/mounts.json
@@ -32,6 +32,28 @@
 				"nodev",
 				"ro"
 			]
+		},
+		{
+			"destination": "/tmp/321/tmp",
+			"type": "type",
+			"source": "/dev/tty",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"ro"
+			]
+		},
+		{
+			"destination": "tmp/321/tmp",
+			"type": "type",
+			"source": "/dev/tty",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"ro"
+			]
 		}
 	]
 }

--- a/tests/data/state.json
+++ b/tests/data/state.json
@@ -15,6 +15,12 @@
       "key1" : "value1",
       "key2" : "value2"
   },
+  "mounts" : [
+      {
+          "destination" : "/tmp/tmp/",
+          "directory_created" : "/tmp/tmp"
+      }
+  ],
   "vm" : {
 	  "image_path" : "/path/to/clear-containers.img",
 	  "workload_path" : "/tmp/bundle//.containerexec",


### PR DESCRIPTION
with this patch directories created by cc-oci-runtime
when directories or files are mounted will be deleted
once umount is done

fixes #178

Signed-off-by: Julio Montes <julio.montes@intel.com>