### PR TITLE
Tests: Fix failure when running under docker.

### DIFF
--- a/tests/namespace_test.c
+++ b/tests/namespace_test.c
@@ -143,11 +143,12 @@ START_TEST(test_cc_oci_ns_setup) {
 		/* setns(2) error */
 		saved = errno;
 
-		/* Normally EINVAL is returned, but if run under
-		 * valgrind, the error could be ENOSYS since valgrind
-		 * doesn't implement this syscall seemingly.
+		/* - Normally EINVAL is returned.
+		 * - If run under valgrind ENOSYS is returned
+		 *   (since valgrind doesn't support this syscall yet seemingly).
+		 * - If run inside a docker container, EPERM is returned.
 		 */
-		ck_assert (saved == EINVAL || saved == ENOSYS);
+		ck_assert (saved == EINVAL || saved == ENOSYS || saved == EPERM);
 
 		ck_assert (! g_remove (ns->path));
 		g_free (ns->path);


### PR DESCRIPTION
The test_cc_oci_ns_setup() test asserts the possible errno values when
cc_oci_ns_setup() fails. However, EPERM was missing, which gets returned
when the tests are run as a non-priv user under docker.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>