### PR TITLE
ci: Add gocyclo to the build

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -73,5 +73,6 @@ go vet $go_packages
 go list -f '{{.Dir}}' $go_packages |\
     xargs gofmt -s -l | wc -l |\
     xargs -I % bash -c "test % -eq 0"
+go list -f '{{.Dir}}' $go_packages | xargs gocyclo -over 15
 
 for p in $go_packages; do golint -set_exit_status $p; done

--- a/.ci/ci-setup.sh
+++ b/.ci/ci-setup.sh
@@ -64,6 +64,7 @@ cp -r vendor/* "$GOPATH/src"
 mkdir -p "$GOPATH/src/github.com/01org/"
 ln -s $PWD "$GOPATH/src/github.com/01org/"
 
+go get github.com/fzipp/gocyclo
 go get github.com/client9/misspell/cmd/misspell
 go get github.com/golang/lint/golint
 


### PR DESCRIPTION
gocyclo computes the cyclomatic complexity in functions and makes sure
we don't go over a certain number, which would indicate the function is
too complicated and needs to be broken up.

The number 15 is taken from ciao. That looks like a fine number.

Fixes: https://github.com/01org/cc-oci-runtime/issues/353
Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>