### PR TITLE
Tests: Fix bats test description.

### DIFF
--- a/tests/functional/help.bats
+++ b/tests/functional/help.bats
@@ -68,7 +68,7 @@ function teardown() {
 	[[ ${lines[0]} =~ Usage:+ ]]
 }
 
-@test "@cor kill --help" {
+@test "cor kill --help" {
 	run $COR kill --help
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ Usage:+ ]]


### PR DESCRIPTION
A rogue "@" had crept into the description for the "kill --help" bats
test.

Signed-off-by: James Hunt <james.o.hunt@intel.com>