### PR TITLE
State: Make runtime re-read statefile last updated by child.

### DIFF
--- a/src/oci.c
+++ b/src/oci.c
@@ -1205,6 +1205,16 @@ cc_oci_run (struct cc_oci_config *config)
 		return false;
 	}
 
+	/* Update the config object based on the state.
+	 *
+	 * This is required since the child process that becomes the
+	 * hypervisor has now updated the on-disk state file. But the
+	 * parents state object does not reflect the on-disk state.
+	 */
+	if (! cc_oci_config_update (config, state)) {
+		return false;
+	}
+
 	if (! cc_oci_start (config, state)) {
 		return false;
 	}


### PR DESCRIPTION
The child process that becomes the hypervisor updates the on-disk state
file, so the parent process (the runtime) must re-read the state file to
reflect the true state.

This fixes the "run" command and the failing functional tests in "start.bats".

Signed-off-by: James Hunt <james.o.hunt@intel.com>