### PR TITLE
cor: remove unused functions

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -453,37 +453,6 @@ out:
 }
 
 /*!
- * Send a QMP shutdown message to the hypervisor.
- *
- * \param conn \ref cc_oci_vm_conn to use.
- * \param pid \c GPid of hypervisor process.
- *
- * \warning \p pid is only required for the temporary shutdown
- * behaviour - remove once ACPI support is available!!
- *
- * \return \c true on success, else \c false.
- */
-static gboolean
-cc_oci_qmp_shutdown (struct cc_oci_vm_conn *conn, GPid pid)
-{
-	g_assert (conn);
-	g_assert (pid);
-
-	/* this command requires ACPI support */
-	const char shutdown_msg[] = "{ \"execute\": \"system_powerdown\" }";
-
-	/*
-	 * Expected messages:
-	 *
-	 * 1) {"return": {}}
-	 * 2) {"timestamp": {"seconds": X, "microseconds": X}, "event": "POWERDOWN"}
-	 * 3) {"timestamp": {"seconds": X, "microseconds": X}, "event": "SHUTDOWN"}
-	 */
-	return cc_oci_qmp_msg_send (conn, shutdown_msg,
-			sizeof(shutdown_msg)-1, 3, false);
-}
-
-/*!
  * Send a QMP pause message to the hypervisor.
  *
  * \param conn \ref cc_oci_vm_conn to use.
@@ -672,42 +641,6 @@ err:
 	}
 
 	return NULL;
-}
-
-/*!
- * Request the running hypervisor shutdown.
- *
- * \param socket_path Path to \ref CC_OCI_HYPERVISOR_SOCKET.
- * \param pid \c GPid of hypervisor process.
- *
- * \return \c true on success, else \c false.
- */
-gboolean
-cc_oci_vm_shutdown (const gchar *socket_path, GPid pid)
-{
-	gboolean                 ret = false;
-	struct cc_oci_vm_conn  *conn = NULL;
-
-	if (! (socket_path != NULL && pid > 0)) {
-		return false;
-	}
-
-	conn = cc_oci_vm_conn_new (socket_path, pid);
-	if (! conn) {
-		goto out;
-	}
-
-	ret = cc_oci_qmp_shutdown (conn, pid);
-	if (! ret) {
-		goto out;
-	}
-
-out:
-	if (conn) {
-		cc_oci_vm_conn_free (conn);
-	}
-
-	return ret;
 }
 
 /*!

--- a/src/network.h
+++ b/src/network.h
@@ -23,6 +23,5 @@
 
 gboolean cc_oci_vm_pause (const gchar *socket_path, GPid pid);
 gboolean cc_oci_vm_resume (const gchar *socket_path, GPid pid);
-gboolean cc_oci_vm_shutdown (const gchar *socket_path, GPid pid);
 
 #endif /* _CC_OCI_NETWORK_H */

--- a/tests/network_test.c
+++ b/tests/network_test.c
@@ -85,20 +85,11 @@ START_TEST(test_cc_oci_vm_resume) {
 	g_free(diname);
 } END_TEST
 
-START_TEST(test_cc_oci_vm_shutdown) {
-	ck_assert (! cc_oci_vm_shutdown (NULL, -1));
-	ck_assert (! cc_oci_vm_shutdown (NULL, 0));
-	ck_assert (! cc_oci_vm_shutdown ("/path/to/nothingness", 1));
-
-	//ck_assert (cc_oci_vm_shutdown (socket_path, pid));
-} END_TEST
-
 Suite* make_oci_suite(void) {
 	Suite* s = suite_create(__FILE__);
 
 	ADD_TEST_TIMEOUT (test_cc_oci_vm_pause, s, 10);
 	ADD_TEST_TIMEOUT (test_cc_oci_vm_resume, s, 10);
-	ADD_TEST_TIMEOUT (test_cc_oci_vm_shutdown, s, 10);
 
 	return s;
 }


### PR DESCRIPTION
since hyperstart is in charge of the VM
the only right way to shutdown the VM is through
hyperstart's API hence qmp shutdown message is not
more needed.

This patch also fix the cppcheck error:
"The function 'cc_oci_vm_shutdown' is never used."

Signed-off-by: Julio Montes <julio.montes@intel.com>