### PR TITLE
environment: Provide HOME in the default container environment

### DIFF
--- a/src/oci.h
+++ b/src/oci.h
@@ -104,6 +104,12 @@
 */
 #define CC_OCI_VM_CONFIG "vm.json"
 
+/* Path to the passwd formatted file. */
+#define PASSWD_PATH "/etc/passwd"
+
+/* Path to the stateless passwd file. */ 
+#define STATELESS_PASSWD_PATH "/usr/share/defaults/etc/passwd"
+
 /** Status of an OCI container. */
 enum oci_status {
 	OCI_STATUS_CREATED = 0,

--- a/tests/data/passwd
+++ b/tests/data/passwd
@@ -1,0 +1,4 @@
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+mongodb:x:129:65534::/var/lib/mongodb:/bin/false
+redis:x:130:141::/var/lib/redis:/bin/false


### PR DESCRIPTION
HOME is provided by default by runc. Users will expect the same behaviour
from our runtime.
We first check if HOME is provided in the config provided by docker.
If not we set it to the home directory of the workload user.

Fixes #139

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>