### PR TITLE
proxy: Rely on hyperstart package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
 - ./.travis/travis-setup.sh
 - go get github.com/client9/misspell/cmd/misspell
 - go get github.com/golang/lint/golint
+- go get github.com/sameo/virtcontainers/hyperstart
 - go get github.com/sameo/virtcontainers/hyperstart/mock
 
 script:

--- a/proxy/vm.go
+++ b/proxy/vm.go
@@ -16,14 +16,12 @@ package main
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
-	"math"
 	"net"
 	"os"
 	"sync"
 
-	hyper "github.com/hyperhq/runv/hyperstart/api/json"
+	"github.com/sameo/virtcontainers/hyperstart"
 )
 
 // Represents a single qemu/hyperstart instance on the system
@@ -32,12 +30,7 @@ type vm struct {
 
 	containerID string
 
-	ctlSerial, ioSerial string
-	ctl, io             net.Conn
-
-	// ctl access is arbitrated by ctlMutex. We can only allow a single
-	// "transaction" (write command + read answer) at a time
-	ctlMutex sync.Mutex
+	hyperHandler *hyperstart.Hyperstart
 
 	// Used to allocate globally unique IO sequence numbers
 	nextIoBase uint64
@@ -65,136 +58,18 @@ type ioSession struct {
 }
 
 func newVM(id, ctlSerial, ioSerial string) *vm {
+	h := hyperstart.NewHyperstart(ctlSerial, ioSerial, "unix")
+
 	return &vm{
-		containerID: id,
-		ctlSerial:   ctlSerial,
-		ioSerial:    ioSerial,
-		nextIoBase:  1,
-		ioSessions:  make(map[uint64]*ioSession),
+		containerID:  id,
+		hyperHandler: h,
+		nextIoBase:   1,
+		ioSessions:   make(map[uint64]*ioSession),
 	}
-}
-
-func (vm *vm) openSockets() error {
-	var err error
-
-	vm.ctl, err = net.Dial("unix", vm.ctlSerial)
-	if err != nil {
-		return err
-	}
-
-	vm.io, err = net.Dial("unix", vm.ioSerial)
-	if err != nil {
-		vm.ctl.Close()
-		return err
-	}
-
-	return nil
-}
-
-func (vm *vm) closeSockets() {
-	if vm.ctl != nil {
-		vm.ctl.Close()
-	}
-	if vm.io != nil {
-		vm.io.Close()
-	}
-}
-
-func (vm *vm) readMessage() (*hyper.DecodedMessage, error) {
-	// see runv's hypervisor/init_comm.go
-	needRead := 8
-	length := 0
-	read := 0
-	buf := make([]byte, 512)
-	res := []byte{}
-	for read < needRead {
-		want := needRead - read
-		if want > 512 {
-			want = 512
-		}
-		nr, err := vm.ctl.Read(buf[:want])
-		if err != nil {
-			return nil, err
-		}
-
-		res = append(res, buf[:nr]...)
-		read = read + nr
-
-		if length == 0 && read >= 8 {
-			length = int(binary.BigEndian.Uint32(res[4:8]))
-			if length > 8 {
-				needRead = length
-			}
-		}
-	}
-
-	return &hyper.DecodedMessage{
-		Code:    binary.BigEndian.Uint32(res[:4]),
-		Message: res[8:],
-	}, nil
-}
-
-func (vm *vm) writeMessage(m *hyper.DecodedMessage) (err error) {
-	length := len(m.Message) + 8
-	// XXX: Support sending messages by chunks to support messages over
-	// 10240 bytes. That limit is from hyperstart src/init.c,
-	// hyper_channel_ops, rbuf_size.
-	if length > 10240 {
-		return fmt.Errorf("message too long %d", length)
-	}
-	msg := make([]byte, length)
-	binary.BigEndian.PutUint32(msg[:], uint32(m.Code))
-	binary.BigEndian.PutUint32(msg[4:], uint32(length))
-	copy(msg[8:], m.Message)
-
-	_, err = vm.ctl.Write(msg)
-	if err != nil {
-		return err
-	}
-
-	// Consume the ack (NEXT) messages until we've acked the full message
-	// we've just written
-	acked := 0
-	for acked < length {
-		next, err := vm.readMessage()
-		if err != nil {
-			return nil
-		}
-		if next.Code != hyper.INIT_NEXT {
-			return errors.New("didn't receive NEXT from hyperstart")
-		}
-		if len(next.Message) != 4 {
-			return errors.New("wrong size for NEXT message")
-		}
-		acked += int(binary.BigEndian.Uint32(next.Message[0:4]))
-	}
-
-	// Somehow hyperstart acked more than it should?
-	if acked != length {
-		fmt.Fprintf(os.Stderr,
-			"wrong acked size by NEXT message (expected %d, got %d)\n", length, acked)
-	}
-
-	return nil
-}
-
-func (vm *vm) waitForReady() error {
-	vm.ctlMutex.Lock()
-	defer vm.ctlMutex.Unlock()
-
-	msg, err := vm.readMessage()
-	if err != nil {
-		return err
-	} else if msg.Code != hyper.INIT_READY {
-		return fmt.Errorf("Unexpected message %d", msg.Code)
-	}
-
-	return nil
 }
 
 // Returns one chunk of data belonging to the seq stream
 func readIoMessage(conn net.Conn) (seq uint64, data []byte, err error) {
-	// see runv's hypervisor/tty.go
 	needRead := 12
 	length := 0
 	read := 0
@@ -242,16 +117,21 @@ func (vm *vm) findClientConn(seq uint64) net.Conn {
 // There's only one instance of this goroutine per-VM
 func (vm *vm) ioHyperToClients() {
 	for {
-		seq, data, err := readIoMessage(vm.io)
+		ttyMsg, err := vm.hyperHandler.ReadIoMessage()
 		if err != nil {
 			// VM process is gone
 			break
 		}
+		length := len(ttyMsg.Message) + 12
+		data := make([]byte, length)
+		binary.BigEndian.PutUint64(data[:], uint64(ttyMsg.Session))
+		binary.BigEndian.PutUint32(data[8:], uint32(length))
+		copy(data[12:], ttyMsg.Message)
 
-		client := vm.findClientConn(seq)
+		client := vm.findClientConn(ttyMsg.Session)
 		if client == nil {
 			fmt.Fprintf(os.Stderr,
-				"couldn't find client with seq number %d\n", seq)
+				"couldn't find client with seq number %d\n", ttyMsg.Session)
 			continue
 		}
 		n, err := client.Write(data)
@@ -268,13 +148,12 @@ func (vm *vm) ioHyperToClients() {
 }
 
 func (vm *vm) Connect() error {
-	if err := vm.openSockets(); err != nil {
+	if err := vm.hyperHandler.OpenSockets(); err != nil {
 		return err
 	}
-	if err := vm.waitForReady(); err != nil {
-		vm.closeSockets()
-		vm.ctl = nil
-		vm.io = nil
+
+	if err := vm.hyperHandler.WaitForReady(); err != nil {
+		vm.hyperHandler.CloseSockets()
 		return err
 	}
 
@@ -284,85 +163,9 @@ func (vm *vm) Connect() error {
 	return nil
 }
 
-func cmdFromSring(cmd string) (uint32, error) {
-	// Commands not supported by proxy:
-	//   hyper.INIT_STOPPOD_DEPRECATED
-	//   hyper.INIT_WRITEFILE
-	//   hyper.INIT_READFILE
-	switch cmd {
-	case "version":
-		return hyper.INIT_VERSION, nil
-	case "startpod":
-		return hyper.INIT_STARTPOD, nil
-	case "getpod":
-		return hyper.INIT_GETPOD, nil
-	case "destroypod":
-		return hyper.INIT_DESTROYPOD, nil
-	case "restartcontainer":
-		return hyper.INIT_RESTARTCONTAINER, nil
-	case "execcmd":
-		return hyper.INIT_EXECCMD, nil
-	case "finishcmd":
-		return hyper.INIT_FINISHCMD, nil
-	case "ready":
-		return hyper.INIT_READY, nil
-	case "ack":
-		return hyper.INIT_ACK, nil
-	case "error":
-		return hyper.INIT_ERROR, nil
-	case "winsize":
-		return hyper.INIT_WINSIZE, nil
-	case "ping":
-		return hyper.INIT_PING, nil
-	case "finishpod":
-		return hyper.INIT_FINISHPOD, nil
-	case "next":
-		return hyper.INIT_NEXT, nil
-	case "newcontainer":
-		return hyper.INIT_NEWCONTAINER, nil
-	case "killcontainer":
-		return hyper.INIT_KILLCONTAINER, nil
-	case "onlinecpumem":
-		return hyper.INIT_ONLINECPUMEM, nil
-	case "setupinterface":
-		return hyper.INIT_SETUPINTERFACE, nil
-	case "setuproute":
-		return hyper.INIT_SETUPROUTE, nil
-	default:
-		return math.MaxUint32, fmt.Errorf("unknown command '%s'", cmd)
-	}
-}
-
-func (vm *vm) SendMessage(name string, data []byte) error {
-	vm.ctlMutex.Lock()
-	defer vm.ctlMutex.Unlock()
-
-	cmd, err := cmdFromSring(name)
-	if err != nil {
-		return err
-	}
-
-	// Write message
-	msg := &hyper.DecodedMessage{
-		Code:    cmd,
-		Message: data,
-	}
-	if err := vm.writeMessage(msg); err != nil {
-		return err
-	}
-
-	// Wait for answer
-	resp, err := vm.readMessage()
-	if err != nil {
-		return err
-	}
-	if resp.Code == hyper.INIT_ERROR {
-		return errors.New("hyperstart returned an error")
-	} else if resp.Code != hyper.INIT_ACK {
-		return fmt.Errorf("unexpected message from hyperstart '%d'", msg.Code)
-	}
-
-	return nil
+func (vm *vm) SendMessage(cmd string, data []byte) error {
+	_, err := vm.hyperHandler.SendCtlMessage(cmd, data)
+	return err
 }
 
 // This function runs in a goroutine, reading data from the client socket and
@@ -382,12 +185,11 @@ func (vm *vm) ioClientToHyper(session *ioSession) {
 			break
 		}
 
-		n, err := vm.io.Write(data)
-		if err != nil || n != len(data) {
+		err = vm.hyperHandler.SendIoMessage(seq, data[12:])
+		if err != nil {
 			fmt.Fprintf(os.Stderr,
-				"error writing I/O data to hyperstart: %v (%d bytes written)\n", err, n)
+				"error writing I/O data to hyperstart: %v\n", err)
 			break
-
 		}
 	}
 
@@ -439,7 +241,7 @@ func (vm *vm) CloseIo(seq uint64) {
 }
 
 func (vm *vm) Close() {
-	vm.closeSockets()
+	vm.hyperHandler.CloseSockets()
 
 	// Wait for per-client goroutines
 	vm.Lock()
@@ -455,6 +257,4 @@ func (vm *vm) Close() {
 
 	// Wait for VM global goroutines
 	vm.wg.Wait()
-	vm.ctl = nil
-	vm.io = nil
 }


### PR DESCRIPTION
This PR fixes issue #395. The code from proxy now relies on common hyperstart package instead of duplicating hyperstart implementations.