### PR TITLE
Add Dockerfiles to create an environment for building and testing cc-oci-runtime 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,6 +56,8 @@ src/commands/cc_oci_runtime-version.$(OBJEXT): \
 GENERATED_FILES = \
 	data/cc-oci-runtime.sh \
 	data/run-bats.sh \
+	data/dockerFiles/Dockerfile.fedora \
+	data/dockerFiles/Dockerfile.ubuntu \
 	tests/functional/common.bash \
 	tests/functional/data/config-minimal-cc-oci.json \
 	tests/metrics/density/docker_cpu_usage.sh \
@@ -77,6 +79,10 @@ $(GENERATED_FILES): %: %.in Makefile
 		-e 's|[@]BATS_PATH[@]|$(BATS_PATH)|g' \
 		-e 's|[@]ROOTFS_PATH[@]|$(BUNDLE_TEST_PATH)/rootfs|g' \
 		-e 's|[@]SYSCONFDIR[@]|$(SYSCONFDIR)|g' \
+		-e 's|[@]DOCKER_FEDORA_VERSION[@]|$(DOCKER_FEDORA_VERSION)|g' \
+		-e 's|[@]DOCKER_ENGINE_FEDORA_VERSION[@]|$(DOCKER_ENGINE_FEDORA_VERSION)|g' \
+		-e 's|[@]DOCKER_UBUNTU_VERSION[@]|$(DOCKER_UBUNTU_VERSION)|g' \
+		-e 's|[@]DOCKER_ENGINE_UBUNTU_VERSION[@]|$(DOCKER_ENGINE_UBUNTU_VERSION)|g' \
 		"$<" > "$@"
 
 if FUNCTIONAL_TESTS
@@ -270,6 +276,9 @@ EXTRA_DIST = \
 	$(cc_proxy_sources) \
 	$(systemdservice_in_files) \
 	data/cc-oci-runtime.sh.in \
+	data/dockerFiles/Dockerfile.fedora.in \
+	data/dockerFiles/Dockerfile.ubuntu.in \
+	data/dockerFiles/Dockerfile.clearlinux \
 	$(bats_test_sources) \
 	tests/integration \
 	tests/metrics/density/docker_cpu_usage.sh.in \

--- a/configure.ac
+++ b/configure.ac
@@ -208,6 +208,12 @@ AC_SUBST([QEMU_PATH], [$ac_cv_path_QEMU])
 #Read Kernel parameters
 AC_SUBST([CMDLINE], [$(cat $srcdir/data/kernel-cmdline)])
 
+# Read Dockerfile parameters
+AC_SUBST([DOCKER_FEDORA_VERSION], [$docker_fedora_version])
+AC_SUBST([DOCKER_ENGINE_FEDORA_VERSION], [$docker_engine_fedora_version])
+AC_SUBST([DOCKER_UBUNTU_VERSION], [$docker_ubuntu_version])
+AC_SUBST([DOCKER_ENGINE_UBUNTU_VERSION], [$docker_engine_ubuntu_version])
+
 # Sytemd unit files (host)
 AC_ARG_WITH([systemdsystemunitdir],
             AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),

--- a/data/dockerFiles/Dockerfile.clearlinux
+++ b/data/dockerFiles/Dockerfile.clearlinux
@@ -1,0 +1,46 @@
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+FROM clearlinux:latest
+
+# Update to latest version and install needed bundles to
+# build cc-oci-runtime and to run Clear Containers
+RUN swupd update
+RUN swupd bundle-add containers-basic-dev editors os-testsuite
+
+# Install TAP HTML formatter
+RUN cpan install TAP::Formatter::HTML
+
+# Move the root image created by make-bundle-dir.sh into the specified
+# directory.
+# https://github.com/01org/cc-oci-runtime/blob/master/data/make-bundle-dir.sh
+ADD rootfs /var/lib/oci/bundle/rootfs
+
+# Create /root/go directory for $GOPATH
+RUN mkdir /root/go
+
+# Create /var/run to let docker deamon run
+RUN mkdir /var/run
+
+# Set $GOPATH and HOME env variables
+ENV GOPATH /root/go
+ENV HOME /root
+WORKDIR $HOME
+
+CMD ["/bin/bash"]

