### PR TITLE
Process: Disable QA pullapprove review group.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,6 +1,6 @@
 approve_by_comment: true
-approve_regex: '^(LGTM|lgtm|Approved|\+1|:\+1:|qa-passed)'
-reject_regex: '^(Rejected|-1|:-1:|qa-failed)'
+approve_regex: '^(LGTM|lgtm|Approved|\+1|:\+1:)'
+reject_regex: '^(Rejected|-1|:-1:)'
 reset_on_push: true
 reset_on_reopened: true
 author_approval: ignored
@@ -10,15 +10,6 @@ reviewers:
     teams:
       - clear-containers-intel
     required: 2
-    conditions:
-      branches:
-        - master
-  -
-    name: qa
-    members:
-      - chavafg
-      - gabyct
-    required: 1
     conditions:
       branches:
         - master


### PR DESCRIPTION
pullapprove doesn't currently provide the funcationality we need to
support a proper QA process, so disable the QA review group and
QA approve/reject regex's for now.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>