### PR TITLE
start: Correct how we determine if the runtime is being run standalone

### DIFF
--- a/src/oci.c
+++ b/src/oci.c
@@ -1144,7 +1144,7 @@ cc_oci_start (struct cc_oci_config *config,
 	 *
 	 * Do not wait when console is empty.
 	 */
-	if ((config->oci.process.terminal && ! config->detached_mode) &&
+	if ((isatty (STDIN_FILENO) && ! config->detached_mode) &&
 	    !config->use_socket_console) {
 		wait = true;
 	}
@@ -1822,11 +1822,6 @@ cc_oci_config_update (struct cc_oci_config *config,
 	}
 
 	config->use_socket_console = state->use_socket_console;
-
-	if (config->console && ! config->use_socket_console && isatty (STDIN_FILENO)) {
-		g_debug ("enabling terminal for standalone mode");
-		config->oci.process.terminal = true;
-	}
 
 	if (state->vm) {
 		config->vm = state->vm;

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -620,7 +620,6 @@ START_TEST(test_cc_oci_config_update) {
 	ck_assert (! config.oci.mounts);
 	ck_assert (! config.console);
 	ck_assert (! config.use_socket_console);
-	ck_assert (! config.oci.process.terminal);
 	ck_assert (! config.vm);
 
 	/**************************/
@@ -663,13 +662,6 @@ START_TEST(test_cc_oci_config_update) {
 	ck_assert (config.oci.mounts);
 	ck_assert (config.console);
 	ck_assert (config.use_socket_console);
-
-	if (isatty (STDIN_FILENO)) {
-		if (config.console && ! config.use_socket_console) {
-			ck_assert (config.oci.process.terminal);
-		}
-
-	}
 
 	ck_assert (config.vm);
 


### PR DESCRIPTION
The correct way of determining if we are being run by conatinerd during
start phase is to check if no tty is attached to stdin. We should'nt
be checking for config.terminal value as this refers to the stdin terminal
for the create phase.
Revert earlier changes introduced with this bug. As a side note, the terminal
value will be stored in the state file in the future to account for
the code that determines the config.terminal value programmatically.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>