### PR TITLE
tests/mock: Fix golint error on SendMessage()

### DIFF
--- a/tests/mock/hyperstart.go
+++ b/tests/mock/hyperstart.go
@@ -110,6 +110,8 @@ func (h *Hyperstart) writeCtl(data []byte) {
 	assert.Equal(h.t, n, len(data))
 }
 
+// SendMessage makes hyperstart send the hyper command cmd along with optional
+// data on the control channel
 func (h *Hyperstart) SendMessage(cmd int, data []byte) {
 	length := ctlHeaderSize + len(data)
 	header := make([]byte, ctlHeaderSize)


### PR DESCRIPTION
We had a race:

  - A branch was introduced a add golint to travis
  - In the mean time, a commit producing a golint error was added

The golint branch didn't have the offending commit and wasn't rebase
before merging so we didn't discover the problem until it was too late.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>