### PR TITLE
Config: Expand path for automatic bundle-generation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -214,9 +214,12 @@ AC_ARG_WITH([auto-bundle-creation-path],
     ],
     [
         # default value
-        auto_bundle_creation_path="$srcdir/tests/functional/bundle"
+        auto_bundle_creation_path="tests/functional/bundle"
     ]
 )
+
+AS_IF([echo "$auto_bundle_creation_path"|grep -qv ^/],
+      [auto_bundle_creation_path="$(pwd)/$auto_bundle_creation_path"])
 
 # Determine if automatic bundle creation should be enabled.
 AS_IF([test x"$auto_bundle_creation" = x"yes" dnl


### PR DESCRIPTION
The automatic bundle generation feature (commit 7dd2c5a) contained a
bug where the default automatic bundle path was relative rather than
absolute.

Now, both the default and the path specified by
"--with-auto-bundle-creation-path=" is made absolute.

Note that symbolic links are not expanded, for symmetry with
other paths passed to configure (such as "--with-cc-image=" and
"--with-cc-kernel=" where symlink expansion is expressely undesirable).

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>