### PR TITLE
tests: remove unnecessary line from volume.bats that was making the tests to fail

### DIFF
--- a/tests/integration/docker/volume.bats
+++ b/tests/integration/docker/volume.bats
@@ -23,7 +23,6 @@
 
 setup() {
 	load common
-	load volume
 	cleanDockerPs
 	runtimeDocker
 	volName='volume1'


### PR DESCRIPTION
tests: remove unnecessary line from volume.bats that was making the tests to fail

when running volume.bats tests, the tests look for a volume.bash
file, which does not exists and is not necessary for the test.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>