### PR TITLE
disable helgrind and drd checks when running make distcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -141,6 +141,8 @@ DISTCHECK_CONFIGURE_FLAGS = \
 	--enable-tests \
 	--enable-cppcheck \
 	--enable-valgrind \
+	--disable-valgrind-helgrind \
+	--disable-valgrind-drd \
 	--enable-code-coverage \
 	--enable-functional-tests \
 	--with-systemdsystemunitdir=/tmp/cc-distcheck/systemdunitdir/


### PR DESCRIPTION
disable helgrind and drd checks when running make distcheck

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>