### PR TITLE
CI: Build qemu-lite with vhost support.

### DIFF
--- a/.ci/ci-setup.sh
+++ b/.ci/ci-setup.sh
@@ -301,6 +301,7 @@ then
     qemu_lite_opts+=" --enable-cap-ng"
     qemu_lite_opts+=" --enable-kvm"
     qemu_lite_opts+=" --enable-virtfs"
+    qemu_lite_opts+=" --enable-vhost-net"
     qemu_lite_opts+=" --target-list=x86_64-softmmu"
     qemu_lite_opts+=" --extra-cflags=\"-fno-semantic-interposition -O3 -falign-functions=32\""
     qemu_lite_opts+=" --prefix=\"${prefix_dir}\""


### PR DESCRIPTION
qemu-lite requires the "--enable-vhost-net" configure option.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>