### PR TITLE
Process: Check hypervisor argument length bounds.

### DIFF
--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1241,7 +1241,9 @@ out:
 		json_object_unref (newcontainer_payload);
 	}
 
-	cc_proxy_disconnect (config->proxy);
+	if (config && config->proxy) {
+		cc_proxy_disconnect (config->proxy);
+	}
 
 	return ret;
 }


### PR DESCRIPTION
Add additional check to ensure the length of the hypervisor arguments
passed to the child process is within reasonable bounds.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>