### PR TITLE
Signals: Ignore SIGPIPE to avoid being killed.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -390,6 +390,15 @@ out:
 }
 
 /**
+ * Handle global setup.
+ */
+static gboolean
+setup (void)
+{
+	return cc_oci_handle_signals ();
+}
+
+/**
  * Handle cleanup.
  *
  * \param options \ref cc_log_options.
@@ -410,9 +419,15 @@ main (int argc, char **argv)
 {
 	gboolean ret;
 
+	ret = setup ();
+	if (! ret) {
+		goto out;
+	}
+
 	ret = handle_arguments (argc, argv);
 
 	cleanup (&cc_log_options);
 
+out:
 	exit (ret ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/src/process.c
+++ b/src/process.c
@@ -418,6 +418,12 @@ cc_run_hook(struct oci_cfg_hook* hook, const gchar* state,
 	if (write(std_in, container_state, state_length) < 0) {
 		g_critical ("failed to send container state to hook: %s",
 				strerror (errno));
+		/* Ignore signal since hook was probably not expecting
+		 * state to be passed via its stdin and has now exited.
+		 */
+		if (errno == EPIPE) {
+			result = true;
+		}
 		goto exit;
 	}
 
@@ -425,6 +431,9 @@ cc_run_hook(struct oci_cfg_hook* hook, const gchar* state,
 	if (write(std_in, "\n", 1) < 0) {
 		g_critical ("failed to commit container state: %s",
 				strerror (errno));
+		if (errno == EPIPE) {
+			result = true;
+		}
 		goto exit;
 	}
 

--- a/src/util.h
+++ b/src/util.h
@@ -89,5 +89,6 @@ int cc_oci_get_signum (const gchar *signame);
 gchar *cc_oci_resolve_path (const gchar *path);
 gboolean cc_oci_fd_set_cloexec (int fd);
 gboolean cc_oci_enable_networking (void);
+gboolean cc_oci_handle_signals (void);
 
 #endif /* _CC_OCI_UTIL_H */


### PR DESCRIPTION
Attempting to write to a pipe without an associated reader will
by default terminate the process. Explicitly ignore SIGPIPE to
avoid that happening.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>