### PR TITLE
CI: add test-suite.log to teardown script

### DIFF
--- a/.ci/ci-teardown.sh
+++ b/.ci/ci-teardown.sh
@@ -27,7 +27,7 @@ printf "=== Build failed ===\n"
 
 cd "$ci_build_dir"
 
-for f in $(ls *_test*.log)
+for f in test-suite.log $(ls *_test*.log)
 do
     printf "\n=== Log file: '$f' ===\n\n"
     cat "$f"


### PR DESCRIPTION
With this patch teardown script also will dump
the log generated by libcheck with more information
about failed tests

Signed-off-by: Julio Montes <julio.montes@intel.com>