### PR TITLE
test metrics: Add script to measure kernel boot time and fix memory usage script

### DIFF
--- a/tests/metrics/density/docker_memory_usage.sh.in
+++ b/tests/metrics/density/docker_memory_usage.sh.in
@@ -53,8 +53,8 @@ function get_docker_memory_usage(){
 }
 
 echo "Executing Test: ${TEST_NAME}"
-if [ ! -f $SMEM_BIN ]; then
-	die "${SMEM_BIN} is not installed in your system, skipping test"
+if [ "$SMEM_BIN" == "" ]; then
+	die "smem is not installed in your system, skipping test"
 fi
 backup_old_file "$TEST_RESULT_FILE"
 write_csv_header "$TEST_RESULT_FILE"

--- a/tests/metrics/run_docker_metrics
+++ b/tests/metrics/run_docker_metrics
@@ -7,17 +7,20 @@ if [ ! -d "$RESULT_DIR" ]; then
 	mkdir "$RESULT_DIR"
 fi
 
-#complete workload : docker run --runtime $runtime -tid $image $cmd
+# complete workload : docker run --runtime $runtime -tid $image $cmd
 bash workload_time/docker_workload_time.sh true ubuntu runc "$TIMES"
 bash workload_time/docker_workload_time.sh true ubuntu cor "$TIMES"
 
-#time that cc-oci-run-time takes to create a container:
+# time that cc-oci-run-time takes to create a container:
 bash workload_time/cor_create_time.sh "$TIMES"
 
-#time to stop container using docker: docker stop $container_id
+# time to stop container using docker: docker stop $container_id
 bash workload_time/docker_shutdown.sh runc "$TIMES"
 bash workload_time/docker_shutdown.sh cor "$TIMES"
 
-#density (CPU and Memory)
+# density (CPU and Memory)
 bash density/docker_cpu_usage.sh "$TIMES" "$CPU_WAIT_TIME"
 bash density/docker_memory_usage.sh "$MEM_CONTAINERS" "$MEM_WAIT_TIME"
+
+# kernel boot time
+bash workload_time/kernel_boot_time.sh $TIMES

--- a/tests/metrics/workload_time/kernel_boot_time.sh
+++ b/tests/metrics/workload_time/kernel_boot_time.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#  Description of the test:
+#  This test measures the time kernelspace takes when a clear container
+#  boots.
+
+set -e
+
+[ $# -ne 1 ] && ( echo >&2 "Usage: $0 <times to run>"; exit 1 )
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../common/test.common"
+
+TEST_NAME="Kernel Boot Time"
+TIMES="$1"
+TMP_FILE=$(mktemp dmesglog.XXXXXXXXXX || true)
+
+function get_kernelspace_time(){
+	net=$1
+	test_args="Network"
+	if [ "$net" == "nonet" ]
+	then
+		test_args="No-network"
+		run_options="--net none"
+	fi
+	test_result_file=$(echo "${RESULT_DIR}/${TEST_NAME}-${test_args}" | sed 's| |-|g')
+	backup_old_file "$test_result_file"
+	write_csv_header "$test_result_file"
+	for i in $(seq 1 "$TIMES")
+	do
+		eval docker run "$run_options" -ti debian dmesg > "$TMP_FILE"
+		test_data=$(grep "Freeing" "$TMP_FILE" | tail -1 | awk '{print $2}' | cut -d']' -f1)
+		write_result_to_file "$TEST_NAME" "$test_args" "$test_data" "$test_result_file"
+		rm "$TMP_FILE"
+	done
+}
+
+echo "Executing test: ${TEST_NAME}"
+
+get_kernelspace_time
+get_kernelspace_time nonet
+
+clean_docker_ps


### PR DESCRIPTION
This PR contains 2 commits:
1. tests: add script to measure kernel boot time.
With this script, we will be able to measure the kernel
boot time when a container is launched using cc-oci-runtime.
The script uses dmesg log to get the data

2. tests: fixed condition to check if smem is installed
docker_memory_usage.sh needs smem tool to be installed in the system.
this commit fixes the condition that checks if smem is installed.
