### PR TITLE
create: exit from  infinite while loop

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -752,7 +752,6 @@ cc_shim_launch (struct cc_oci_config *config,
 		 */
 		while(proxy_socket_fd < 3) {
 			int fd = dup(proxy_socket_fd);
-			close(proxy_socket_fd);
 			if (fd < 0) {
 				g_critical("dup failed: %s", strerror(errno));
 				goto child_failed;
@@ -762,7 +761,6 @@ cc_shim_launch (struct cc_oci_config *config,
 
 		while(proxy_io_fd < 3) {
 			int fd = dup(proxy_io_fd);
-			close(proxy_io_fd);
 			if (fd < 0) {
 				g_critical("dup failed: %s", strerror(errno));
 				goto child_failed;


### PR DESCRIPTION
A previous patch causes a docker hang trying to 
create a container, lets unlock create command.

Description:  
File descriptos 0,1,2 are close on exec.
This allow shim use stdio fd to print and read.

The fds are duplicated until its value is more
than 2.
If close the old file descriptor, next time
dup is called will get the lowest fd , and this
could be the previous closed, causing that
runtime never exit from while loop.

After this loop exec is done, and previous duplicated
fd are close on exec.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>