### PR TITLE
Go linters and the resulting proxy fixes

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -29,6 +29,7 @@ source $cwd/versions.txt
 go_tarball="go${go_version}.linux-amd64.tar.gz"
 curl -L -O "https://storage.googleapis.com/golang/$go_tarball"
 tar xvf $go_tarball 1>/dev/null
+mv go $GOROOT
 # Unfortunately, go doesn't support vendoring outside of GOPATH (maybe in 1.8?)
 # So, we setup a GOPATH tree with our vendored dependencies.
 # See: https://github.com/golang/go/issues/14566

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ script:
 - export go_packages=`go list ./... | grep -v cc-oci-runtime/vendor | sed -e 's#.*/cc-oci-runtime/#./#'`
 - go list -f '{{.Dir}}/*.go' $go_packages | xargs -I % bash -c "misspell -error %"
 - go vet $go_packages
+- go list -f '{{.Dir}}' $go_packages | xargs gofmt -s -l | wc -l | xargs -I % bash -c "test % -eq 0"
 
 after_failure:
 - ./.travis-teardown.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
 # go checks
 - export go_packages=`go list ./... | grep -v cc-oci-runtime/vendor | sed -e 's#.*/cc-oci-runtime/#./#'`
 - go list -f '{{.Dir}}/*.go' $go_packages | xargs -I % bash -c "misspell -error %"
+- go vet $go_packages
 
 after_failure:
 - ./.travis-teardown.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
     - LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
     - PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
     - ACLOCAL_FLAGS="-I /usr/local/share/aclocal $ACLOCAL_FLAG"
-    - GOROOT=$PWD/go
-    - GOPATH=$PWD/gopath
+    - GOROOT=$HOME/go
+    - GOPATH=$HOME/gopath
     - PATH=$GOROOT/bin:$GOPATH/bin:/usr/local/bin:$PATH
     # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
     #   via the "travis encrypt" command using the project repo's public key

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
 before_script:
 - ./.travis-setup.sh
 - go get github.com/client9/misspell/cmd/misspell
+- go get github.com/golang/lint/golint
 
 script:
 - ./autogen.sh --enable-cppcheck --enable-valgrind --disable-valgrind-helgrind --disable-valgrind-drd --disable-silent-rules --disable-docker-tests
@@ -33,6 +34,7 @@ script:
 - go list -f '{{.Dir}}/*.go' $go_packages | xargs -I % bash -c "misspell -error %"
 - go vet $go_packages
 - go list -f '{{.Dir}}' $go_packages | xargs gofmt -s -l | wc -l | xargs -I % bash -c "test % -eq 0"
+- for p in $go_packages; do golint -set_exit_status $p; done
 
 after_failure:
 - ./.travis-teardown.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,14 @@ env:
 
 before_script:
 - ./.travis-setup.sh
+- go get github.com/client9/misspell/cmd/misspell
 
 script:
 - ./autogen.sh --enable-cppcheck --enable-valgrind --disable-valgrind-helgrind --disable-valgrind-drd --disable-silent-rules --disable-docker-tests
 - make -j5 CFLAGS=-Werror check
+# go checks
+- export go_packages=`go list ./... | grep -v cc-oci-runtime/vendor | sed -e 's#.*/cc-oci-runtime/#./#'`
+- go list -f '{{.Dir}}/*.go' $go_packages | xargs -I % bash -c "misspell -error %"
 
 after_failure:
 - ./.travis-teardown.sh

