### PR TITLE
pullapprove: Require review and testing on PRs against any branch

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -23,9 +23,6 @@ group_defaults:
     enabled: true
   author_approval:
     ignored: true
-  conditions:
-    branches:
-      - master
 
 groups:
   code-reviewers:


### PR DESCRIPTION
I don't think we want to restrict review for PRs to the master branch
but do it for PRs to any branch.

2 scenarii:

  - Someone pushes commits to a branch without going through a PR, with
    that one bypasses the whole PR/review mechanism (but still has
    travis testing)

  - A PR is opened to ask for review/permission to merge some patches in
    a branch. In this case it sounds like a good idea to always go
    through review/CI.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>