### PR TITLE
tests: Make testing for the run.bats output more robust

### DIFF
--- a/tests/integration/docker/run.bats
+++ b/tests/integration/docker/run.bats
@@ -31,5 +31,5 @@ setup() {
 @test "Run shell echo" {
 	run $DOCKER_EXE run busybox sh -c "echo Passed"
 	[ "${status}" -eq 0 ]
-	[ "${output}" == $'Passed\r' ]
+	[[ "${output}" == 'Passed'* ]]
 }


### PR DESCRIPTION
I had to include the "\r" in that string for things to work in the 2.0
era. It was a bit odd but I didn't question it too much then, the test
was doing what it was supposed to do: ensure the runtime doesn't output
anything on stdout/err.

2.1 fixes a few things with terminal handling, in particular we don't
have that spurious \r!

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>