### PR TITLE
travis: Don't run the tests with make -j5

### DIFF
--- a/.travis/travis-build.sh
+++ b/.travis/travis-build.sh
@@ -40,4 +40,5 @@ mkdir travis_build
      --enable-valgrind --disable-valgrind-helgrind --disable-valgrind-drd \
      --disable-silent-rules \
      --disable-docker-tests \
- && make -j5 CFLAGS=-Werror check)
+ && make -j5 CFLAGS=-Werror \
+ && make check)


### PR DESCRIPTION
Having multiple threads running the tests also means having their output
interleaved. When a test fails it's then that much harder to figure out
what happened.

The small time gain isn't worth it.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>