### PR TITLE
Mount: fix mount sysfs

### DIFF
--- a/data/container.target
+++ b/data/container.target
@@ -10,4 +10,5 @@ Wants=systemd-networkd.service
 Wants=systemd-resolved.service
 Wants=opt-rootfs.mount
 Wants=opt-rootfs-proc.mount
+Wants=opt-rootfs-sys.mount
 Wants=hyperstart.service


### PR DESCRIPTION
With this patch sysfs will be mounted on /sys
this change is needed by hyperstart due to it
reads /sys/class/virtio-ports/ in order to find
CTL and TTY channels

Signed-off-by: Julio Montes <julio.montes@intel.com>