### PR TITLE
Tests: Unbreak bats error handling.

### DIFF
--- a/tests/functional/common.bash.in
+++ b/tests/functional/common.bash.in
@@ -189,7 +189,7 @@ function verify_runtime_dirs()
 
 	else
 		log_msg "Invalid state: '$state'"
-		exit 1
+		false
 	fi
 
 	return 0
@@ -210,7 +210,7 @@ function testcontainer() {
 	local got=0
 	local cmd="$COR list --format table"
 	[ "$timeout_cmd"  -eq "$timeout_cmd" ] || \
-	{ log_msg "timeout is not a number"; exit 1; }
+	{ log_msg "timeout is not a number"; false; }
 
 	# The status passed to this function needs to be "simplified"
 	# in the case of "killed" to match the acceptable OCI states
@@ -239,7 +239,7 @@ function testcontainer() {
 		sleep 1
 		i=$((i+1))
 	done
-	[ "$got" -eq 1 ] || { log_msg "FAILED"; exit 1; }
+	[ "$got" -eq 1 ] || { log_msg "FAILED"; false; }
 	log_msg "SUCCESS"
 
 	# Pass full status to the verify function


### PR DESCRIPTION
Previously, if certain bats helper functions failed, they would log a
message and "exit 1". This was incorrect since "exit 1" caused the
script to exit, meaning the bats framework was unaware that an error
had occured. The result was that no error output would be produced for
failing tests.

Replacing the "exit 1" with a call to false(1) results in the correct
behaviour since bats notices the failing assertion triggered by the
false result and displays the error as expected, before failing the
test.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>