### PR TITLE
cc-shim: Use simple assignment to get the exit code from buffer

### DIFF
--- a/shim/shim.c
+++ b/shim/shim.c
@@ -457,7 +457,8 @@ handle_proxy_output(struct cc_shim *shim)
 		shim->exiting = true;
 		goto out;
 	} else if (shim->exiting && stream_len == (STREAM_HEADER_SIZE+1)) {
-		code = atoi(buf + STREAM_HEADER_SIZE); 	// hyperstart has sent the exit status
+		code = *(buf + STREAM_HEADER_SIZE); 	// hyperstart has sent the exit status
+		shim_debug("Exit status for container: %d\n", code);
 		free(buf);
 		exit(code);
 	}


### PR DESCRIPTION
Since the exit code is a single char byte, use simple assignment to get
the exit code instead of atoi() call.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>