### PR TITLE
Tests: Fix bats test running as root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ cscope.files
 cscope.in.out
 cscope.po.out
 data/cc-oci-runtime.sh
+data/run-bats.sh
 data/config.json
 data/hypervisor.args
 data/vm.json

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,6 +55,7 @@ src/commands/cc_oci_runtime-version.$(OBJEXT): \
 
 GENERATED_FILES = \
 	data/cc-oci-runtime.sh \
+	data/run-bats.sh \
 	tests/functional/common.bash \
 	tests/functional/data/config-minimal-cc-oci.json
 
@@ -68,6 +69,7 @@ $(GENERATED_FILES): %: %.in Makefile
 		-e 's|[@]DEFAULTSDIR[@]|$(DEFAULTSDIR)|g' \
 		-e 's|[@]PACKAGE_NAME[@]|$(PACKAGE_NAME)|g' \
 		-e 's|[@]QEMU_PATH[@]|$(QEMU_PATH)|g' \
+		-e 's|[@]BATS_PATH[@]|$(BATS_PATH)|g' \
 		-e 's|[@]ROOTFS_PATH[@]|$(BUNDLE_TEST_PATH)/rootfs|g' \
 		-e 's|[@]SYSCONFDIR[@]|$(SYSCONFDIR)|g' \
 		"$<" > "$@"
@@ -196,6 +198,7 @@ cc_oci_runtime_CFLAGS = \
 
 bats_test_sources = \
 	tests/functional/common.bash.in \
+	data/run-bats.sh.in \
 	tests/functional/data/config-minimal-cc-oci.json.in \
 	tests/functional/help.bats \
 	tests/functional/kill.bats \
@@ -237,7 +240,7 @@ FUNCTIONAL_TESTS_DEPS += cc-oci-runtime $(GENERATED_FILES)
 functional-tests: $(FUNCTIONAL_TESTS_DEPS)
 		$(AM_V_GEN)test -n "$(BUNDLE_TEST_PATH)" && \
 			echo "Using bundle '$(BUNDLE_TEST_PATH)'" || true
-		@$(BATS_PATH) $(srcdir)/tests/functional/
+		@bash $(srcdir)/data/run-bats.sh $(srcdir)/tests/functional/
 endif
 
 if DOCKER_TESTS

--- a/data/run-bats.sh.in
+++ b/data/run-bats.sh.in
@@ -1,0 +1,29 @@
+#!/bin/bash
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+# This script can be used to run bats functional test without lose network
+# configuration.
+#
+# See https://github.com/01org/cc-oci-runtime/issues/93
+cmd="@BATS_PATH@"
+#Networking is not configured using non-root user
+#run bats functional tesst with network namespace unshared
+[ $(id -u) -eq 0 ] && cmd="unshare -n $cmd"
+eval "$cmd" $@

--- a/tests/functional/README.rst
+++ b/tests/functional/README.rst
@@ -69,9 +69,11 @@ Only run functional tests::
 
     $ make functional-test
 
-Run a specific tests::
+To Run a specific tests is needed to use run-bats.sh script 
+to run with network namespace unshared (done by docker); 
+otherwise cc-oci-runtime will set container network using host interaces::
 
-    $ bats tests/functional/test-name.bats
+    $ bash ./data/run-bats.sh tests/functional/test-name.bats
 
 Links
 -----


### PR DESCRIPTION
Fixes #123 
When running cc-oci-runtime as root, it configure network using
hosts interaces; This makes the host machine lose network configuration.
To avoid this, it is required to run it with network namespace unshared.

An script (run-bats.sh) is added to run functional tests. This will unshare network
namespace when running as root.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>