### PR TITLE
Tests: Fix incorrect paths introduced by commit 1008fe2.

### DIFF
--- a/tests/data/state-mounts-no-mount-destination.json
+++ b/tests/data/state-mounts-no-mount-destination.json
@@ -3,12 +3,12 @@
   "id" : "foo",
   "pid" : 9127,
   "bundlePath" : "/tmp/bundle/",
-  "commsPath" : "/run/cc-oci-runtimefoo/hypervisor.sock",
-  "processPath": "/run/cc-oci-runtimefoo/process.sock",
+  "commsPath" : "/run/cc-oci-runtime/foo/hypervisor.sock",
+  "processPath": "/run/cc-oci-runtime/foo/process.sock",
   "status" : "running",
   "created" : "2016-05-18T17:02:55.250085Z",
   "console" : {
-      "path" : "/run/cc-oci-runtimetest/console.sock",
+      "path" : "/run/cc-oci-runtime/test/console.sock",
       "socket" : true
   },
   "mounts" : [

--- a/tests/data/state-mounts-no-mount-directory_created.json
+++ b/tests/data/state-mounts-no-mount-directory_created.json
@@ -3,12 +3,12 @@
   "id" : "foo",
   "pid" : 9127,
   "bundlePath" : "/tmp/bundle/",
-  "commsPath" : "/run/cc-oci-runtimefoo/hypervisor.sock",
-  "processPath": "/run/cc-oci-runtimefoo/process.sock",
+  "commsPath" : "/run/cc-oci-runtime/foo/hypervisor.sock",
+  "processPath": "/run/cc-oci-runtime/foo/process.sock",
   "status" : "running",
   "created" : "2016-05-18T17:02:55.250085Z",
   "console" : {
-      "path" : "/run/cc-oci-runtimetest/console.sock",
+      "path" : "/run/cc-oci-runtime/test/console.sock",
       "socket" : true
   },
   "mounts" : [

--- a/tests/data/state-no-annotations.json
+++ b/tests/data/state-no-annotations.json
@@ -3,12 +3,12 @@
   "id" : "foo",
   "pid" : 9127,
   "bundlePath" : "/tmp/bundle/",
-  "commsPath" : "/run/cc-oci-runtimefoo/hypervisor.sock",
-  "processPath": "/run/cc-oci-runtimefoo/process.sock",
+  "commsPath" : "/run/cc-oci-runtime/foo/hypervisor.sock",
+  "processPath": "/run/cc-oci-runtime/foo/process.sock",
   "status" : "running",
   "created" : "2016-05-18T17:02:55.250085Z",
   "console" : {
-      "path" : "/run/cc-oci-runtimetest/console.sock",
+      "path" : "/run/cc-oci-runtime/test/console.sock",
       "socket" : true
   },
 

--- a/tests/data/state-no-bundlePath.json
+++ b/tests/data/state-no-bundlePath.json
@@ -2,5 +2,5 @@
   "ociVersion" : "0.4.0",
   "id" : "foo",
   "pid" : 9127,
-  "commsPath" : "/run/cc-oci-runtimefoo/hypervisor.sock"
+  "commsPath" : "/run/cc-oci-runtime/foo/hypervisor.sock"
 }

--- a/tests/data/state-no-console-path.json
+++ b/tests/data/state-no-console-path.json
@@ -3,7 +3,7 @@
   "id" : "foo",
   "pid" : 9127,
   "bundlePath" : "/tmp/bundle/",
-  "commsPath" : "/run/cc-oci-runtimefoo/hypervisor.sock",
+  "commsPath" : "/run/cc-oci-runtime/foo/hypervisor.sock",
   "status" : "running",
   "created" : "2016-05-18T17:02:55.250085Z",
   "console" : {

--- a/tests/data/state-no-console-socket.json
+++ b/tests/data/state-no-console-socket.json
@@ -3,10 +3,10 @@
   "id" : "foo",
   "pid" : 9127,
   "bundlePath" : "/tmp/bundle/",
-  "commsPath" : "/run/cc-oci-runtimefoo/hypervisor.sock",
+  "commsPath" : "/run/cc-oci-runtime/foo/hypervisor.sock",
   "status" : "running",
   "created" : "2016-05-18T17:02:55.250085Z",
   "console" : {
-      "path" : "/run/cc-oci-runtimetest/console.sock"
+      "path" : "/run/cc-oci-runtime/test/console.sock"
   }
 }

--- a/tests/data/state-no-console.json
+++ b/tests/data/state-no-console.json
@@ -3,7 +3,7 @@
   "id" : "foo",
   "pid" : 9127,
   "bundlePath" : "/tmp/bundle/",
-  "commsPath" : "/run/cc-oci-runtimefoo/hypervisor.sock",
+  "commsPath" : "/run/cc-oci-runtime/foo/hypervisor.sock",
   "status" : "running",
   "created" : "2016-05-18T17:02:55.250085Z"
 }