--- a/data/dockerFiles/Dockerfile.fedora.in
+++ b/data/dockerFiles/Dockerfile.fedora.in
@@ -1,0 +1,100 @@
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+# XXX: named version (also referenced below for the OBS elements)
+FROM fedora:@DOCKER_FEDORA_VERSION@
+
+# Disable deltarpms.
+#
+# See: https://bugzilla.redhat.com/show_bug.cgi?id=1343114)
+RUN echo deltarpm=0 >> /etc/dnf/dnf.conf
+
+# Ensure packages are current, then install:
+#
+# - a basic development environment
+# - runtime build dependencies and additional general tooling
+#
+# (Note: python3-dnf-plugins-core is required for "dnf config-manager").
+RUN dnf -y update && \
+    dnf -y install \
+        @development-tools \
+        autoconf \
+        automake \
+        bats \
+        check \
+        check-devel \
+        cppcheck \
+        gettext-devel \
+        glib2-devel \
+        json-glib-devel \
+        lcov \
+        libffi-devel \
+        libmnl-devel \
+        libtool \
+        libuuid-devel \
+        pcre-devel \
+        pkgconfig \
+        python3-dnf-plugins-core \
+        sudo \
+        valgrind \
+        zlib-devel \
+		cpan \
+		htop procps-ng \
+		file \
+		perl-TAP-Formatter-HTML.noarch \
+		golang
+
+
+
+# Add the OBS repository
+# XXX: Note the named version of Fedora
+RUN dnf -y config-manager --add-repo \
+    http://download.opensuse.org/repositories/home:clearlinux:preview:clear-containers-2.0/Fedora_@DOCKER_FEDORA_VERSION@/home:clearlinux:preview:clear-containers-2.0.repo
+
+# Install the Clear Containers assets.
+#
+# Note that the command below installs (a version of) the runtime. This
+# version isn't used (since this docker image after all is for testing
+# development versions of the runtime). However, specifying the runtime
+# package ensures the Clear Containers assets are installed
+# automatically as dependencies of the runtime package.
+RUN dnf -y install cc-oci-runtime linux-container
+
+# Install Docker 1.12.1
+# Note that currently cc-oci-runtime only works with Docker 1.12.1 as it
+# only supports OCI specification 1.0.0-rc1
+# More info can be found at https://github.com/01org/cc-oci-runtime/issues/275
+RUN dnf config-manager --add-repo https://yum.dockerproject.org/repo/testing/fedora/@DOCKER_FEDORA_VERSION@
+RUN rpm --import https://yum.dockerproject.org/gpg
+RUN dnf -y install docker-engine-@DOCKER_ENGINE_FEDORA_VERSION@
+
+# Move the root image created by make-bundle-dir.sh into the specified
+# directory.
+# https://github.com/01org/cc-oci-runtime/blob/master/data/make-bundle-dir.sh
+ADD rootfs /var/lib/oci/bundle/rootfs
+
+# Create /root/go directory for $GOPATH
+RUN mkdir /root/go
+
+# Set $GOPATH and $HOME env variables
+ENV GOPATH /root/go
+ENV HOME /root
+WORKDIR $HOME
+
+CMD ["/bin/bash"]

