### PR TITLE
proxy: Add a "containerId" argument to Bye

### DIFF
--- a/proxy/api/api.go
+++ b/proxy/api/api.go
@@ -53,13 +53,17 @@ type Attach struct {
 }
 
 // The Bye payload does the opposite of what hello does, indicating to the
-// proxy it should release resources created by hello. This command has no
-// parameter.
+// proxy it should release resources created by hello for the container
+// identified by containerId.
 //
 //  {
-//    "id": "bye"
+//    "id": "bye",
+//    "data": {
+//      "containerId": "756535dc6e9ab9b560f84c8..."
+//    }
 //  }
 type Bye struct {
+	ContainerID string `json:"containerId"`
 }
 
 // The AllocateIo payload asks the proxy to allocate IO stream sequence numbers

--- a/proxy/api/client.go
+++ b/proxy/api/client.go
@@ -169,8 +169,12 @@ func (client *Client) Hyper(hyperName string, hyperMessage interface{}) error {
 }
 
 // Bye wraps the Bye payload (see payload description for more details)
-func (client *Client) Bye() error {
-	resp, err := client.sendPayload("bye", nil)
+func (client *Client) Bye(containerID string) error {
+	bye := Bye{
+		ContainerID: containerID,
+	}
+
+	resp, err := client.sendPayload("bye", &bye)
 	if err != nil {
 		return err
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -111,10 +111,19 @@ func attachHandler(data []byte, userData interface{}, response *handlerResponse)
 func byeHandler(data []byte, userData interface{}, response *handlerResponse) {
 	client := userData.(*client)
 	proxy := client.proxy
-	vm := client.vm
+
+	bye := api.Bye{}
+	if err := json.Unmarshal(data, &bye); err != nil {
+		response.SetError(err)
+		return
+	}
+
+	proxy.Lock()
+	vm := proxy.vms[bye.ContainerID]
+	proxy.Unlock()
 
 	if vm == nil {
-		response.SetErrorMsg("client not attached to a vm")
+		response.SetErrorf("unknown containerID: %s", bye.ContainerID)
 		return
 	}
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -219,12 +219,16 @@ func TestBye(t *testing.T) {
 	err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath)
 	assert.Nil(t, err)
 
+	// Bye with a bad containerID
+	err = rig.Client.Bye("foo")
+	assert.NotNil(t, err)
+
 	// Bye!
-	err = rig.Client.Bye()
+	err = rig.Client.Bye(testContainerID)
 	assert.Nil(t, err)
 
 	// A second Bye (client not attached anymore) should return an error
-	err = rig.Client.Bye()
+	err = rig.Client.Bye(testContainerID)
 	assert.NotNil(t, err)
 
 	// Bye should unregister the vm object
@@ -263,7 +267,7 @@ func TestAttach(t *testing.T) {
 	// attached, we issue a bye that would error out if not attatched.
 	err = rig.Client.Attach(testContainerID)
 	assert.Nil(t, err)
-	err = rig.Client.Bye()
+	err = rig.Client.Bye(testContainerID)
 	assert.Nil(t, err)
 
 	// This test shouldn't send anything with hyperstart


### PR DESCRIPTION
Archana suggested we add a containerId parameter to Bye so we don't have
to issue an attach payload to associate the connection beforehand. That
saves a round-trip with the proxy.

Because it's still early times and we don't have any user, let alone any
stable user, yet, I broke the API: the old behaviour using Bye with no
parameter when the client is already attached to a VM will not work
anymore.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>