### PR TITLE
delete: Pass hypervisor pid for qmp shutdown.

### DIFF
--- a/src/oci.c
+++ b/src/oci.c
@@ -279,11 +279,11 @@ error:
 private gboolean
 cc_oci_vm_running (const struct oci_state *state)
 {
-	if (! (state && state->pid)) {
+	if (! (state && state->vm && state->vm->pid)) {
 		return false;
 	}
 
-	return kill (state->pid, 0) == 0;
+	return kill (state->vm->pid, 0) == 0;
 }
 
 /*!
@@ -1177,7 +1177,7 @@ cc_oci_stop (struct cc_oci_config *config,
 
 	if (cc_oci_vm_running (state)) {
 		gboolean ret;
-		ret = cc_oci_vm_shutdown (state->comms_path, state->pid);
+		ret = cc_oci_vm_shutdown (state->comms_path, state->vm->pid);
 		if (! ret) {
 			return false;
 		}

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -793,17 +793,25 @@ START_TEST(test_cc_oci_vm_running) {
 
 	ck_assert (! cc_oci_vm_running (NULL));
 
-	/* no pid */
+	/* no vm */
 	ck_assert (! cc_oci_vm_running (&state));
 
-	/* our pid */
-	state.pid = getpid ();
+	state.vm = g_malloc0(sizeof(struct cc_oci_vm_cfg));
+	ck_assert(state.vm);
+
+	/* no pid for vm */
+	ck_assert (! cc_oci_vm_running (&state));
+
+	/* our pid provided as hypervisor pid*/
+	state.vm->pid = getpid ();
 	ck_assert (cc_oci_vm_running (&state));
 
 	/* invalid pid (we hope: this is potential an unreliable test).
 	 */
-	state.pid = (pid_t)INT_MAX;
+	state.vm->pid = (pid_t)INT_MAX;
 	ck_assert (! cc_oci_vm_running (&state));
+
+	g_free(state.vm);
 
 } END_TEST
 


### PR DESCRIPTION
The shim pid was getting passed for the vm shutdown.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>