### PR TITLE
proxy: Fix tracing messages for the hyper payload

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -231,7 +231,7 @@ func hyperHandler(data []byte, userData interface{}, response *handlerResponse) 
 		return
 	}
 
-	client.infof(1, "cmd=%s, data=%s)", hyper.HyperName, hyper.Data)
+	client.infof(1, "hyper(cmd=%s, data=%s)", hyper.HyperName, hyper.Data)
 
 	err := vm.SendMessage(hyper.HyperName, hyper.Data)
 	response.SetError(err)


### PR DESCRIPTION
I was missing telling the user this was the hyper payload like the other
payloads.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>