### PR TITLE
console: Fix missing prompt when bash is run interactively.

### DIFF
--- a/src/proxy.c
+++ b/src/proxy.c
@@ -809,7 +809,8 @@ out:
 gboolean
 cc_proxy_cmd_allocate_io (struct cc_proxy *proxy,
 	int *proxy_io_fd,
-	int *ioBase )
+	int *ioBase,
+	bool tty)
 {
 	JsonObject        *obj = NULL;
 	JsonObject        *data = NULL;
@@ -834,8 +835,15 @@ cc_proxy_cmd_allocate_io (struct cc_proxy *proxy,
 
 	json_object_set_string_member (obj, "id", proxy_cmd);
 
-	json_object_set_int_member (data, "nStreams",
-		n_streams);
+	/* If run interactively, allocate just 1 stream since
+	 * stdout and stderr are both connected to the terminal
+	 */
+	if (tty) {
+		json_object_set_int_member (data, "nStreams", 1);
+	} else {
+		json_object_set_int_member (data, "nStreams",
+			n_streams);
+	}
 
 	json_object_set_object_member (obj, "data", data);
 

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -34,7 +34,7 @@ gboolean cc_proxy_wait_until_ready (struct cc_oci_config *config);
 gboolean cc_proxy_hyper_pod_create (struct cc_oci_config *config);
 gboolean cc_proxy_cmd_bye (struct cc_proxy *proxy, const char *container_id);
 gboolean cc_proxy_cmd_allocate_io (struct cc_proxy *proxy, int *proxy_io_fd,
-		int *ioBase);
+		int *ioBase, bool tty);
 gboolean cc_proxy_hyper_new_container (struct cc_oci_config *config);
 void cc_proxy_free (struct cc_proxy *proxy);
 


### PR DESCRIPTION
When we run bash in interactive mode under docker, the prompt is
not shown. We can see the prompt for other shells.

A quick test using this:
https://www.gnu.org/software/bash/manual/html_node/Is-this-Shell-Interactive_003f.html

shows that bash is not running in interactive mode causing the
systemwide startup files not being read and settings not
being applied resulting in PS1 variable to be empty.

The shell is not run in interactive mode because stderr is not
pointing to a terminal even though stdout and stdin are attached to
a tty by hypertstart. The reason being, hyperstart does not attach
the terminal to tty when the stderr sequence number is not set to 0.

Hence, allocate just one stream for the tty case, and explicitly set the
error sequence number to 0 with the "newcontainer" command.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>