### PR TITLE
data: Add cc-agent.target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -104,6 +104,8 @@ defaultsdir = $(datadir)/defaults/$(PACKAGE_NAME)
 defaults_DATA = data/vm.json data/hypervisor.args data/kernel-cmdline
 
 cc_image_systemd_files = \
+	data/cc-agent.target \
+	data/cc-agent.service \
 	data/container.target \
 	data/opt-rootfs.mount \
 	data/opt-rootfs-proc.mount \

--- a/data/cc-agent.service
+++ b/data/cc-agent.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Clear Container Agent
+
+[Service]
+StandardOutput=tty
+Type=simple
+ExecStart=/bin/hyperstart
+ExecStop=/usr/bin/systemctl --force poweroff
+FailureAction=poweroff

--- a/data/cc-agent.target
+++ b/data/cc-agent.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=Clear Containers Agent Target
+Requires=basic.target
+Requires=cc-agent.service
+Conflicts=rescue.service rescue.target
+After=basic.target rescue.service rescue.target
+AllowIsolate=yes


### PR DESCRIPTION
This patch adds cc-agent.target and cc-target.service. The target
starts the clear containers guest agent (hyperstart). After the agent is finished
the VM will be powered off.

The agent output is sent to tty for debug information. Can be retrieved
by using a serial console in the guest.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>