### PR TITLE
Config: Set sockets=1 for qemu.

### DIFF
--- a/data/hypervisor.args.in
+++ b/data/hypervisor.args.in
@@ -18,7 +18,7 @@ virtio-9p-pci,fsdev=workload9p,mount_tag=rootfs
 -fsdev
 local,id=workload9p,path=@WORKLOAD_DIR@,security_model=none
 -smp
-2,sockets=2,cores=1,threads=1
+2,sockets=1,cores=2,threads=1
 -cpu
 host
 -rtc


### PR DESCRIPTION
When qemu is launched with socket > 1 ("-smp" option), performance is
harmed, so "sockets" and "threads" must be 1. The other values can
change (and should ideally match the cpu count on the host system).

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>