--- a/tests/data/state-no-id.json
+++ b/tests/data/state-no-id.json
@@ -2,5 +2,5 @@
   "ociVersion" : "0.4.0",
   "pid" : 9127,
   "bundlePath" : "/tmp/bundle/",
-  "commsPath" : "/run/cc-oci-runtimefoo/hypervisor.sock"
+  "commsPath" : "/run/cc-oci-runtime/foo/hypervisor.sock"
 }

--- a/tests/data/state-no-mounts.json
+++ b/tests/data/state-no-mounts.json
@@ -3,12 +3,12 @@
   "id" : "foo",
   "pid" : 9127,
   "bundlePath" : "/tmp/bundle/",
-  "commsPath" : "/run/cc-oci-runtimefoo/hypervisor.sock",
-  "processPath": "/run/cc-oci-runtimefoo/process.sock",
+  "commsPath" : "/run/cc-oci-runtime/foo/hypervisor.sock",
+  "processPath": "/run/cc-oci-runtime/foo/process.sock",
   "status" : "running",
   "created" : "2016-05-18T17:02:55.250085Z",
   "console" : {
-      "path" : "/run/cc-oci-runtimetest/console.sock",
+      "path" : "/run/cc-oci-runtime/test/console.sock",
       "socket" : true
   },
   "annotations" : {

--- a/tests/data/state-no-ociVersion.json
+++ b/tests/data/state-no-ociVersion.json
@@ -2,5 +2,5 @@
   "id" : "foo",
   "pid" : 9127,
   "bundlePath" : "/tmp/bundle/",
-  "commsPath" : "/run/cc-oci-runtimefoo/hypervisor.sock"
+  "commsPath" : "/run/cc-oci-runtime/foo/hypervisor.sock"
 }

--- a/tests/data/state-no-processPath.json
+++ b/tests/data/state-no-processPath.json
@@ -3,11 +3,11 @@
   "id" : "foo",
   "pid" : 9127,
   "bundlePath" : "/tmp/bundle/",
-  "commsPath" : "/run/cc-oci-runtimefoo/hypervisor.sock",
+  "commsPath" : "/run/cc-oci-runtime/foo/hypervisor.sock",
   "status" : "running",
   "created" : "2016-05-18T17:02:55.250085Z",
   "console" : {
-      "path" : "/run/cc-oci-runtimetest/console.sock",
+      "path" : "/run/cc-oci-runtime/test/console.sock",
       "socket" : true
   },
   "annotations" : {

--- a/tests/data/state-no-vm-object.json
+++ b/tests/data/state-no-vm-object.json
@@ -3,11 +3,11 @@
   "id" : "foo",
   "pid" : 9127,
   "bundlePath" : "/tmp/bundle/",
-  "commsPath" : "/run/cc-oci-runtimefoo/hypervisor.sock",
+  "commsPath" : "/run/cc-oci-runtime/foo/hypervisor.sock",
   "status" : "running",
   "created" : "2016-05-18T17:02:55.250085Z",
   "console" : {
-      "path" : "/run/cc-oci-runtimetest/console.sock",
+      "path" : "/run/cc-oci-runtime/test/console.sock",
       "socket" : true
   }
 }

--- a/tests/data/state.json
+++ b/tests/data/state.json
@@ -3,12 +3,12 @@
   "id" : "foo",
   "pid" : 9127,
   "bundlePath" : "/tmp/bundle/",
-  "commsPath" : "/run/cc-oci-runtimefoo/hypervisor.sock",
-  "processPath": "/run/cc-oci-runtimefoo/process.sock",
+  "commsPath" : "/run/cc-oci-runtime/foo/hypervisor.sock",
+  "processPath": "/run/cc-oci-runtime/foo/process.sock",
   "status" : "running",
   "created" : "2016-05-18T17:02:55.250085Z",
   "console" : {
-      "path" : "/run/cc-oci-runtimetest/console.sock",
+      "path" : "/run/cc-oci-runtime/test/console.sock",
       "socket" : true
   },
   "annotations" : {


### PR DESCRIPTION
Commit 1008fe2 included an erroneous search-and-replace that missed off
a slash, resulting in incorrect paths in the JSON files used by the
tests.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>