### PR TITLE
Shim: Perform check on data length returned by proxy.

### DIFF
--- a/shim/shim.c
+++ b/shim/shim.c
@@ -350,7 +350,7 @@ read_IO_message(struct cc_shim *shim, uint64_t *seq, ssize_t *stream_len) {
 
 		bytes_read += ret;
 
-		if (*stream_len == 0 && bytes_read >=12) {
+		if (*stream_len == 0 && bytes_read >= STREAM_HEADER_SIZE) {
 			*stream_len = get_big_endian_32((uint8_t*)(buf+STREAM_HEADER_LENGTH_OFFSET));
 
 			// length is 12 when hyperstart sends eof before sending exit code

--- a/shim/shim.h
+++ b/shim/shim.h
@@ -50,3 +50,12 @@ struct cc_shim {
 #define PROXY_CTL_HEADER_SIZE           8
 #define PROXY_CTL_HEADER_LENGTH_OFFSET  0
 
+/*
+ * Hyperstart is limited to sending this number of bytes to
+ * a client.
+ *
+ * (This value can be determined by inspecting the hyperstart
+ * source where hyper_event_ops->wbuf_size is set).
+ */
+#define HYPERSTART_MAX_RECV_BYTES       10240
+


### PR DESCRIPTION
Check to ensure data length value returned by proxy is positive before
using this value in a loop.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>