### PR TITLE
data: guest-config: Add hyperstart.service as boot dependency

### DIFF
--- a/data/container.target
+++ b/data/container.target
@@ -10,3 +10,4 @@ Wants=systemd-networkd.service
 Wants=systemd-resolved.service
 Wants=opt-rootfs.mount
 Wants=opt-rootfs-proc.mount
+Wants=hyperstart.service


### PR DESCRIPTION
Clear containers image will use hyperstart as daemon started by
hypertart.service. This patch adds this service in the boot flow.

Notice that it uses Wants=hyperstart.service in container.target
(as others services and mount units), "if the units
fail to start or cannot be added to the transaction, this has no
impact on the validity of the transaction as a whole"[1]. This means
that if a container image does not provide hyperstart.service or
fails the boot wont fail.

1. https://www.freedesktop.org/software/systemd/man/systemd.unit.html

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>