### PR TITLE
proxy: Create runtime directory if needed when not started by systemd

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 
@@ -261,6 +262,10 @@ func (proxy *proxy) init() error {
 			return fmt.Errorf("couldn't listen on socket: %v", err)
 		}
 	} else {
+		socketDir := filepath.Dir(socketPath)
+		if err = os.MkdirAll(socketDir, 0750); err != nil {
+			return fmt.Errorf("couldn't create socket directory: %v", err)
+		}
 		if err = os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("couldn't remove exiting socket: %v", err)
 		}


### PR DESCRIPTION
It's expected that cc-proxy is socket activated by systemd in
production, but, the proxy also has a path where it creates the socket
itself. This is useful for debugging as it allows people to launch the
proxy from the command line directly.

Unfortunately, we were not able to create the socket in that second
path when the /run/cc-oci-runtime/ directory wasn't already created
(systemd will do that for us in the socket activated case).

Fix this by creating the /run/cc-oci-runtime directory if needed.

Fixes: https://github.com/01org/cc-oci-runtime/issues/459
Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>