### PR TITLE
exec: Add support for runtime exec command

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -417,7 +417,7 @@ handle_option_user (const gchar *option_name,
 	}
 
 	/* gid is optional */
-	if (ids+1 && *(ids+1)) {
+	if ((ids+1) != NULL && *(ids+1) != NULL) {
 		/* copy gid */
 		strgid = *(ids+1);
 		gid = g_ascii_strtoll (strgid, &endptr,	10);

--- a/src/command.h
+++ b/src/command.h
@@ -64,7 +64,8 @@ struct subcommand
 };
 
 /*!
- * Data used to create and start a container.
+ * Data used to create and start a container
+ * or execute a new workload.
  *
  * This structure is used to simplify command-line parsing for various
  * similar sub-commands. Values are eventually added to a \ref
@@ -76,6 +77,8 @@ struct start_data {
 	gchar *pid_file;
 	gboolean detach;
 	gboolean dry_run_mode;
+	gboolean  allocate_tty;
+	struct oci_cfg_user  user;
 };
 
 gboolean handle_command_toggle (const struct subcommand *sub,
@@ -89,6 +92,10 @@ gboolean handle_command_setup (const struct subcommand *sub,
 		int argc, char *argv[]);
 gboolean handle_default_usage (int argc, char *argv[], const char *cmd, gboolean *ret, int min_argc, const char *extra);
 gboolean handle_option_console (const gchar *option_name,
+		const gchar *value,
+		gpointer data,
+		GError **error);
+gboolean handle_option_user (const gchar *option_name,
 		const gchar *value,
 		gpointer data,
 		GError **error);

--- a/src/commands/exec.c
+++ b/src/commands/exec.c
@@ -20,6 +20,118 @@
 
 #include "command.h"
 
+/*
+ * Minimum permitted args for exec command
+ * Only one is required ( container id )
+ * exec can be done using:
+ * - runtime exec [options] container_id cmd args
+ * - runtime exec [options] -p process.json container_id
+ * where process.json is have a
+ * json node like \c oci_cfg_process
+ **/
+#define MIN_EXEC_ARGS 1
+
+extern struct start_data start_data;
+
+struct oci_cfg_process process;
+
+gchar    *cwd          = NULL;
+gchar    *process_json = NULL;
+
+/* Not supported flags */
+/* clear containers does not support apparmor*/
+gchar    *apparmor       = NULL;
+gchar    *cap            = NULL;
+/* clear containers does not support SELINUX*/
+gchar    *process_label  = NULL;
+gboolean  no_new_privs   = false;
+gboolean *no_subreaper   = NULL;
+
+
+/* ignore -pedantic to cast handle_option_console
+ * and  handle_option_user, a function pointer, to a
+ * void* */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+static GOptionEntry options_exec[] =
+{
+	{
+		"apparmor", 0, G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_STRING, &apparmor,
+		/* clear containers does not support apparmor */
+		"not implemented",
+		NULL
+	},
+	{
+		"cap", 'c', G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_STRING, &cap,
+		"not implemented",
+		NULL
+	},
+	{
+		"console", 0, G_OPTION_FLAG_OPTIONAL_ARG,
+		G_OPTION_ARG_CALLBACK, handle_option_console,
+		"set pty console that will by the exec workload",
+		NULL
+	},
+	{
+		"cwd", 0, G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_STRING, &cwd,
+		"current working directory to run the exec workload",
+		NULL
+	},
+	{
+		"detach", 'd' , G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_NONE, &start_data.detach,
+		"exec process in detach mode",
+		NULL
+	},
+	{
+		"env", 'e', G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_STRING_ARRAY, &process.env,
+		"in the container",
+		NULL
+	},
+	{
+		"no-new-privs", 0, G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_NONE, &no_new_privs,
+		"not implemented",
+		NULL
+	},
+	{
+		"no-subreaper", 0, G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_NONE, &no_subreaper,
+		"not implemented",
+		NULL
+	},
+	{
+		"pid-file", 0, G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_STRING, &start_data.pid_file,
+		"the file to write the process ID of the new "
+		"process executed in the container",
+		NULL
+	},
+	{
+		"process", 'p' , G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_STRING, &process_json,
+		"specify path to process.json",
+		NULL
+	},
+	{
+		"tty", '0' , G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_NONE, &start_data.allocate_tty,
+		"allocate a pseudo-TTY for the new exec process",
+		NULL
+	},
+	{
+		"user", 'u' , G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_CALLBACK, handle_option_user,
+		"<uid>[:<gid>], UID for the process to run in format",
+		NULL
+	},
+	{NULL}
+};
+
 static gboolean
 handler_exec (const struct subcommand *sub,
 		struct cc_oci_config *config,
@@ -27,13 +139,13 @@ handler_exec (const struct subcommand *sub,
 {
 	struct oci_state  *state = NULL;
 	gchar             *config_file = NULL;
-	gboolean           ret;
+	gboolean           ret = false;
 
 	g_assert (sub);
 	g_assert (config);
 
 	if (handle_default_usage (argc, argv, sub->name,
-				&ret, 2, "<cmd> [args]")) {
+				&ret, MIN_EXEC_ARGS, "<cmd> [args]")) {
 		return ret;
 	}
 
@@ -42,6 +154,22 @@ handler_exec (const struct subcommand *sub,
 
 	/* Jump over the container name */
 	argv++; argc--;
+
+	if ( argc == 0  && ! process_json) {
+		g_print ("Usage: %s <container-id> <cmd> [args]\n",
+			sub->name);
+		goto out;
+	}
+
+	process.user.uid = start_data.user.uid;
+	process.user.gid = start_data.user.gid;
+	if (cwd){
+		if (snprintf(process.cwd,sizeof(process.cwd),
+		    "%s", cwd) < 0) {
+			g_critical("failed to copy process cwd");
+		}
+
+	}
 
 	ret = cc_oci_get_config_and_state (&config_file, config, &state);
 	if (! ret) {
@@ -58,6 +186,18 @@ handler_exec (const struct subcommand *sub,
 out:
 	g_free_if_set (config_file);
 	cc_oci_state_free (state);
+	g_free_if_set (apparmor);
+	g_free_if_set (cap);
+	g_free_if_set (cwd);
+	g_free_if_set (process_json);
+	g_free_if_set (process_label);
+	if (config->oci.process.args) {
+		g_strfreev (config->oci.process.args);
+	}
+
+	if (config->oci.process.env) {
+		g_strfreev (config->oci.process.env);
+	}
 
 	return ret;
 }
@@ -65,6 +205,7 @@ out:
 struct subcommand command_exec =
 {
 	.name        = "exec",
+	.options     = options_exec,
 	.handler     = handler_exec,
 	.description = "execute a new task inside an existing container",
 };

--- a/src/commands/exec.c
+++ b/src/commands/exec.c
@@ -183,7 +183,7 @@ handler_exec (const struct subcommand *sub,
 		goto out;
 	}
 
-	ret = cc_oci_exec (config, state, &process);
+	ret = cc_oci_exec (config, state, &process, process_json);
 	if (! ret) {
 		goto out;
 	}
@@ -198,6 +198,7 @@ out:
 	g_free_if_set (cwd);
 	g_free_if_set (process_json);
 	g_free_if_set (process_label);
+	g_free_if_set (process_json);
 	if (config->oci.process.args) {
 		g_strfreev (config->oci.process.args);
 	}

--- a/src/commands/exec.c
+++ b/src/commands/exec.c
@@ -199,13 +199,6 @@ out:
 	g_free_if_set (process_json);
 	g_free_if_set (process_label);
 	g_free_if_set (process_json);
-	if (config->oci.process.args) {
-		g_strfreev (config->oci.process.args);
-	}
-
-	if (config->oci.process.env) {
-		g_strfreev (config->oci.process.env);
-	}
 
 	return ret;
 }

--- a/src/commands/exec.c
+++ b/src/commands/exec.c
@@ -168,7 +168,14 @@ handler_exec (const struct subcommand *sub,
 		    "%s", cwd) < 0) {
 			g_critical("failed to copy process cwd");
 		}
+	}
 
+	if (argc > 0){
+		/* +1 NULL */
+		process.args = g_new0 (gchar *, (gsize) argc + 1 );
+		for ( int i = 0; i < argc ; i++){
+			process.args[i] = g_strdup(argv[i]);
+		}
 	}
 
 	ret = cc_oci_get_config_and_state (&config_file, config, &state);
@@ -176,7 +183,7 @@ handler_exec (const struct subcommand *sub,
 		goto out;
 	}
 
-	ret = cc_oci_exec (config, state, argc, argv);
+	ret = cc_oci_exec (config, state, &process);
 	if (! ret) {
 		goto out;
 	}

--- a/src/commands/exec.c
+++ b/src/commands/exec.c
@@ -187,6 +187,9 @@ handler_exec (const struct subcommand *sub,
 		goto out;
 	}
 
+	g_free_if_set(config->console);
+	config->console = g_strdup(start_data.console);
+
 	ret = cc_oci_exec (config, state, process_json);
 	if (! ret) {
 		goto out;

--- a/src/oci.c
+++ b/src/oci.c
@@ -1205,23 +1205,22 @@ out:
 gboolean
 cc_oci_exec (struct cc_oci_config *config,
 		struct oci_state *state,
-		struct oci_cfg_process *process,
 		const gchar *process_json)
 {
 	gboolean ret = false;
 
-	if (! (config && state && process)) {
+	if (! (config && state)) {
 		return false;
 	}
 
 	if (process_json){
 		if(! cc_oci_process_exec_file(process_json,
-					process)) {
+					&config->oci.process)) {
 			goto out;
 		}
 	}
 
-	if (! cc_oci_vm_connect (config, process)) {
+	if (! cc_oci_vm_connect (config)) {
 		g_critical ("failed to connect to VM");
 		goto out;
 	}

--- a/src/oci.c
+++ b/src/oci.c
@@ -1165,7 +1165,7 @@ cc_oci_process_exec_file (const gchar *process_json,
 	 * use \ref cc_oci_config to parse
 	 * the json file from --process option
 	 **/
-	struct cc_oci_config *process_config = NULL;
+	struct cc_oci_config process_config = { { 0 } };
 	GNode *root = NULL;
 	gboolean ret = false;
 
@@ -1180,24 +1180,12 @@ cc_oci_process_exec_file (const gchar *process_json,
 	cc_oci_node_dump (root);
 #endif /*DEBUG*/
 
-	process_config = g_malloc0 (sizeof (struct cc_oci_config));
-	if (! process_config){
-		goto out;
-	}
-
-	process_config->oci.process = *process;
-	process_spec_handler.handle_section(root, process_config);
-	*process = process_config->oci.process;
+	process_config.oci.process = *process;
+	process_spec_handler.handle_section(root, &process_config);
+	*process = process_config.oci.process;
 
 	ret = true;
 out:
-
-	/* Only process_config.oci.process data has handled
-	 * just free process_config pointer
-	 * process_config.oci.processprocess was copied to
-	 * process param pointer.
-	 * */
-	g_free (process_config);
 	g_free_node(root);
 
 	return ret;

--- a/src/oci.c
+++ b/src/oci.c
@@ -1225,6 +1225,14 @@ cc_oci_exec (struct cc_oci_config *config,
 		goto out;
 	}
 
+	if (start_data.pid_file) {
+		ret = cc_oci_create_pidfile (start_data.pid_file,
+				config->state.workload_pid);
+		if (! ret) {
+			goto out;
+		}
+	}
+
 	ret = true;
 out:
 	return ret;

--- a/src/oci.c
+++ b/src/oci.c
@@ -1154,22 +1154,20 @@ cc_oci_toggle (struct cc_oci_config *config,
  *
  * \param config \ref cc_oci_config.
  * \param state \ref oci_state.
- * \param argc Argument count.
- * \param argv Argument vector.
+ * \param process \ref oci_cfg_process.
  *
  * \return \c true on success, else \c false.
  */
 gboolean
 cc_oci_exec (struct cc_oci_config *config,
 		struct oci_state *state,
-		int argc,
-		char *const argv[])
+		struct oci_cfg_process *process)
 {
-	if (! (config && state && argc && argv)) {
+	if (! (config && state && process)) {
 		return false;
 	}
 
-	if (! cc_oci_vm_connect (config, argc, argv)) {
+	if (! cc_oci_vm_connect (config, process)) {
 		g_critical ("failed to connect to VM");
 		return false;
 	}

--- a/src/oci.h
+++ b/src/oci.h
@@ -591,7 +591,7 @@ gboolean cc_oci_toggle (struct cc_oci_config *config,
 		struct oci_state *state, gboolean pause);
 gboolean cc_oci_exec (struct cc_oci_config *config,
 		struct oci_state *state,
-		int argc, char *const args[]);
+		struct oci_cfg_process *process);
 gboolean cc_oci_list (struct cc_oci_config *config,
 		const gchar *format, gboolean show_all);
 gboolean cc_oci_delete (struct cc_oci_config *config,

--- a/src/oci.h
+++ b/src/oci.h
@@ -126,9 +126,6 @@
 /** Shell to use for \ref CC_OCI_WORKLOAD_FILE. */
 #define CC_OCI_WORKLOAD_SHELL		"/bin/sh"
 
-/** Command to use to allow "exec" to connect to the container. */
-#define CC_OCI_EXEC_CMD               "ssh"
-
 /** File that contains vm spec configuration, used if vm node
  * in CC_OCI_CONFIG_FILE bundle file
 */

--- a/src/oci.h
+++ b/src/oci.h
@@ -591,7 +591,8 @@ gboolean cc_oci_toggle (struct cc_oci_config *config,
 		struct oci_state *state, gboolean pause);
 gboolean cc_oci_exec (struct cc_oci_config *config,
 		struct oci_state *state,
-		struct oci_cfg_process *process);
+		struct oci_cfg_process *process,
+		const gchar *process_json);
 gboolean cc_oci_list (struct cc_oci_config *config,
 		const gchar *format, gboolean show_all);
 gboolean cc_oci_delete (struct cc_oci_config *config,

--- a/src/oci.h
+++ b/src/oci.h
@@ -591,7 +591,6 @@ gboolean cc_oci_toggle (struct cc_oci_config *config,
 		struct oci_state *state, gboolean pause);
 gboolean cc_oci_exec (struct cc_oci_config *config,
 		struct oci_state *state,
-		struct oci_cfg_process *process,
 		const gchar *process_json);
 gboolean cc_oci_list (struct cc_oci_config *config,
 		const gchar *format, gboolean show_all);

--- a/src/process.c
+++ b/src/process.c
@@ -1416,7 +1416,7 @@ cc_oci_exec_shim (struct cc_oci_config *config,
 	*/
 
 	if (! cc_proxy_cmd_allocate_io(config->proxy,
-			&proxy_io_fd, &ioBase)) {
+			&proxy_io_fd, &ioBase, process->terminal)) {
 		goto out;
 	}
 
@@ -1428,8 +1428,8 @@ cc_oci_exec_shim (struct cc_oci_config *config,
 	}
 
 	/* save ioBase */
-	config->oci.process.stdio_stream = ioBase;
-	config->oci.process.stderr_stream = ioBase + 1;
+	process->stdio_stream = ioBase;
+	process->stderr_stream = ioBase + 1;
 
 	/*
 	 * 3. The child blocks waiting for a write proxy IO fd to shim_socket_fd.
@@ -1510,12 +1510,22 @@ cc_oci_vm_connect (struct cc_oci_config *config,
 	if (! cc_proxy_connect (config->proxy)) {
 		goto out;
 	}
+
 	if (! cc_proxy_attach (config->proxy, config->optarg_container_id)) {
 		goto out;
 	}
+
 	if (! cc_oci_exec_shim (config, process)) {
 		goto out;
 	}
+
+	if (! cc_proxy_hyper_exec_command (config, process)) {
+		goto out;
+	}
+
+	//if (cc_oci_exec_have_to_wait()) {
+		/* FIXME: wait exec-shim or qemu finish */
+	//}
 
 #if 0
 	/* create a new main loop */

--- a/src/process.c
+++ b/src/process.c
@@ -1352,19 +1352,15 @@ exit:
  * Create a connection to the VM, run a command and disconnect.
  *
  * \param config \ref cc_oci_config.
- * \param argc Argument count.
- * \param argv Argument vector.
+ * \param process \ref oci_cfg_process
  *
  * \return \c true on success, else \c false.
  */
 gboolean
 cc_oci_vm_connect (struct cc_oci_config *config,
-		int argc,
-		char *const argv[]) {
-	gchar     **args = NULL;
+		struct oci_cfg_process *process)
+{
 	gboolean    ret = false;
-	guint       args_len = 0;
-	gboolean    cmd_is_just_shell = false;
 #if 0
 	GError     *err = NULL;
 	GPid        pid;
@@ -1377,9 +1373,7 @@ cc_oci_vm_connect (struct cc_oci_config *config,
 #endif
 
 	g_assert (config);
-	g_assert (argc);
-	g_assert (argv);
-
+	g_assert (process);
 #if 0
 	/* create a new main loop */
 	main_loop = g_main_loop_new (NULL, 0);
@@ -1406,17 +1400,13 @@ cc_oci_vm_connect (struct cc_oci_config *config,
 		goto out;
 	}
 
-	ret = true;
 #else
 	g_critical ("not implemented yet");
-	ret = false;
+	goto out;
 #endif
 
+	ret = true;
 out:
-	if (args) {
-		g_strfreev (args);
-	}
-
 	if (main_loop) {
 		g_main_loop_unref (main_loop);
 		main_loop = NULL;

--- a/src/process.c
+++ b/src/process.c
@@ -1552,10 +1552,6 @@ cc_oci_vm_connect (struct cc_oci_config *config)
 		/* failed */
 		goto out;
 	}
-
-#else
-	g_critical ("not implemented yet");
-	goto out;
 #endif
 
 	ret = true;

--- a/src/process.c
+++ b/src/process.c
@@ -69,56 +69,6 @@
 static GMainLoop* main_loop = NULL;
 private GMainLoop* hook_loop = NULL;
 
-/** List of shells that are recognised by "exec", ordered by likelihood. */
-static const gchar *recognised_shells[] =
-{
-	"sh",
-	"bash",
-	"zsh",
-	"ksh",
-	"csh",
-
-	/* terminator */
-	NULL,
-};
-
-/*!
- * Determine if \p cmd is a shell.
- *
- * \param cmd Command to check.
- *
- * \return \c true on success, else \c false.
- */
-private gboolean
-cc_oci_cmd_is_shell (const char *cmd)
-{
-	const gchar **shell;
-
-	if (! cmd) {
-		return false;
-	}
-
-	for (shell = (const gchar **)recognised_shells;
-			shell && *shell;
-			shell++) {
-		g_autofree gchar *suffix = NULL;
-
-		if (! g_strcmp0 (*shell, cmd)) {
-			/* exact match */
-			return true;
-		}
-
-		suffix = g_strdup_printf ("/%s", *shell);
-
-		if (g_str_has_suffix (cmd, suffix)) {
-			/* full path to shell was specified */
-			return true;
-		}
-	}
-
-	return false;
-}
-
 /*!
  * Close file descriptors, excluding standard streams.
  *
@@ -1430,74 +1380,7 @@ cc_oci_vm_connect (struct cc_oci_config *config,
 	g_assert (argc);
 	g_assert (argv);
 
-	/* Check if the user has specified a shell to run.
-	 *
-	 * FIXME: This is a pragmatic (but potentially unreliable) solution
-	 * FIXME:   if the user wants to run an unknown shell.
-	 */
-	if (cc_oci_cmd_is_shell (argv[0])) {
-		cmd_is_just_shell = true;
-	}
-
-	/* The user wants to run an interactive shell.
-	 * However, this is the default with ssh if no command is
-	 * specified.
-	 *
-	 * If a shell is passed as the 1st arg, ssh gets
-	 * confused as it's expecting to run a non-interactive command,
-	 * so simply remove it to get the behaviour the user wants.
-	 *
-	 * An extra check is performed to ensure that the argument after
-	 * the shell is not an option to ensure that commands like:
-	 * "bash -c ..." still work as expected.
-	 */
-	if (argv[1] && argv[1][0] == '-') {
-		cmd_is_just_shell = false;
-	}
-
-	/* Just a shell, so remove the argument to get the expected
-	 * behavior of an interactive shell.
-	 */
-	if (cmd_is_just_shell) {
-		argc--;
-		argv++;
-	}
-
-	args_len = (guint)argc;
-
-	/* +2 for CC_OCI_EXEC_CMD + hostname to connect to */
-	args_len += 2;
-
-	/* +1 for NULL terminator */
-	args = g_new0 (gchar *, args_len + 1);
-	if (! args) {
-		return false;
-	}
-
-	/* The command to use to connect to the VM */
-	args[0] = g_strdup (CC_OCI_EXEC_CMD);
-	if (! args[0]) {
-		ret = false;
-		goto out;
-	}
-
-	/* connection string to connect to the VM */
-	// FIXME: replace with proper connection string once networking details available.
 #if 0
-	args[1] = g_strdup_printf (ip_address);
-
-	/* append argv to the end of args */
-	if (argc) {
-		for (i = 0; i < args_len; ++i) {
-			args[i+2] = g_strdup (argv[i]);
-		}
-	}
-
-	g_debug ("running command:");
-	for (gchar** p = args; p && *p; p++) {
-		g_debug ("arg: '%s'", *p);
-	}
-
 	/* create a new main loop */
 	main_loop = g_main_loop_new (NULL, 0);
 	if (! main_loop) {
@@ -1505,26 +1388,9 @@ cc_oci_vm_connect (struct cc_oci_config *config,
 		goto out;
 	}
 
-	ret = g_spawn_async_with_pipes (NULL, /* working directory */
-			args,
-			NULL, /* inherit parents environment */
-			flags,
-			(GSpawnChildSetupFunc)cc_oci_close_fds,
-			NULL, /* user_data */
-			&pid,
-			NULL, /* standard_input */
-			NULL, /* standard_output */
-			NULL, /* standard_error */
-			&err);
+	/* FIXME: launch shim */
 
-	if (! ret) {
-		g_critical ("failed to spawn child process (%s): %s",
-				args[0], err->message);
-		g_error_free (err);
-		goto out;
-	}
-
-	g_debug ("child process ('%s') running with pid %u",
+	g_debug ("shim process ('%s') running with pid %u",
 			args[0], (unsigned)pid);
 
 	g_child_watch_add (pid, cc_oci_child_watcher, &exit_code);

--- a/src/process.c
+++ b/src/process.c
@@ -1358,8 +1358,7 @@ exit:
  * \return \c true on success, else \c false.
  */
 gboolean
-cc_oci_exec_shim (struct cc_oci_config *config,
-		struct oci_cfg_process *process) {
+cc_oci_exec_shim (struct cc_oci_config *config) {
 
 	gboolean           ret = false;
 	GSocketConnection *shim_socket_connection = NULL;
@@ -1373,7 +1372,7 @@ cc_oci_exec_shim (struct cc_oci_config *config,
 	int                ioBase = -1;
 	GError            *error = NULL;
 
-	if(! (config && process)){
+	if(! config){
 		return false;
 	}
 
@@ -1414,8 +1413,8 @@ cc_oci_exec_shim (struct cc_oci_config *config,
 	}
 
 	/* save ioBase */
-	process->stdio_stream = ioBase;
-	process->stderr_stream = ioBase + 1;
+	config->oci.process.stdio_stream = ioBase;
+	config->oci.process.stderr_stream = ioBase + 1;
 
 	/*
 	 * 3. The child blocks waiting for a write proxy IO fd to shim_socket_fd.
@@ -1479,8 +1478,7 @@ out:
  * \return \c true on success, else \c false.
  */
 gboolean
-cc_oci_vm_connect (struct cc_oci_config *config,
-		struct oci_cfg_process *process)
+cc_oci_vm_connect (struct cc_oci_config *config)
 {
 	gboolean    ret = false;
 #if 0
@@ -1494,7 +1492,7 @@ cc_oci_vm_connect (struct cc_oci_config *config,
 	guint i;
 #endif
 
-	if(! (config && process)){
+	if(! config){
 		goto out;
 	}
 
@@ -1506,11 +1504,11 @@ cc_oci_vm_connect (struct cc_oci_config *config,
 		goto out;
 	}
 
-	if (! cc_oci_exec_shim (config, process)) {
+	if (! cc_oci_exec_shim (config)) {
 		goto out;
 	}
 
-	if (! cc_proxy_hyper_exec_command (config, process)) {
+	if (! cc_proxy_hyper_exec_command (config)) {
 		goto out;
 	}
 

--- a/src/process.h
+++ b/src/process.h
@@ -26,7 +26,6 @@ gboolean cc_oci_vm_launch (struct cc_oci_config *config);
 gboolean cc_run_hooks(GSList* hooks, const gchar* state_file_path,
                        gboolean stop_on_failure);
 
-gboolean cc_oci_vm_connect (struct cc_oci_config *config,
-		struct oci_cfg_process *process);
+gboolean cc_oci_vm_connect (struct cc_oci_config *config);
 
 #endif /* _CC_OCI_PROCESS_H */

--- a/src/process.h
+++ b/src/process.h
@@ -27,6 +27,6 @@ gboolean cc_run_hooks(GSList* hooks, const gchar* state_file_path,
                        gboolean stop_on_failure);
 
 gboolean cc_oci_vm_connect (struct cc_oci_config *config,
-		int argc, char *const argv[]);
+		struct oci_cfg_process *process);
 
 #endif /* _CC_OCI_PROCESS_H */

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -675,7 +675,7 @@ out:
  *
  * \return \c true on success, else \c false.
  */
-static gboolean
+gboolean
 cc_proxy_attach (struct cc_proxy *proxy, const char *container_id)
 {
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1454,14 +1454,14 @@ out:
  * \return \c true on success, else \c false.
  */
 gboolean
-cc_proxy_hyper_exec_command (struct cc_oci_config *config,
-		struct oci_cfg_process *process)
+cc_proxy_hyper_exec_command (struct cc_oci_config *config)
 {
 	JsonObject *payload= NULL;
 	JsonObject *process_node = NULL;
 	JsonArray *args= NULL;
 	JsonArray *envs= NULL;
 	gboolean ret = false;
+	struct oci_cfg_process *process = &config->oci.process;
 
 	if (! (config && config->proxy)) {
 		goto out;

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1444,3 +1444,88 @@ out:
 
 	return ret;
 }
+
+/**
+ * Request \ref CC_OCI_PROXY to execute a workload in a container.
+ *
+ * \param config \ref cc_oci_config.
+ * \param process \ref oci_cfg_process.
+ *
+ * \return \c true on success, else \c false.
+ */
+gboolean
+cc_proxy_hyper_exec_command (struct cc_oci_config *config,
+		struct oci_cfg_process *process)
+{
+	JsonObject *payload= NULL;
+	JsonObject *process_node = NULL;
+	JsonArray *args= NULL;
+	JsonArray *envs= NULL;
+	gboolean ret = false;
+
+	if (! (config && config->proxy)) {
+		goto out;
+	}
+
+	if (process->stdio_stream < 0  ||
+			process->stderr_stream < 0 ) {
+		g_critical("invalid io stream number");
+		goto out;
+	}
+
+	payload = json_object_new ();
+	process_node  = json_object_new ();
+	args     = json_array_new ();
+	envs     = json_array_new ();
+
+	json_object_set_string_member (payload, "container",
+			config->optarg_container_id);
+
+	/* execcmd.process */
+	json_object_set_boolean_member(process_node, "terminal",
+			config->oci.process.terminal);
+
+	json_object_set_int_member (process_node, "stdio",
+			process->stdio_stream);
+	json_object_set_int_member (process_node, "stderr",
+			process->stderr_stream);
+
+	for (gchar** p = process->args; p && *p; p++) {
+		json_array_add_string_element (args, *p);
+	}
+
+	set_env_home(config);
+	for (gchar** p = process->env; p && *p; p++) {
+		JsonObject *env_var = json_object_new ();
+		g_autofree char *var = g_strdup(*p);
+
+		char *e = g_strstr_len (var, -1, "=");
+		if (! e ){
+			g_critical("failed to split enviroment variable value");
+			goto out;
+		}
+		*e = '\0';
+		e++;
+		json_object_set_string_member (env_var, "value", e);
+		json_object_set_string_member (env_var, "env", var);
+		json_array_add_object_element (envs, env_var);
+	}
+
+	json_object_set_string_member (process_node, "workdir", process->cwd);
+	json_object_set_array_member (process_node, "args", args);
+	json_object_set_array_member (process_node, "envs", envs);
+	json_object_set_object_member (payload,
+			"process", process_node);
+
+	if (! cc_proxy_run_hyper_cmd (config, "execcmd", payload)) {
+		g_critical("failed to run execcmd");
+		goto out;
+	}
+
+	ret = true;
+out:
+	if (payload) {
+		json_object_unref (payload);
+	}
+	return ret;
+}

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -41,6 +41,5 @@ gboolean cc_proxy_hyper_destroy_pod (struct cc_oci_config *config);
 gboolean cc_proxy_hyper_new_container (struct cc_oci_config *config);
 void cc_proxy_free (struct cc_proxy *proxy);
 gboolean cc_proxy_attach (struct cc_proxy *proxy, const char *container_id);
-gboolean cc_proxy_hyper_exec_command (struct cc_oci_config *config,
-		struct oci_cfg_process *process);
+gboolean cc_proxy_hyper_exec_command (struct cc_oci_config *config);
 #endif /* _CC_OCI_PROXY_H */

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -40,5 +40,6 @@ cc_proxy_hyper_kill_container (struct cc_oci_config *config, int signum);
 gboolean cc_proxy_hyper_destroy_pod (struct cc_oci_config *config);
 gboolean cc_proxy_hyper_new_container (struct cc_oci_config *config);
 void cc_proxy_free (struct cc_proxy *proxy);
+gboolean cc_proxy_attach (struct cc_proxy *proxy, const char *container_id);
 
 #endif /* _CC_OCI_PROXY_H */

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -41,5 +41,6 @@ gboolean cc_proxy_hyper_destroy_pod (struct cc_oci_config *config);
 gboolean cc_proxy_hyper_new_container (struct cc_oci_config *config);
 void cc_proxy_free (struct cc_proxy *proxy);
 gboolean cc_proxy_attach (struct cc_proxy *proxy, const char *container_id);
-
+gboolean cc_proxy_hyper_exec_command (struct cc_oci_config *config,
+		struct oci_cfg_process *process);
 #endif /* _CC_OCI_PROXY_H */

--- a/tests/integration/docker/exec.bats
+++ b/tests/integration/docker/exec.bats
@@ -30,7 +30,6 @@ setup() {
 }
 
 @test "modifying a container with exec" {
-	skip "exec is still not working (see https://github.com/01org/cc-oci-runtime/issues/18)"
 	$DOCKER_EXE run --name containertest -d ubuntu bash -c "sleep 50"
 	$DOCKER_EXE ps -a | grep "sleep 50"
 	$DOCKER_EXE exec -d containertest bash -c "echo 'hello world' > file"
@@ -38,34 +37,31 @@ setup() {
 }
 
 @test "exec a container with privileges" {
-	skip "exec is still not working (see https://github.com/01org/cc-oci-runtime/issues/18)"
 	$DOCKER_EXE run -d --name containertest ubuntu bash -c "sleep 30"
 	$DOCKER_EXE exec -i --privileged containertest bash -c "mount -t tmpfs none /mnt"
 	$DOCKER_EXE exec containertest bash -c "df -h | grep "/mnt""
 }
 
 @test "copying file from host to container using exec" {
-	skip "exec is still not working (see https://github.com/01org/cc-oci-runtime/issues/18)"
+	skip "Read from external pipe does not work (https://github.com/01org/cc-oci-runtime/issues/506)"
 	content="hello world"
 	$DOCKER_EXE run --name containertest -d ubuntu bash -c "sleep 30"
 	echo $content | $DOCKER_EXE exec -i containertest bash -c "cat > /home/file.txt"
-	$DOCKER_EXE exec -i containertest bash -c "cat /home/file.txt" | grep "hello world"
+	$DOCKER_EXE exec -i containertest bash -c "cat /home/file.txt" | grep "$content"
 }
 
 @test "stdout forwarded using exec" {
-	skip "exec is still not working (see https://github.com/01org/cc-oci-runtime/issues/18 and https://github.com/01org/cc-oci-runtime/issues/171)"
 	$DOCKER_EXE run --name containertest -d ubuntu bash -c "sleep 30"
-	$DOCKER_EXE exec containertest ls /etc/resolv.conf 2>/dev/null | grep "/etc/resolv.conf" 
+	$DOCKER_EXE exec -ti containertest ls /etc/resolv.conf 2>/dev/null | grep "/etc/resolv.conf" 
 }
 
 @test "stderr forwarded using exec" {
-        skip "exec is still not working (see https://github.com/01org/cc-oci-runtime/issues/18 and https://github.com/01org/cc-oci-runtime/issues/171)"
+        skip "stderr forwarded does not work"
         $DOCKER_EXE run --name containertest -d ubuntu bash -c "sleep 30"
         if $DOCKER_EXE exec containertest ls /etc/foo >/dev/null; then false; else true; fi	
 }
 
 @test "check exit code using exec" {
-	skip "exec is still not working (see https://github.com/01org/cc-oci-runtime/issues/18)"
 	$DOCKER_EXE run --name containertest -d ubuntu bash -c "sleep 30"
 	run $DOCKER_EXE exec containertest bash -c "exit 42"
 	[ "$status" -eq 42 ]

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -1090,10 +1090,10 @@ START_TEST(test_cc_oci_process_to_json) {
 START_TEST(test_cc_oci_exec) {
 	struct cc_oci_config config;
 	struct oci_state state;
-	struct oci_cfg_process process;
-	ck_assert(! cc_oci_exec(NULL, NULL, NULL, NULL));
-	ck_assert(! cc_oci_exec(&config, &state, NULL , NULL));
-	ck_assert(! cc_oci_exec(&config, &state, &process, NULL));
+	char  *process_json = NULL;
+	ck_assert(! cc_oci_exec(NULL, NULL, NULL));
+	ck_assert(! cc_oci_exec(&config, &state, NULL));
+	ck_assert(! cc_oci_exec(&config, &state, process_json));
 } END_TEST
 
 START_TEST(test_cc_oci_toggle) {

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -1091,9 +1091,9 @@ START_TEST(test_cc_oci_exec) {
 	struct cc_oci_config config;
 	struct oci_state state;
 	struct oci_cfg_process process;
-	ck_assert(! cc_oci_exec(NULL, NULL, NULL));
-	ck_assert(! cc_oci_exec(&config, &state, NULL));
-	ck_assert(! cc_oci_exec(&config, &state, &process));
+	ck_assert(! cc_oci_exec(NULL, NULL, NULL, NULL));
+	ck_assert(! cc_oci_exec(&config, &state, NULL , NULL));
+	ck_assert(! cc_oci_exec(&config, &state, &process, NULL));
 } END_TEST
 
 START_TEST(test_cc_oci_toggle) {

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -1090,11 +1090,10 @@ START_TEST(test_cc_oci_process_to_json) {
 START_TEST(test_cc_oci_exec) {
 	struct cc_oci_config config;
 	struct oci_state state;
-	char *argv[] = { "hello", "world" };
-	ck_assert(! cc_oci_exec(NULL, NULL, 0, NULL));
-	ck_assert(! cc_oci_exec(&config, &state, 0, NULL));
-	ck_assert(! cc_oci_exec(&config, &state, 2, NULL));
-	ck_assert(! cc_oci_exec(&config, &state, 2, argv));
+	struct oci_cfg_process process;
+	ck_assert(! cc_oci_exec(NULL, NULL, NULL));
+	ck_assert(! cc_oci_exec(&config, &state, NULL));
+	ck_assert(! cc_oci_exec(&config, &state, &process));
 } END_TEST
 
 START_TEST(test_cc_oci_toggle) {

--- a/tests/process_test.c
+++ b/tests/process_test.c
@@ -52,48 +52,6 @@ cc_shim_launch (struct cc_oci_config *config, int *child_err_fd,
 
 extern GMainLoop *hook_loop;
 
-START_TEST(test_cc_oci_cmd_is_shell) {
-
-	ck_assert (! cc_oci_cmd_is_shell (""));
-	ck_assert (! cc_oci_cmd_is_shell (NULL));
-
-	ck_assert (cc_oci_cmd_is_shell ("sh"));
-	ck_assert (cc_oci_cmd_is_shell ("/sh"));
-	ck_assert (cc_oci_cmd_is_shell ("/bin/sh"));
-	ck_assert (cc_oci_cmd_is_shell ("/usr/bin/sh"));
-	ck_assert (cc_oci_cmd_is_shell ("/usr/local/bin/sh"));
-
-	ck_assert (cc_oci_cmd_is_shell ("bash"));
-	ck_assert (cc_oci_cmd_is_shell ("/bash"));
-	ck_assert (cc_oci_cmd_is_shell ("/bin/bash"));
-	ck_assert (cc_oci_cmd_is_shell ("/usr/bin/bash"));
-	ck_assert (cc_oci_cmd_is_shell ("/usr/local/bin/bash"));
-
-	ck_assert (cc_oci_cmd_is_shell ("zsh"));
-	ck_assert (cc_oci_cmd_is_shell ("/zsh"));
-	ck_assert (cc_oci_cmd_is_shell ("/bin/zsh"));
-	ck_assert (cc_oci_cmd_is_shell ("/usr/bin/zsh"));
-	ck_assert (cc_oci_cmd_is_shell ("/usr/local/bin/zsh"));
-
-	ck_assert (cc_oci_cmd_is_shell ("ksh"));
-	ck_assert (cc_oci_cmd_is_shell ("/ksh"));
-	ck_assert (cc_oci_cmd_is_shell ("/bin/ksh"));
-	ck_assert (cc_oci_cmd_is_shell ("/usr/bin/ksh"));
-	ck_assert (cc_oci_cmd_is_shell ("/usr/local/bin/ksh"));
-
-	ck_assert (cc_oci_cmd_is_shell ("csh"));
-	ck_assert (cc_oci_cmd_is_shell ("/csh"));
-	ck_assert (cc_oci_cmd_is_shell ("/bin/csh"));
-	ck_assert (cc_oci_cmd_is_shell ("/usr/bin/csh"));
-	ck_assert (cc_oci_cmd_is_shell ("/usr/local/bin/csh"));
-
-	ck_assert (! cc_oci_cmd_is_shell ("true"));
-	ck_assert (! cc_oci_cmd_is_shell ("/true"));
-	ck_assert (! cc_oci_cmd_is_shell ("/bin/true"));
-	ck_assert (! cc_oci_cmd_is_shell ("/usr/bin/true"));
-	ck_assert (! cc_oci_cmd_is_shell ("/usr/local/bin/true"));
-
-} END_TEST
 
 START_TEST(test_cc_run_hook) {
 
@@ -291,7 +249,6 @@ START_TEST(test_cc_oci_setup_child) {
 Suite* make_process_suite(void) {
 	Suite* s = suite_create(__FILE__);
 
-	ADD_TEST(test_cc_oci_cmd_is_shell, s);
 	ADD_TEST(test_cc_run_hook, s);
 	ADD_TEST(test_cc_oci_setup_shim, s);
 	ADD_TEST(test_socket_connection_from_fd, s);


### PR DESCRIPTION
This PR adds support for exec command. 

- Adds support for missing command options
- launch shim for an exec workload
- adds execmd function request hyperstart to exec a new workload
- Enable skipped docker exec tests

-Missing/wip:
*Add bats tests 
*Add unit tests 
*allocate a pseudo-TTY
*use newcontainer if exec is done before start

Fixes #18 #298 