### PR TITLE
hypervisor: Add sockets for guest agent

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -290,6 +290,8 @@ Currently, the runtime will expand the following `special tags` found in
 - ``@SIZE@`` - size of @IMAGE@ which is auto-calculated.
 - ``@UUID@`` - VM uuid.
 - ``@WORKLOAD_DIR@`` - path to workload chroot directory that will be mounted (via 9p) inside the VM.
+- ``@AGENT_CTL_SOCKET@`` - path to the guest agent control socket ( control serial port for hyperstart)
+- ``@AGENT_TTY_SOCKET@`` - path to the guest agent multiplex tty I/O socket ( tty serial port for hyperstart)
 
 Logging
 -------

--- a/data/hypervisor.args.in
+++ b/data/hypervisor.args.in
@@ -35,6 +35,16 @@ virtconsole,chardev=charconsole0,id=console0
 @CONSOLE_DEVICE@
 -chardev
 @PROCESS_SOCKET@
+#hyperstart ctl serial port
+-chardev
+socket,id=charch0,path=@AGENT_CTL_SOCKET@,server,nowait
+-device
+virtserialport,bus=virtio-serial0.0,nr=1,chardev=charch0,id=channel0,name=sh.hyper.channel.0
+#hyperstart tty_serial port
+-chardev
+socket,id=charch1,path=@AGENT_TTY_SOCKET@,server,nowait
+-device
+virtserialport,bus=virtio-serial0.0,nr=2,chardev=charch1,id=channel1,name=sh.hyper.channel.1
 -uuid
 @UUID@
 -qmp

--- a/src/hypervisor.c
+++ b/src/hypervisor.c
@@ -153,6 +153,8 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 	gchar            *bytes = NULL;
 	gchar            *console_device = NULL;
 	g_autofree gchar *procsock_device = NULL;
+	g_autofree gchar *agent_ctl_socket = NULL;
+	g_autofree gchar *agent_tty_socket = NULL;
 
 	gboolean          ret = false;
 	gint              count;
@@ -300,6 +302,16 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 
 	procsock_device = g_strdup_printf ("socket,id=procsock,path=%s,server,nowait", config->state.procsock_path);
 
+	agent_ctl_socket = g_build_path ("/", config->state.runtime_path,
+					CC_OCI_AGENT_CTL_SOCKET, NULL);
+
+	g_debug("guest agent ctl socket: %s", agent_ctl_socket);
+
+	agent_tty_socket = g_build_path("/", config->state.runtime_path,
+					CC_OCI_AGENT_TTY_SOCKET, NULL);
+
+	g_debug("guest agent tty socket: %s", agent_tty_socket);
+
 	kernel_net_params = cc_oci_expand_net_cmdline(config);
 
 	if ( config->net.interfaces == NULL ) {
@@ -344,6 +356,8 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 		{ "@NETDEV_PARAMS@"     , netdev_params              },
 		{ "@NETDEVICE@"         , net_device_option          },
 		{ "@NETDEVICE_PARAMS@"  , net_device_params          },
+		{ "@AGENT_CTL_SOCKET@"  , agent_ctl_socket           },
+		{ "@AGENT_TTY_SOCKET@"  , agent_tty_socket           },
 		{ NULL }
 	};
 

--- a/src/oci.h
+++ b/src/oci.h
@@ -62,6 +62,11 @@
 /** Name of hypervisor socket used as a console device. */
 #define CC_OCI_CONSOLE_SOCKET		"console.sock"
 
+/** Name of control socket used to communicate guest agent. */
+#define CC_OCI_AGENT_CTL_SOCKET		"ga-ctl.sock"
+/** Name of hypervisor socket used as a console device. */
+#define CC_OCI_AGENT_TTY_SOCKET		"ga-tty.sock"
+
 /** File generated below \ref CC_OCI_RUNTIME_DIR_PREFIX at runtime that
  * contains metadata about the running instance.
  */


### PR DESCRIPTION
Fixes #258
This patch adds serial ports used by hyperstart using Unix socket backend

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>