--- a/data/dockerFiles/Dockerfile.ubuntu.in
+++ b/data/dockerFiles/Dockerfile.ubuntu.in
@@ -1,0 +1,94 @@
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+# XXX: named version (also referenced below for the OBS elements)
+FROM ubuntu:@DOCKER_UBUNTU_VERSION@
+
+# Ensure packages are current, then install dependencies
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y \
+		build-essential \
+		python zlib1g-dev \
+		libcap-ng-dev \
+		libglib2.0-dev \
+		libpixman-1-dev \
+		libattr1-dev \
+		libcap-dev \
+		autoconf \
+		libtool \
+		libjson-glib-dev \
+		uuid-dev \
+		check \bats \
+		libdevmapper-dev \
+		file \
+		golang \
+		apt-utils \
+		wget \
+		valgrind \
+		lcov \
+		libmnl-dev \
+		cppcheck \
+		libtap-formatter-html-perl
+
+
+# Add the OBS repository
+RUN sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearlinux:/preview:/clear-containers-2.0/xUbuntu_@DOCKER_UBUNTU_VERSION@/ /' >> /etc/apt/sources.list.d/cc-oci-runtime.list"
+
+# Install OBS key
+RUN wget http://download.opensuse.org/repositories/home:clearlinux:preview:clear-containers-2.0/xUbuntu_@DOCKER_UBUNTU_VERSION@/Release.key
+RUN apt-key add Release.key
+RUN rm Release.key
+
+# Install the Clear Containers assets.
+# Note that the command below installs (a version of) the runtime. This
+# version isn't used (since this docker image after all is for testing
+# development versions of the runtime). However, specifying the runtime
+# package ensures the Clear Containers assets are installed
+# automatically as dependencies of the runtime package.
+RUN apt-get update
+RUN apt-get install -y cc-oci-runtime
+
+# Install Docker 1.12.1
+# Note that currently cc-oci-runtime only works with Docker 1.12.1 as it
+# only supports OCI specification 1.0.0-rc1
+# More info can be found at https://github.com/01org/cc-oci-runtime/issues/275
+RUN apt-get update
+RUN apt-get install -y apt-transport-https ca-certificates
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+RUN sh -c "echo 'deb https://apt.dockerproject.org/repo ubuntu-xenial main' >> /etc/apt/sources.list.d/docker.list"
+RUN apt-get update
+RUN apt-get purge lxc-docker
+RUN apt-cache policy docker-engine
+RUN apt-get install -y docker-engine=@DOCKER_ENGINE_UBUNTU_VERSION@
+
+# Move the root image created by make-bundle-dir.sh into the specified
+# directory.
+# https://github.com/01org/cc-oci-runtime/blob/master/data/make-bundle-dir.sh
+ADD rootfs /var/lib/oci/bundle/rootfs
+
+# Create /root/go directory for $GOPATH
+RUN mkdir /root/go
+
+# Set $GOPATH and $HOME env variables
+ENV GOPATH /root/go
+ENV HOME /root
+WORKDIR $HOME
+
+CMD ["/bin/bash"]

--- a/data/dockerFiles/README.md
+++ b/data/dockerFiles/README.md
@@ -1,0 +1,21 @@
+# Dockerfiles to create a development environment
+
+In this section you can find some Dockerfiles to build an image that will have all necessary
+dependencies to build cc-oci-runtime source code and run tests.
+
+### Prerequisite:
+
+Before building the docker image, please run `make-bundle-dir.sh` as the `rootfs` generated
+by this script will be used while building the image.
+```bash
+	$ sudo ../make-bundle-dir.sh ./rootfs
+```
+
+### Build container image:
+
+To build and run, execute the next commands:
+
+```bash
+$ sudo docker build -t clearlinux-cor -f Dockerfile.clearlinux .
+$ sudo docker run -ti clearlinux-cor bash
+```

--- a/versions.txt
+++ b/versions.txt
@@ -2,3 +2,7 @@ go_version=1.7.1
 glib_version=2.46.2
 json_glib_version=1.2.2
 check_version=0.10.0
+docker_fedora_version=24
+docker_ubuntu_version=16.04
+docker_engine_fedora_version=1.12.1
+docker_engine_ubuntu_version=1.12.1-0~xenial


### PR DESCRIPTION
These Dockerfiles for Clear Linux, Fedora and Ubuntu contain
all dependencies needed to build cc-oci-runtime from sources
and launch Clear Containers as stand alone or with docker.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>