### PR TITLE
cmdline: Clarify where you can place global and command options

### DIFF
--- a/src/commands/help.c
+++ b/src/commands/help.c
@@ -25,7 +25,7 @@ usage (void)
 {
 	struct subcommand **sub;
 	g_print ("Usage:\n");
-	g_print ("%s [options] [command] [options]\n",
+	g_print ("%s [global options] [command] [command options]\n",
 			PACKAGE_NAME);
 	g_print ("\n");
 	g_print ("Supported commands:\n");


### PR DESCRIPTION
The Usage string inferred that you could place any options any side
of the [command], but what it meant to indiate was that global options
come before the command and command specific options come after the
command. Change the message to make that clearer.

Ideally we would also modifiy the 'Options:' paragraph section in the
help to say 'Global Options:', but that is buried in the source of the
glib g_option source, with no way to override.

Fixes #242

Signed-off-by: Graham Whaley <graham.whaley@intel.com>