### PR TITLE
Proxy: Only disconnect on error.

### DIFF
--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1241,7 +1241,9 @@ out:
 		json_object_unref (newcontainer_payload);
 	}
 
-	cc_proxy_disconnect (config->proxy);
+	if (config && config->proxy) {
+		cc_proxy_disconnect (config->proxy);
+	}
 
 	return ret;
 }


### PR DESCRIPTION
Don't call cc_proxy_disconnect() if not connected or config invalid.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>