### PR TITLE
hypervisor: don't use qemu console

### DIFF
--- a/src/hypervisor.c
+++ b/src/hypervisor.c
@@ -152,6 +152,7 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 	gchar           **arg;
 	gchar            *bytes = NULL;
 	gchar            *console_device = NULL;
+	g_autofree gchar *hypervisor_console = NULL;
 	g_autofree gchar *procsock_device = NULL;
 
 	gboolean          ret = false;
@@ -227,82 +228,12 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 
 	bytes = g_strdup_printf ("%lu", (unsigned long int)st.st_size);
 
-	/* XXX: Note that "signal=off" ensures that the key sequence
-	 * CONTROL+c will not cause the VM to exit.
-	 */
-	if (! config->console || ! g_utf8_strlen(config->console, LINE_MAX)) {
+	hypervisor_console = g_build_path ("/", config->state.runtime_path,
+			CC_OCI_CONSOLE_SOCKET, NULL);
 
-		config->use_socket_console = true;
-
-		/* Temporary fix for non-console output, since -chardev stdio is not working as expected
-		 * 
-		 * Check if called from docker. Use -chardev pipe as virtualconsole.
-		 * Create symlinks to docker named pipes in the format qemu expects.
-		 *
-		 * Eventually move to using "stdio,id=charconsole0,signal=off"
-		 */
-		if (! config->oci.process.terminal ) {
-
-			config->console = g_build_path ("/",
-					config->bundle_path,
-					"cc-std", NULL);
-
-			g_debug ("no console device provided , so using pipe: %s", config->console);
-
-			g_autofree gchar *init_stdout = g_build_path ("/",
-							config->bundle_path,
-							"init-stdout", NULL);
-
-			g_autofree gchar *cc_stdout = g_build_path ("/",
-							config->bundle_path,
-							"cc-std.out", NULL);
-
-			g_autofree gchar *init_stdin = g_build_path ("/",
-							config->bundle_path,
-							"init-stdin", NULL);
-			g_autofree gchar *cc_stdin = g_build_path ("/",
-							config->bundle_path,
-							"cc-std.in", NULL);
-
-			if ( symlink (init_stdout, cc_stdout) == -1) {
-				g_critical("Failed to create symlink for output pipe: %s",
-					   strerror (errno));
-				goto out;
-			}
-
-			if ( symlink (init_stdin, cc_stdin) == -1) {
-				g_critical("Failed to create symlink for input pipe: %s",
-					   strerror (errno));
-				goto out;
-			}
-
-			console_device = g_strdup_printf ("pipe,id=charconsole0,path=%s", config->console);
-
-		} else {
-
-			/* In case the runtime is called standalone without console */
-
-			/* No console specified, so make the hypervisor create
-			 * a Unix domain socket.
-			 */	
-			config->console = g_build_path ("/",
-					config->state.runtime_path,
-					CC_OCI_CONSOLE_SOCKET, NULL);
-
-			/* Note that path is not quoted - attempting to do so
-			 * results in qemu failing with the error:
-			 *
-			 *   Failed to bind socket to "/a/dir/console.sock": No such file or directory
-			 */
-
-			g_debug ("no console device provided, so using socket: %s", config->console);
-
-			console_device = g_strdup_printf ("socket,path=%s,server,nowait,id=charconsole0,signal=off",
-				config->console);
-		}
-	} else {
-		console_device = g_strdup_printf ("serial,id=charconsole0,path=%s", config->console);
-	}
+	console_device = g_strdup_printf (
+			"socket,path=%s,server,nowait,id=charconsole0,signal=off",
+			hypervisor_console);
 
 	procsock_device = g_strdup_printf ("socket,id=procsock,path=%s,server,nowait", config->state.procsock_path);
 

