### PR TITLE
cor: Implement kill container and destroy pod

### DIFF
--- a/src/oci.c
+++ b/src/oci.c
@@ -1180,12 +1180,13 @@ gboolean
 cc_oci_stop (struct cc_oci_config *config,
 		struct oci_state *state)
 {
-	g_assert (config);
-	g_assert (state);
+	if (! (config && state)){
+		return false;
+	}
 
 	if (cc_oci_vm_running (state)) {
 		gboolean ret;
-		ret = cc_oci_vm_shutdown (state->comms_path, state->vm->pid);
+		ret = cc_proxy_hyper_destroy_pod(config);
 		if (! ret) {
 			return false;
 		}

--- a/src/oci.c
+++ b/src/oci.c
@@ -236,6 +236,13 @@ cc_oci_kill (struct cc_oci_config *config,
 		goto error;
 	}
 
+#ifndef UNIT_TESTING
+	if (! cc_proxy_hyper_kill_container(config, signum)) {
+		g_critical("failed to kill container");
+		goto error;
+	}
+#else
+	//FIXME: should we kill to cc-shim?
 	if (kill (state->pid, signum) < 0) {
 		g_critical ("failed to stop container %s "
 				"running with pid %u: %s",
@@ -249,6 +256,7 @@ cc_oci_kill (struct cc_oci_config *config,
 		}
 		return false;
 	}
+#endif //UNIT_TESTING
 
 	last_status = config->state.status;
 
@@ -1192,8 +1200,6 @@ cc_oci_stop (struct cc_oci_config *config,
 				"not running",
 				state->id, state->pid);
 	}
-
-	cc_proxy_connect(config->proxy);
 
 	/* Allow the proxy to clean up resources */
 	if (! cc_proxy_cmd_bye (config->proxy, config->optarg_container_id)) {

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -35,6 +35,9 @@ gboolean cc_proxy_hyper_pod_create (struct cc_oci_config *config);
 gboolean cc_proxy_cmd_bye (struct cc_proxy *proxy, const char *container_id);
 gboolean cc_proxy_cmd_allocate_io (struct cc_proxy *proxy, int *proxy_io_fd,
 		int *ioBase, bool tty);
+gboolean
+cc_proxy_hyper_kill_container (struct cc_oci_config *config, int signum);
+gboolean cc_proxy_hyper_destroy_pod (struct cc_oci_config *config);
 gboolean cc_proxy_hyper_new_container (struct cc_oci_config *config);
 void cc_proxy_free (struct cc_proxy *proxy);
 


### PR DESCRIPTION
This patch adds kill container and destroy pod
functionalities using hyperstart commands
(killcontainer and destroypod)

Signed-off-by: Julio Montes <julio.montes@intel.com>