### PR TITLE
delete: Connect to the proxy before calling bye command for proxy

### DIFF
--- a/src/oci.c
+++ b/src/oci.c
@@ -1193,6 +1193,8 @@ cc_oci_stop (struct cc_oci_config *config,
 				state->id, state->pid);
 	}
 
+	cc_proxy_connect(config->proxy);
+
 	/* Allow the proxy to clean up resources */
 	if (! cc_proxy_cmd_bye (config->proxy)) {
 		return false;

--- a/src/oci.c
+++ b/src/oci.c
@@ -1196,7 +1196,7 @@ cc_oci_stop (struct cc_oci_config *config,
 	cc_proxy_connect(config->proxy);
 
 	/* Allow the proxy to clean up resources */
-	if (! cc_proxy_cmd_bye (config->proxy)) {
+	if (! cc_proxy_cmd_bye (config->proxy, config->optarg_container_id)) {
 		return false;
 	}
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -731,9 +731,10 @@ out:
  * \return \c true on success, else \c false.
  */
 gboolean
-cc_proxy_cmd_bye (struct cc_proxy *proxy)
+cc_proxy_cmd_bye (struct cc_proxy *proxy, const char *container_id)
 {
 	JsonObject        *obj = NULL;
+	JsonObject        *data = NULL;
 	JsonNode          *root = NULL;
 	JsonGenerator     *generator = NULL;
 	gchar             *msg_to_send = NULL;
@@ -745,7 +746,7 @@ cc_proxy_cmd_bye (struct cc_proxy *proxy)
 	 */
 	const gchar       *proxy_cmd = "bye";
 
-	if (! proxy) {
+	if (! (proxy && container_id)) {
 		return false;
 	}
 
@@ -755,8 +756,14 @@ cc_proxy_cmd_bye (struct cc_proxy *proxy)
 	}
 
 	obj = json_object_new ();
+	data = json_object_new ();
 
 	json_object_set_string_member (obj, "id", proxy_cmd);
+
+	json_object_set_string_member (data, "containerId",
+			container_id);
+
+	json_object_set_object_member (obj, "data", data);
 
 	root = json_node_new (JSON_NODE_OBJECT);
 	generator = json_generator_new ();

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -32,7 +32,7 @@ gboolean cc_proxy_connect (struct cc_proxy *proxy);
 gboolean cc_proxy_disconnect (struct cc_proxy *proxy);
 gboolean cc_proxy_wait_until_ready (struct cc_oci_config *config);
 gboolean cc_proxy_hyper_pod_create (struct cc_oci_config *config);
-gboolean cc_proxy_cmd_bye (struct cc_proxy *proxy);
+gboolean cc_proxy_cmd_bye (struct cc_proxy *proxy, const char *container_id);
 gboolean cc_proxy_cmd_allocate_io (struct cc_proxy *proxy, int *proxy_io_fd,
 		int *ioBase);
 gboolean cc_proxy_hyper_new_container (struct cc_oci_config *config);


### PR DESCRIPTION
On stopping a container with docker stop, bye command is issued to
the proxy. It is necessary for the runtime to esatablish connection
with the proxy before issuing bye command.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>