--- a/proxy/api/api.go
+++ b/proxy/api/api.go
@@ -33,7 +33,7 @@ import (
 //    }
 //  }
 type Hello struct {
-	ContainerId string `json:"containerId"`
+	ContainerID string `json:"containerId"`
 	CtlSerial   string `json:"ctlSerial"`
 	IoSerial    string `json:"ioSerial"`
 }
@@ -49,7 +49,7 @@ type Hello struct {
 //    }
 //  }
 type Attach struct {
-	ContainerId string `json:"containerId"`
+	ContainerID string `json:"containerId"`
 }
 
 // The bye payload does the opposite of what hello does, indicating to the

--- a/proxy/api/api.go
+++ b/proxy/api/api.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 )
 
-// The hello payload is issued first after connecting to the proxy socket.
+// The Hello payload is issued first after connecting to the proxy socket.
 // It is used to let the proxy know about a new container on the system along
 // with the paths go hyperstart's command and I/O channels (AF_UNIX sockets).
 //
@@ -38,7 +38,7 @@ type Hello struct {
 	IoSerial    string `json:"ioSerial"`
 }
 
-// The attach payload can be used to associate clients to an already known VM.
+// The Attach payload can be used to associate clients to an already known VM.
 // attach cannot be issued if a hello for this container hasn't been issued
 // beforehand.
 //
@@ -52,7 +52,7 @@ type Attach struct {
 	ContainerID string `json:"containerId"`
 }
 
-// The bye payload does the opposite of what hello does, indicating to the
+// The Bye payload does the opposite of what hello does, indicating to the
 // proxy it should release resources created by hello. This command has no
 // parameter.
 //
@@ -62,7 +62,7 @@ type Attach struct {
 type Bye struct {
 }
 
-// The allocateIO payload asks the proxy to allocate IO stream sequence numbers
+// The AllocateIo payload asks the proxy to allocate IO stream sequence numbers
 // for use with the execcmd hyperstart command.
 //
 // A stream sequence number is a globally unique number identifying a data
@@ -88,7 +88,7 @@ type AllocateIo struct {
 	NStreams int `json:"nStreams"`
 }
 
-// allocateIOResult is the result from a successful allocateIO.
+// AllocateIoResult is the result from a successful allocateIO.
 //
 // The sequence numbers allocated are:
 //   ioBase, ioBase + 1, ..., ioBase + nStreams - 1
@@ -113,7 +113,7 @@ type AllocateIoResult struct {
 	IoBase uint64 `json:"ioBase"`
 }
 
-// The hyper payload will forward an hyperstart command to hyperstart.
+// The Hyper payload will forward an hyperstart command to hyperstart.
 //
 //  {
 //    "id": "hyper",

--- a/proxy/api/client.go
+++ b/proxy/api/client.go
@@ -21,18 +21,22 @@ import (
 	"os"
 )
 
+// The Client struct can be used to issue proxy API calls with a convenient
+// high level API.
 type Client struct {
 	conn *net.UnixConn
 }
 
-// Creates a new client object to communicate with the proxy using the
-// connection conn
+// NewClient creates a new client object to communicate with the proxy using
+// the connection conn. The user should call Close() once finished with the
+// client object to close conn.
 func NewClient(conn *net.UnixConn) *Client {
 	return &Client{
 		conn: conn,
 	}
 }
 
+// Close a client, closing the underlying AF_UNIX socket.
 func (client *Client) Close() {
 	client.conn.Close()
 }
@@ -74,6 +78,7 @@ func errorFromResponse(resp *Response) error {
 	return nil
 }
 
+// Hello wraps the Hello payload (see payload description for more details)
 func (client *Client) Hello(containerID, ctlSerial, ioSerial string) error {
 	hello := Hello{
 		ContainerID: containerID,
@@ -89,6 +94,7 @@ func (client *Client) Hello(containerID, ctlSerial, ioSerial string) error {
 	return errorFromResponse(resp)
 }
 
+// Attach wraps the Attach payload (see payload description for more details)
 func (client *Client) Attach(containerID string) error {
 	hello := Attach{
 		ContainerID: containerID,
@@ -102,6 +108,7 @@ func (client *Client) Attach(containerID string) error {
 	return errorFromResponse(resp)
 }
 
+// AllocateIo wraps the AllocateIo payload (see payload description for more details)
 func (client *Client) AllocateIo(nStreams int) (ioBase uint64, ioFile *os.File, err error) {
 	allocate := AllocateIo{
 		NStreams: nStreams,
@@ -135,6 +142,7 @@ func (client *Client) AllocateIo(nStreams int) (ioBase uint64, ioFile *os.File, 
 	return
 }
 
+// Hyper wraps the Hyper payload (see payload description for more details)
 func (client *Client) Hyper(hyperName string, hyperMessage interface{}) error {
 	var data []byte
 
@@ -160,6 +168,7 @@ func (client *Client) Hyper(hyperName string, hyperMessage interface{}) error {
 	return errorFromResponse(resp)
 }
 
+// Bye wraps the Bye payload (see payload description for more details)
 func (client *Client) Bye() error {
 	resp, err := client.sendPayload("bye", nil)
 	if err != nil {

--- a/proxy/api/client.go
+++ b/proxy/api/client.go
@@ -45,7 +45,7 @@ func (client *Client) sendPayload(id string, payload interface{}) (*Response, er
 	var err error
 
 	req := Request{}
-	req.Id = id
+	req.ID = id
 	if payload != nil {
 		if req.Data, err = json.Marshal(payload); err != nil {
 			return nil, err

--- a/proxy/api/client.go
+++ b/proxy/api/client.go
@@ -74,9 +74,9 @@ func errorFromResponse(resp *Response) error {
 	return nil
 }
 
-func (client *Client) Hello(containerId, ctlSerial, ioSerial string) error {
+func (client *Client) Hello(containerID, ctlSerial, ioSerial string) error {
 	hello := Hello{
-		ContainerId: containerId,
+		ContainerID: containerID,
 		CtlSerial:   ctlSerial,
 		IoSerial:    ioSerial,
 	}
@@ -89,9 +89,9 @@ func (client *Client) Hello(containerId, ctlSerial, ioSerial string) error {
 	return errorFromResponse(resp)
 }
 
-func (client *Client) Attach(containerId string) error {
+func (client *Client) Attach(containerID string) error {
 	hello := Attach{
-		ContainerId: containerId,
+		ContainerID: containerID,
 	}
 
 	resp, err := client.sendPayload("attach", &hello)

--- a/proxy/api/common_test.go
+++ b/proxy/api/common_test.go
@@ -28,7 +28,7 @@ func socketpair() (*net.UnixConn, *net.UnixConn, error) {
 
 	// First end
 	f0 := os.NewFile(uintptr(fds[0]), "")
-	// os.NewFile() dups the fd and we're reponsible for closing it
+	// os.NewFile() dups the fd and we're responsible for closing it
 	defer f0.Close()
 	c0, err := net.FileConn(f0)
 	if err != nil {

--- a/proxy/api/fdpassing.go
+++ b/proxy/api/fdpassing.go
@@ -27,7 +27,7 @@ import (
 // not possible to send out of band data without actual data to write, we write
 // a dummy byte, 'F', to the socket when passing the fd.
 
-var fileTag []byte = []byte{'F'}
+var fileTag = []byte{'F'}
 
 func WriteFd(c *net.UnixConn, fd int) error {
 	rights := syscall.UnixRights(fd)

--- a/proxy/api/fdpassing.go
+++ b/proxy/api/fdpassing.go
@@ -29,12 +29,17 @@ import (
 
 var fileTag = []byte{'F'}
 
+// WriteFd passes the fd file descriptor through the c AF_UNIX socket using out
+// of band data. Along with the file descriptor, WriteFd will write the single
+// byte 'F' to the socket as stream sockets need some data to actually unblock
+// the read at the other end.
 func WriteFd(c *net.UnixConn, fd int) error {
 	rights := syscall.UnixRights(fd)
 	_, _, err := c.WriteMsgUnix(fileTag, rights, nil)
 	return err
 }
 
+// ReadFd reads a fd file descriptor written with WriteFd.
 func ReadFd(c *net.UnixConn) (int, error) {
 	oob := make([]byte, 32)
 	buf := make([]byte, 1)

--- a/proxy/api/fdpassing_test.go
+++ b/proxy/api/fdpassing_test.go
@@ -41,7 +41,7 @@ func TestFdPassing(t *testing.T) {
 
 	// write into the pipe and check reading from newReader gives the
 	// expected result
-	var data []byte = []byte("foo")
+	var data = []byte("foo")
 
 	n, err := writer.Write(data)
 	assert.Nil(t, err)

--- a/proxy/api/protocol.go
+++ b/proxy/api/protocol.go
@@ -37,7 +37,7 @@ type header struct {
 //
 // Each Request has a corresponding Response message sent back from the proxy.
 type Request struct {
-	Id   string          `json:"id"`
+	ID   string          `json:"id"`
 	Data json.RawMessage `json:"data,omitempty"`
 }
 

--- a/proxy/protocol.go
+++ b/proxy/protocol.go
@@ -81,18 +81,18 @@ type clientCtx struct {
 }
 
 func (proto *Protocol) handleRequest(ctx *clientCtx, req *api.Request, hr *HandlerResponse) *api.Response {
-	if req.Id == "" {
+	if req.ID == "" {
 		return &api.Response{
 			Success: false,
 			Error:   "no 'id' field in request",
 		}
 	}
 
-	handler, ok := proto.handlers[req.Id]
+	handler, ok := proto.handlers[req.ID]
 	if !ok {
 		return &api.Response{
 			Success: false,
-			Error:   fmt.Sprintf("no payload named '%s'", req.Id),
+			Error:   fmt.Sprintf("no payload named '%s'", req.ID),
 		}
 	}
 

--- a/proxy/protocol.go
+++ b/proxy/protocol.go
@@ -45,10 +45,6 @@ func (r *HandlerResponse) SetErrorf(format string, a ...interface{}) {
 	r.SetError(fmt.Errorf(format, a...))
 }
 
-func (r *HandlerResponse) SetResults(results map[string]interface{}) {
-	r.results = results
-}
-
 func (r *HandlerResponse) AddResult(key string, value interface{}) {
 	if r.results == nil {
 		r.results = make(map[string]interface{})

--- a/proxy/protocol.go
+++ b/proxy/protocol.go
@@ -24,49 +24,49 @@ import (
 )
 
 // XXX: could do with its own package to remove that ugly namespacing
-type ProtocolHandler func([]byte, interface{}, *HandlerResponse)
+type protocolHandler func([]byte, interface{}, *handlerResponse)
 
 // Encapsulates the different parts of what a handler can return.
-type HandlerResponse struct {
+type handlerResponse struct {
 	err     error
 	results map[string]interface{}
 	file    *os.File
 }
 
-func (r *HandlerResponse) SetError(err error) {
+func (r *handlerResponse) SetError(err error) {
 	r.err = err
 }
 
-func (r *HandlerResponse) SetErrorMsg(msg string) {
+func (r *handlerResponse) SetErrorMsg(msg string) {
 	r.err = errors.New(msg)
 }
 
-func (r *HandlerResponse) SetErrorf(format string, a ...interface{}) {
+func (r *handlerResponse) SetErrorf(format string, a ...interface{}) {
 	r.SetError(fmt.Errorf(format, a...))
 }
 
-func (r *HandlerResponse) AddResult(key string, value interface{}) {
+func (r *handlerResponse) AddResult(key string, value interface{}) {
 	if r.results == nil {
 		r.results = make(map[string]interface{})
 	}
 	r.results[key] = value
 }
 
-func (r *HandlerResponse) SetFile(f *os.File) {
+func (r *handlerResponse) SetFile(f *os.File) {
 	r.file = f
 }
 
-type Protocol struct {
-	handlers map[string]ProtocolHandler
+type protocol struct {
+	handlers map[string]protocolHandler
 }
 
-func NewProtocol() *Protocol {
-	return &Protocol{
-		handlers: make(map[string]ProtocolHandler),
+func newProtocol() *protocol {
+	return &protocol{
+		handlers: make(map[string]protocolHandler),
 	}
 }
 
-func (proto *Protocol) Handle(cmd string, handler ProtocolHandler) {
+func (proto *protocol) Handle(cmd string, handler protocolHandler) {
 	proto.handlers[cmd] = handler
 }
 
@@ -76,7 +76,7 @@ type clientCtx struct {
 	userData interface{}
 }
 
-func (proto *Protocol) handleRequest(ctx *clientCtx, req *api.Request, hr *HandlerResponse) *api.Response {
+func (proto *protocol) handleRequest(ctx *clientCtx, req *api.Request, hr *handlerResponse) *api.Response {
 	if req.ID == "" {
 		return &api.Response{
 			Success: false,
@@ -107,7 +107,7 @@ func (proto *Protocol) handleRequest(ctx *clientCtx, req *api.Request, hr *Handl
 	}
 }
 
-func (proto *Protocol) Serve(conn net.Conn, userData interface{}) {
+func (proto *protocol) Serve(conn net.Conn, userData interface{}) {
 	ctx := &clientCtx{
 		conn:     conn,
 		userData: userData,
@@ -116,7 +116,7 @@ func (proto *Protocol) Serve(conn net.Conn, userData interface{}) {
 	for {
 		// Parse a request.
 		req := api.Request{}
-		hr := HandlerResponse{}
+		hr := handlerResponse{}
 
 		err := api.ReadMessage(conn, &req)
 		if err != nil {

--- a/proxy/protocol.go
+++ b/proxy/protocol.go
@@ -99,11 +99,11 @@ func (proto *protocol) handleRequest(ctx *clientCtx, req *api.Request, hr *handl
 			Error:   hr.err.Error(),
 			Data:    hr.results,
 		}
-	} else {
-		return &api.Response{
-			Success: true,
-			Data:    hr.results,
-		}
+	}
+
+	return &api.Response{
+		Success: true,
+		Data:    hr.results,
 	}
 }
 

--- a/proxy/protocol_test.go
+++ b/proxy/protocol_test.go
@@ -35,7 +35,7 @@ type mockServer struct {
 	serverConn, clientConn net.Conn
 }
 
-func NewMockServer(t *testing.T, proto *protocol) *mockServer {
+func newMockServer(t *testing.T, proto *protocol) *mockServer {
 	var err error
 
 	server := &mockServer{
@@ -62,7 +62,7 @@ func (server *mockServer) ServeWithUserData(userData interface{}) {
 }
 
 func setupMockServer(t *testing.T, proto *protocol) (client net.Conn, server *mockServer) {
-	server = NewMockServer(t, proto)
+	server = newMockServer(t, proto)
 	client = server.GetClientConn()
 	go server.Serve()
 
@@ -138,7 +138,7 @@ func TestUserData(t *testing.T) {
 	proto := newProtocol()
 	proto.Handle("foo", userDataHandler)
 
-	server := NewMockServer(t, proto)
+	server := newMockServer(t, proto)
 	client := server.GetClientConn()
 	testUserData.t = t
 	go server.ServeWithUserData(&testUserData)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Main struct holding the proxy state
-type Proxy struct {
+type proxy struct {
 	// Protect concurrent accesses from separate client goroutines to this
 	// structure fields
 	sync.Mutex
@@ -40,7 +40,7 @@ type Proxy struct {
 // Represents a client, either a cc-oci-runtime or cc-shim process having
 // opened a socket to the proxy
 type client struct {
-	proxy *Proxy
+	proxy *proxy
 	vm    *vm
 
 	conn net.Conn
@@ -190,8 +190,8 @@ func hyperHandler(data []byte, userData interface{}, response *handlerResponse) 
 	response.SetError(err)
 }
 
-func NewProxy() *Proxy {
-	return &Proxy{
+func newProxy() *proxy {
+	return &proxy{
 		vms: make(map[string]*vm),
 	}
 }
@@ -200,7 +200,7 @@ func NewProxy() *Proxy {
 //   ${locatestatedir}/run/cc-oci-runtime/proxy
 var socketPath string
 
-func (proxy *Proxy) Init() error {
+func (proxy *proxy) init() error {
 	var l net.Listener
 	var err error
 
@@ -232,7 +232,7 @@ func (proxy *Proxy) Init() error {
 	return nil
 }
 
-func (proxy *Proxy) serveNewClient(proto *protocol, newConn net.Conn) {
+func (proxy *proxy) serveNewClient(proto *protocol, newConn net.Conn) {
 	newClient := &client{
 		proxy: proxy,
 		conn:  newConn,
@@ -241,7 +241,7 @@ func (proxy *Proxy) serveNewClient(proto *protocol, newConn net.Conn) {
 	proto.Serve(newConn, newClient)
 }
 
-func (proxy *Proxy) Serve() {
+func (proxy *proxy) serve() {
 
 	// Define the client (runtime/shim) <-> proxy protocol
 	proto := newProtocol()
@@ -263,12 +263,12 @@ func (proxy *Proxy) Serve() {
 }
 
 func proxyMain() {
-	proxy := NewProxy()
-	if err := proxy.Init(); err != nil {
+	proxy := newProxy()
+	if err := proxy.init(); err != nil {
 		fmt.Fprintln(os.Stderr, "init:", err.Error())
 		os.Exit(1)
 	}
-	proxy.Serve()
+	proxy.serve()
 }
 
 func main() {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -218,7 +218,7 @@ func (proxy *Proxy) Init() error {
 		if err = os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("couldn't remove exiting socket: %v\n", err)
 		}
-		l, err = net.ListenUnix("unix", &net.UnixAddr{socketPath, "unix"})
+		l, err = net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
 		if err != nil {
 			return fmt.Errorf("couldn't create AF_UNIX socket: %v", err)
 		}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -69,7 +69,7 @@ func helloHandler(data []byte, userData interface{}, response *handlerResponse) 
 			hello.ContainerID)
 		return
 	}
-	vm := NewVM(hello.ContainerID, hello.CtlSerial, hello.IoSerial)
+	vm := newVM(hello.ContainerID, hello.CtlSerial, hello.IoSerial)
 	proxy.vms[hello.ContainerID] = vm
 	proxy.Unlock()
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -56,26 +56,26 @@ func helloHandler(data []byte, userData interface{}, response *HandlerResponse) 
 		return
 	}
 
-	if hello.ContainerId == "" || hello.CtlSerial == "" || hello.IoSerial == "" {
+	if hello.ContainerID == "" || hello.CtlSerial == "" || hello.IoSerial == "" {
 		response.SetErrorMsg("malformed hello command")
 	}
 
 	proxy := client.proxy
 	proxy.Lock()
-	if _, ok := proxy.vms[hello.ContainerId]; ok {
+	if _, ok := proxy.vms[hello.ContainerID]; ok {
 
 		proxy.Unlock()
 		response.SetErrorf("%s: container already registered",
-			hello.ContainerId)
+			hello.ContainerID)
 		return
 	}
-	vm := NewVM(hello.ContainerId, hello.CtlSerial, hello.IoSerial)
-	proxy.vms[hello.ContainerId] = vm
+	vm := NewVM(hello.ContainerID, hello.CtlSerial, hello.IoSerial)
+	proxy.vms[hello.ContainerID] = vm
 	proxy.Unlock()
 
 	if err := vm.Connect(); err != nil {
 		proxy.Lock()
-		delete(proxy.vms, hello.ContainerId)
+		delete(proxy.vms, hello.ContainerID)
 		proxy.Unlock()
 		response.SetError(err)
 		return
@@ -96,11 +96,11 @@ func attachHandler(data []byte, userData interface{}, response *HandlerResponse)
 	}
 
 	proxy.Lock()
-	vm := proxy.vms[attach.ContainerId]
+	vm := proxy.vms[attach.ContainerID]
 	proxy.Unlock()
 
 	if vm == nil {
-		response.SetErrorf("unknown containerId: %s", attach.ContainerId)
+		response.SetErrorf("unknown containerID: %s", attach.ContainerID)
 		return
 	}
 
@@ -119,7 +119,7 @@ func byeHandler(data []byte, userData interface{}, response *HandlerResponse) {
 	}
 
 	proxy.Lock()
-	delete(proxy.vms, vm.containerId)
+	delete(proxy.vms, vm.containerID)
 	proxy.Unlock()
 
 	client.vm = nil

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -47,7 +47,7 @@ type client struct {
 }
 
 // "hello"
-func helloHandler(data []byte, userData interface{}, response *HandlerResponse) {
+func helloHandler(data []byte, userData interface{}, response *handlerResponse) {
 	client := userData.(*client)
 	hello := api.Hello{}
 
@@ -85,7 +85,7 @@ func helloHandler(data []byte, userData interface{}, response *HandlerResponse) 
 }
 
 // "attach"
-func attachHandler(data []byte, userData interface{}, response *HandlerResponse) {
+func attachHandler(data []byte, userData interface{}, response *handlerResponse) {
 	client := userData.(*client)
 	proxy := client.proxy
 
@@ -108,7 +108,7 @@ func attachHandler(data []byte, userData interface{}, response *HandlerResponse)
 }
 
 // "bye"
-func byeHandler(data []byte, userData interface{}, response *HandlerResponse) {
+func byeHandler(data []byte, userData interface{}, response *handlerResponse) {
 	client := userData.(*client)
 	proxy := client.proxy
 	vm := client.vm
@@ -127,7 +127,7 @@ func byeHandler(data []byte, userData interface{}, response *HandlerResponse) {
 }
 
 // "allocateIO"
-func allocateIoHandler(data []byte, userData interface{}, response *HandlerResponse) {
+func allocateIoHandler(data []byte, userData interface{}, response *handlerResponse) {
 	client := userData.(*client)
 	vm := client.vm
 
@@ -171,7 +171,7 @@ func allocateIoHandler(data []byte, userData interface{}, response *HandlerRespo
 }
 
 // "hyper"
-func hyperHandler(data []byte, userData interface{}, response *HandlerResponse) {
+func hyperHandler(data []byte, userData interface{}, response *handlerResponse) {
 	client := userData.(*client)
 	hyper := api.Hyper{}
 	vm := client.vm
@@ -232,7 +232,7 @@ func (proxy *Proxy) Init() error {
 	return nil
 }
 
-func (proxy *Proxy) serveNewClient(proto *Protocol, newConn net.Conn) {
+func (proxy *Proxy) serveNewClient(proto *protocol, newConn net.Conn) {
 	newClient := &client{
 		proxy: proxy,
 		conn:  newConn,
@@ -244,7 +244,7 @@ func (proxy *Proxy) serveNewClient(proto *Protocol, newConn net.Conn) {
 func (proxy *Proxy) Serve() {
 
 	// Define the client (runtime/shim) <-> proxy protocol
-	proto := NewProtocol()
+	proto := newProtocol()
 	proto.Handle("hello", helloHandler)
 	proto.Handle("attach", attachHandler)
 	proto.Handle("bye", byeHandler)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -169,7 +169,7 @@ func (rig *testRig) Stop() {
 	rig.wg.Wait()
 }
 
-const testContainerId = "0987654321"
+const testContainerID = "0987654321"
 
 func TestHello(t *testing.T) {
 	proto := NewProtocol()
@@ -180,21 +180,21 @@ func TestHello(t *testing.T) {
 
 	// Register new VM
 	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
-	err := rig.Client.Hello(testContainerId, ctlSocketPath, ioSocketPath)
+	err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath)
 	assert.Nil(t, err)
 
-	// A new Hello message with the same containerId should error out
-	err = rig.Client.Hello(testContainerId, "fooCtl", "fooIo")
+	// A new Hello message with the same containerID should error out
+	err = rig.Client.Hello(testContainerID, "fooCtl", "fooIo")
 	assert.NotNil(t, err)
 
 	// Hello should register a new vm object
 	proxy := rig.Proxy
 	proxy.Lock()
-	vm := proxy.vms[testContainerId]
+	vm := proxy.vms[testContainerID]
 	proxy.Unlock()
 
 	assert.NotNil(t, vm)
-	assert.Equal(t, testContainerId, vm.containerId)
+	assert.Equal(t, testContainerID, vm.containerID)
 
 	// This test shouldn't send anything to hyperstart
 	msgs := rig.Hyperstart.GetLastMessages()
@@ -213,7 +213,7 @@ func TestBye(t *testing.T) {
 
 	// Register new VM
 	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
-	err := rig.Client.Hello(testContainerId, ctlSocketPath, ioSocketPath)
+	err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath)
 	assert.Nil(t, err)
 
 	// Bye!
@@ -227,7 +227,7 @@ func TestBye(t *testing.T) {
 	// Bye should unregister the vm object
 	proxy := rig.Proxy
 	proxy.Lock()
-	vm := proxy.vms[testContainerId]
+	vm := proxy.vms[testContainerID]
 	proxy.Unlock()
 	assert.Nil(t, vm)
 
@@ -249,7 +249,7 @@ func TestAttach(t *testing.T) {
 
 	// Register new VM
 	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
-	err := rig.Client.Hello(testContainerId, ctlSocketPath, ioSocketPath)
+	err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath)
 	assert.Nil(t, err)
 
 	// Attaching to an unknown VM should return an error
@@ -258,7 +258,7 @@ func TestAttach(t *testing.T) {
 
 	// Attaching to an existing VM should work. To test we are effectively
 	// attached, we issue a bye that would error out if not attatched.
-	err = rig.Client.Attach(testContainerId)
+	err = rig.Client.Attach(testContainerID)
 	assert.Nil(t, err)
 	err = rig.Client.Bye()
 	assert.Nil(t, err)
@@ -279,7 +279,7 @@ func TestHyperPing(t *testing.T) {
 	rig.Start()
 
 	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
-	err := rig.Client.Hello(testContainerId, ctlSocketPath, ioSocketPath)
+	err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath)
 	assert.Nil(t, err)
 
 	// Send ping and verify we have indeed received the message on the
@@ -308,7 +308,7 @@ func TestHyperStartpod(t *testing.T) {
 
 	// Register new VM
 	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
-	err := rig.Client.Hello(testContainerId, ctlSocketPath, ioSocketPath)
+	err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath)
 	assert.Nil(t, err)
 
 	// Send startopd and verify we have indeed received the message on the
@@ -394,7 +394,7 @@ func TestAllocateIo(t *testing.T) {
 
 	// Register new VM
 	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
-	err := rig.Client.Hello(testContainerId, ctlSocketPath, ioSocketPath)
+	err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath)
 	assert.Nil(t, err)
 
 	// Allocate 2 seq numbers and verify we can use the fd passed from

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -47,7 +47,7 @@ type testRig struct {
 	proxyFork bool
 
 	// proxy, in process
-	Proxy     *Proxy
+	proxy     *proxy
 	protocol  *protocol
 	proxyConn net.Conn // socket used by proxy to communicate with Client
 
@@ -113,10 +113,10 @@ func (rig *testRig) Start() {
 		clientConn, rig.proxyConn, err = Socketpair()
 		assert.Nil(rig.t, err)
 		// Start proxy main go routine
-		rig.Proxy = NewProxy()
+		rig.proxy = newProxy()
 		rig.wg.Add(1)
 		go func() {
-			rig.Proxy.serveNewClient(rig.protocol, rig.proxyConn)
+			rig.proxy.serveNewClient(rig.protocol, rig.proxyConn)
 			rig.wg.Done()
 		}()
 	}
@@ -188,7 +188,7 @@ func TestHello(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// Hello should register a new vm object
-	proxy := rig.Proxy
+	proxy := rig.proxy
 	proxy.Lock()
 	vm := proxy.vms[testContainerID]
 	proxy.Unlock()
@@ -225,7 +225,7 @@ func TestBye(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// Bye should unregister the vm object
-	proxy := rig.Proxy
+	proxy := rig.proxy
 	proxy.Lock()
 	vm := proxy.vms[testContainerID]
 	proxy.Unlock()

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -48,7 +48,7 @@ type testRig struct {
 
 	// proxy, in process
 	Proxy     *Proxy
-	protocol  *Protocol
+	protocol  *protocol
 	proxyConn net.Conn // socket used by proxy to communicate with Client
 
 	// proxy, forked
@@ -59,7 +59,7 @@ type testRig struct {
 	Client *api.Client
 }
 
-func newTestRig(t *testing.T, proto *Protocol) *testRig {
+func newTestRig(t *testing.T, proto *protocol) *testRig {
 	return &testRig{
 		t:        t,
 		protocol: proto,
@@ -172,7 +172,7 @@ func (rig *testRig) Stop() {
 const testContainerID = "0987654321"
 
 func TestHello(t *testing.T) {
-	proto := NewProtocol()
+	proto := newProtocol()
 	proto.Handle("hello", helloHandler)
 
 	rig := newTestRig(t, proto)
@@ -204,7 +204,7 @@ func TestHello(t *testing.T) {
 }
 
 func TestBye(t *testing.T) {
-	proto := NewProtocol()
+	proto := newProtocol()
 	proto.Handle("hello", helloHandler)
 	proto.Handle("bye", byeHandler)
 
@@ -239,7 +239,7 @@ func TestBye(t *testing.T) {
 }
 
 func TestAttach(t *testing.T) {
-	proto := NewProtocol()
+	proto := newProtocol()
 	proto.Handle("hello", helloHandler)
 	proto.Handle("attach", attachHandler)
 	proto.Handle("bye", byeHandler)
@@ -271,7 +271,7 @@ func TestAttach(t *testing.T) {
 }
 
 func TestHyperPing(t *testing.T) {
-	proto := NewProtocol()
+	proto := newProtocol()
 	proto.Handle("hello", helloHandler)
 	proto.Handle("hyper", hyperHandler)
 
@@ -299,7 +299,7 @@ func TestHyperPing(t *testing.T) {
 }
 
 func TestHyperStartpod(t *testing.T) {
-	proto := NewProtocol()
+	proto := newProtocol()
 	proto.Handle("hello", helloHandler)
 	proto.Handle("hyper", hyperHandler)
 
@@ -384,7 +384,7 @@ func readIo(t *testing.T, reader io.Reader) (seq uint64, data []byte) {
 }
 
 func TestAllocateIo(t *testing.T) {
-	proto := NewProtocol()
+	proto := newProtocol()
 	proto.Handle("hello", helloHandler)
 	proto.Handle("allocateIO", allocateIoHandler)
 

--- a/proxy/syscall.go
+++ b/proxy/syscall.go
@@ -20,6 +20,8 @@ import (
 	"syscall"
 )
 
+// Socketpair wraps the eponymous syscall but gives go friendly objects instead
+// of the raw file descriptors.
 func Socketpair() (*net.UnixConn, *net.UnixConn, error) {
 	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
 	if err != nil {

--- a/proxy/syscall.go
+++ b/proxy/syscall.go
@@ -28,7 +28,7 @@ func Socketpair() (*net.UnixConn, *net.UnixConn, error) {
 
 	// First end
 	f0 := os.NewFile(uintptr(fds[0]), "")
-	// os.NewFile() dups the fd and we're reponsible for closing it
+	// os.NewFile() dups the fd and we're responsible for closing it
 	defer f0.Close()
 	c0, err := net.FileConn(f0)
 	if err != nil {

--- a/proxy/vm.go
+++ b/proxy/vm.go
@@ -30,7 +30,7 @@ import (
 type vm struct {
 	sync.Mutex
 
-	containerId string
+	containerID string
 
 	ctlSerial, ioSerial string
 	ctl, io             net.Conn
@@ -66,7 +66,7 @@ type ioSession struct {
 
 func NewVM(id, ctlSerial, ioSerial string) *vm {
 	return &vm{
-		containerId: id,
+		containerID: id,
 		ctlSerial:   ctlSerial,
 		ioSerial:    ioSerial,
 		nextIoBase:  1,

--- a/proxy/vm.go
+++ b/proxy/vm.go
@@ -64,7 +64,7 @@ type ioSession struct {
 	wg sync.WaitGroup
 }
 
-func NewVM(id, ctlSerial, ioSerial string) *vm {
+func newVM(id, ctlSerial, ioSerial string) *vm {
 	return &vm{
 		containerID: id,
 		ctlSerial:   ctlSerial,

--- a/tests/mock/hyperstart.go
+++ b/tests/mock/hyperstart.go
@@ -306,7 +306,7 @@ type acceptCb func(c net.Conn)
 
 func (h *Hyperstart) startListening(path string, cb acceptCb) *net.UnixListener {
 
-	addr := &net.UnixAddr{path, "unix"}
+	addr := &net.UnixAddr{Name: path, Net: "unix"}
 	l, err := net.ListenUnix("unix", addr)
 	assert.Nil(h.t, err)
 

--- a/tests/mock/hyperstart.go
+++ b/tests/mock/hyperstart.go
@@ -54,7 +54,7 @@ func newMessageList() []hyper.DecodedMessage {
 }
 
 // Creates a new hyperstart instance. Ownership of the ctl and io connections
-// is transfered to this object (it will close them on Stop())
+// is transferred to this object (it will close them on Stop())
 func NewHyperstart(t *testing.T) *Hyperstart {
 	dir := os.TempDir()
 	ctlSocketPath := filepath.Join(dir, "mock.hyper."+nextSuffix()+".0.sock")

--- a/tests/mock/misc.go
+++ b/tests/mock/misc.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 )
 
-// GetTmpPath() will return a filename suitable for a tempory file according to
+// GetTmpPath will return a filename suitable for a tempory file according to
 // the format string given in argument. The format string must contain a single
 // %s which will be replaced by a random string. Eg.:
 //


### PR DESCRIPTION
Added a few linters to the travis checks:
  - misspell
  - go vet
  - gofmt
  - golint

Of course, having never run those linters on the proxy code before, it needed a few fixes here and there for everything to be green.