### PR TITLE
CI: Fix running valgrind under Travis.

### DIFF
--- a/m4/ax_valgrind_check.m4
+++ b/m4/ax_valgrind_check.m4
@@ -205,7 +205,7 @@ VALGRIND_LOG_COMPILER = \
 	$(valgrind_lt) \
 	$(VALGRIND) $(VALGRIND_SUPPRESSIONS) --error-exitcode=1 $(VALGRIND_FLAGS)
 
-define valgrind_tool_rule =
+define valgrind_tool_rule
 check-valgrind-$(1):
 ifeq ($$(VALGRIND_ENABLED)-$$(ENABLE_VALGRIND_$(1)),yes-yes)
 	$$(valgrind_v_use)$$(MAKE) check-TESTS \


### PR DESCRIPTION
By dropping the equals sign ("define name" rather than "define name ="),
multi-line variables can be used with $(eval) under make 3.81 (as
provided by Ubuntu Trusty).

The effect of this is that the valgrind build will now run under Travis,
which uses Trusty.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>