### PR TITLE
build: Make the generated files depend on Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,7 @@ GENERATED_FILES = \
 	tests/functional/common.bash \
 	tests/functional/data/config-minimal-cc-oci.json
 
-$(GENERATED_FILES): %: %.in
+$(GENERATED_FILES): %: %.in Makefile
 	$(AM_V_GEN)$(SED) \
 		-e 's|[@]bindir[@]|$(bindir)|g' \
 		-e 's|[@]BUNDLE_TEST_PATH[@]|$(BUNDLE_TEST_PATH)|g' \


### PR DESCRIPTION
When we re-run configure, some Makefile variables may have changed as a
result and so we need to re-generate files potentially impacted.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>