### PR TITLE
Process: Add QA check to pullapprove config.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,15 +1,26 @@
 approve_by_comment: true
-approve_regex: '^(LGTM|lgtm|Approve|\+1|:\+1:)'
+approve_regex: '^(LGTM|lgtm|Approved|\+1|:\+1:|qa-passed)'
+reject_regex: '^(Rejected|-1|:-1:|qa-failed)'
 reset_on_push: true
 reset_on_reopened: true
 author_approval: ignored
 reviewers:
-  teams:
-    - clear-containers-intel
-  name: default
-  required: 2
-  conditions:
-    branches:
-      - master 
+  -
+    name: default
+    teams:
+      - clear-containers-intel
+    required: 2
+    conditions:
+      branches:
+        - master
+  -
+    name: qa
+    members:
+      - chavafg
+      - gabyct
+    required: 1
+    conditions:
+      branches:
+        - master
 signed_off_by:
   required: true


### PR DESCRIPTION
The QA team are now running additional tests which are triggered when
new PRs are raised. The test outcome is marked by adding a special
comment to the PR:

  - a "qa-passed" comment means all the tests passed.
  - a "qa-failed" comment means atleast one test failed.

Updated the pullapprove configuration file to:

- Require an additional approval from named QA members.

- Allow a PR to be explicitly rejected by introducing use of the
  `reject_regex` option containing `qa-failed`
  (if any QA tests fail, the PR cannot be approved).

- Modified the `approve_regex` to add `qa-passed` and changed `Approve`
  to `Approved` to mirror the `reject_regex`'s `rejected` value.

Signed-off-by: James Hunt <james.o.hunt@intel.com>