### PR TITLE
proxy: Restrict access to the proxy socket a bit

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -268,7 +268,7 @@ func (proxy *proxy) init() error {
 		if err != nil {
 			return fmt.Errorf("couldn't create AF_UNIX socket: %v", err)
 		}
-		if err = os.Chmod(socketPath, 0666|os.ModeSocket); err != nil {
+		if err = os.Chmod(socketPath, 0660|os.ModeSocket); err != nil {
 			return fmt.Errorf("couldn't set mode on socket: %v", err)
 		}
 	}


### PR DESCRIPTION
When not socket activated, the proxy creates the socket itself. That
socket doesn't need to be world rw, so remove those permissions.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>