--- a/src/oci.c
+++ b/src/oci.c
@@ -1127,8 +1127,7 @@ cc_oci_start (struct cc_oci_config *config,
 	 *
 	 * Do not wait when console is empty.
 	 */
-	if ((isatty (STDIN_FILENO) && ! config->detached_mode) &&
-	    !config->use_socket_console) {
+	if ((isatty (STDIN_FILENO) && ! config->detached_mode)) {
 		wait = true;
 	}
 
@@ -1804,8 +1803,6 @@ cc_oci_config_update (struct cc_oci_config *config,
 		config->console = state->console;
 		state->console = NULL;
 	}
-
-	config->use_socket_console = state->use_socket_console;
 
 	if (state->vm) {
 		config->vm = state->vm;

--- a/src/oci.h
+++ b/src/oci.h
@@ -408,9 +408,6 @@ struct oci_state {
 	/* See member of same name in \ref cc_oci_config. */
 	gchar           *console;
 
-	/* See member of same name in \ref cc_oci_config. */
-	gboolean         use_socket_console;
-
 	struct cc_oci_vm_cfg *vm;
 	struct cc_proxy      *proxy;
 };
@@ -524,11 +521,6 @@ struct cc_oci_config {
 
 	/** Path to device to use for I/O. */
 	gchar *console;
-
-	/** If \c true, \ref console will be a socket rather than a pty
-	 * device.
-	 */
-	gboolean use_socket_console;
 
 	/** If set, use an alternative root directory to the default
 	 * CC_OCI_RUNTIME_DIR_PREFIX.

--- a/src/state.c
+++ b/src/state.c
@@ -87,7 +87,7 @@ static struct state_handler {
 	{ "status"      , handle_state_status_section      , 1 , 0 },
 	{ "created"     , handle_state_created_section     , 1 , 0 },
 	{ "mounts"      , handle_state_mounts_section      , 0 , 0 },
-	{ "console"     , handle_state_console_section     , 2 , 0 },
+	{ "console"     , handle_state_console_section     , 1 , 0 },
 	{ "vm"          , handle_state_vm_section          , 6 , 0 },
 	{ "proxy"       , handle_state_proxy_section       , 2 , 0 },
 	{ "annotations" , handle_state_annotations_section , 0 , 0 },
@@ -294,11 +294,7 @@ handle_state_console_section(GNode* node, struct handler_data* data) {
 		g_critical("%s missing value", (char*)node->data);
 		return;
 	}
-	if (g_strcmp0(node->data, "socket") == 0) {
-		(*(data->subelements_count))++;
-		data->state->use_socket_console =
-		    g_strcmp0(node->children->data, "true") ? false : true;
-	} else if (g_strcmp0(node->data, "path") == 0) {
+	if (g_strcmp0(node->data, "path") == 0) {
 		(*(data->subelements_count))++;
 		data->state->console = g_strdup(node->children->data);
 	} else {
@@ -735,8 +731,6 @@ cc_oci_state_file_create (struct cc_oci_config *config,
 	 * used.
 	 */
 	console = json_object_new ();
-	json_object_set_boolean_member (console, "socket",
-			config->use_socket_console);
 	json_object_set_string_member (console, "path",
 			config->console);
 

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -628,13 +628,11 @@ START_TEST(test_cc_oci_config_update) {
 
 	ck_assert (! config->oci.mounts);
 	ck_assert (! config->console);
-	ck_assert (! config->use_socket_console);
 	ck_assert (! config->vm);
 
 	/**************************/
 	/* setup the state object */
 
-	state->use_socket_console = true;
 	state->console = g_strdup ("console");
 
 	/* create mount object */
@@ -670,7 +668,6 @@ START_TEST(test_cc_oci_config_update) {
 
 	ck_assert (config->oci.mounts);
 	ck_assert (config->console);
-	ck_assert (config->use_socket_console);
 
 	ck_assert (config->vm);
 


### PR DESCRIPTION
This patch removes qemu console logic
used to provide qemu serial console
as container tty.

Console must be managed by cc-shim,
The qemu serial console backend now is
socket, useful to get debug information.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>