### PR TITLE
Proxy: Fix gofmt newline error.

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -225,7 +225,7 @@ func (proxy *proxy) init() error {
 		}
 	} else {
 		if err = os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("couldn't remove exiting socket: %v\n", err)
+			return fmt.Errorf("couldn't remove exiting socket: %v", err)
 		}
 		l, err = net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
 		if err != nil {


### PR DESCRIPTION
Remove a superfluous newline that was causing a build failure
(due to "gofmt").

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>