### PR TITLE
configure: Add configure option for running proxy tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -267,10 +267,13 @@ cc_proxy_extra_dist =			\
 	proxy/README.md			\
 	proxy/COPYING
 
+if PROXY_TESTS
+
 CHECK_DEPS += check-proxy
 
 check-proxy:
 	go test -v -race -timeout 2s $(srcdir)/proxy
+endif
 
 libexec_PROGRAMS = cc-shim
 

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,23 @@ AS_IF([test x"$enable_cppcheck" = "xyes"],
     [AC_SUBST([CPPCHECK], [0])])
 AM_CONDITIONAL([CPPCHECK], [test x$enable_cppcheck = x"yes"])
 
+# Runtime proxy tests
+
+AC_ARG_ENABLE(proxy-tests,
+              AS_HELP_STRING([--disable-proxy-tests],
+                             [disable proxy tests @<:@default=no@:>@]))
+
+# If "--[enable|disable]-proxy-tests" isn't specified, the variable will not
+# have a value (meaning *DO* run the tests).
+AS_IF([test x"$enable_proxy_tests" = x"yes" -o x"$enable_proxy_tests" = x""],
+    [run_proxy_tests=yes],
+    [run_proxy_tests=no])
+
+AS_IF([test x"$run_proxy_tests" = x"yes"],
+    [AC_SUBST([PROXY_TESTS], [1])],
+    [AC_SUBST([PROXY_TESTS], [0])])
+AM_CONDITIONAL([PROXY_TESTS], [test x"$run_proxy_tests" = x"yes"])
+
 # Runtime functional tests
 
 AC_ARG_ENABLE(functional-tests,
@@ -327,6 +344,7 @@ cc-oci-runtime - $VERSION
  • Tests:
 
        Unit tests               : $enable_tests
+       Proxy tests              : $run_proxy_tests
        Functional tests         : $run_functional_tests
        Docker tests             : $run_docker_tests
        Cppcheck                 : $enable_cppcheck


### PR DESCRIPTION
Certain distros do not support go build with -race. Provide
an option to disable running proxy tests for OBS builds.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>