### PR TITLE
config: Provide full path to the cc-shim for invoking it.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -108,7 +108,8 @@ AM_CPPFLAGS = -I $(top_srcdir)/src -DG_LOG_DOMAIN=\"$(PACKAGE_NAME)\" \
 	-DSYSCONFDIR=\"$(SYSCONFDIR)\" \
 	-DDEFAULTSDIR=\"$(DEFAULTSDIR)\" \
 	-DLOCALSTATEDIR=\"$(localstatedir)\" \
-	-DGIT_COMMIT=\"$(STORED_COMMIT)\"
+	-DGIT_COMMIT=\"$(STORED_COMMIT)\" \
+	-DLIBEXECDIR=\"$(libexecdir)\"
 
 defaultsdir = $(datadir)/defaults/$(PACKAGE_NAME)
 defaults_DATA = data/vm.json data/hypervisor.args data/kernel-cmdline

--- a/src/oci.h
+++ b/src/oci.h
@@ -97,7 +97,7 @@
  *  - Reacts to signals.
  *  - Exits with return code of real workload process.
  */
-#define CC_OCI_SHIM 			"cc-shim"
+#define CC_OCI_SHIM                     LIBEXECDIR"/cc-shim"
 
 /** Full path to socket used to talk to \ref CC_OCI_PROXY. */
 #define CC_OCI_PROXY_SOCKET 		CC_OCI_RUNTIME_DIR_PREFIX \


### PR DESCRIPTION
cc-shim is installed under /usr/libexec as it is not meant
to be started on its own.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>