### PR TITLE
Fix 2 races in tests/mock

### DIFF
--- a/tests/mock/hyperstart.go
+++ b/tests/mock/hyperstart.go
@@ -379,9 +379,6 @@ func (h *Hyperstart) Stop() {
 
 	h.wg.Wait()
 
-	h.ctl = nil
-	h.io = nil
-
 	os.Remove(h.ctlSocketPath)
 	os.Remove(h.ioSocketPath)
 

--- a/tests/mock/hyperstart.go
+++ b/tests/mock/hyperstart.go
@@ -349,15 +349,23 @@ func (h *Hyperstart) Start() {
 		// a client is now connected to the ctl socket
 		h.ctl = s
 
-		h.wgConnected.Done()
-
+		// Close() was called before we had a chance to accept a
+		// connection.
 		if s == nil {
+			h.wgConnected.Done()
 			return
 		}
 
 		// start the goroutine that will handle the ctl socket
 		h.wg.Add(1)
 		go h.handleCtl()
+
+		// we need signal wgConnected late, so wg.Add(1) is done before
+		// the wg.Wait() in Close()
+		// See https://golang.org/pkg/sync/#WaitGroup.Wait:
+		//   "Note that calls with a positive delta that occur when the
+		//    counter is zero must happen before a Wait"
+		h.wgConnected.Done()
 	})
 
 	h.ioListener = h.startListening(h.ioSocketPath, func(s net.Conn) {


### PR DESCRIPTION
I try to reset the net.Conn objects to nil, but that's not necessary,
and races with the code setting them to real objects.

This should fix:

==================
WARNING: DATA RACE
Read at 0x00c420010308 by goroutine 20:
  github.com/01org/cc-oci-runtime/tests/mock.(*Hyperstart).readCtl()
      github.com/01org/cc-oci-runtime/tests/mock/hyperstart.go:133 +0x6b
  github.com/01org/cc-oci-runtime/tests/mock.(*Hyperstart).readMessage()
      github.com/01org/cc-oci-runtime/tests/mock/hyperstart.go:150 +0xa2
  github.com/01org/cc-oci-runtime/tests/mock.(*Hyperstart).handleCtl()
      github.com/01org/cc-oci-runtime/tests/mock/hyperstart.go:225 +0x6e
Previous write at 0x00c420010308 by goroutine 14:
  github.com/01org/cc-oci-runtime/tests/mock.(*Hyperstart).Stop()
      github.com/01org/cc-oci-runtime/tests/mock/hyperstart.go:382 +0x10c
  01org/cc-oci-runtime/cc-oci-runtime-0.1/proxy.(*testRig).Stop()
      github.com/01org/cc-oci-runtime/cc-oci-runtime-0.1/proxy/proxy_test.go:170 +0xd8
  01org/cc-oci-runtime/cc-oci-runtime-0.1/proxy.TestHello()
      github.com/01org/cc-oci-runtime/cc-oci-runtime-0.1/proxy/proxy_test.go:206 +0x803 testing.tRunner()
      /home/travis/go/src/testing/testing.go:610 +0xc9
  01org/cc-oci-runtime/cc-oci-runtime-0.1/proxy.(*testRig).Stop()
      github.com/01org/cc-oci-runtime/cc-oci-runtime-0.1/proxy/proxy_test.go:170 +0xd8
  01org/cc-oci-runtime/cc-oci-runtime-0.1/proxy.TestHello()
      /home/travis/build/01org/cc-oci-runtime/cc-oci-runtime-0.1/proxy/proxy_test.go:206 +0x803
  testing.tRunner()
      /home/travis/go/src/testing/testing.go:610 +0xc9

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>