### PR TITLE
proxy & hyperstart logging

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -133,5 +133,9 @@ environment variable.
 $ sudo CC_PROXY_LOG_LEVEL=1 ./cc-proxy
 ```
 
-There are 2 verbosity levels. The second one will dump the raw data going over
-the I/O channel.
+There are 3 verbosity levels:
+
+  - Level 1 will show the important events happening at the proxy interfaces
+  - Level 2 will dump the raw data going over the I/O channel
+  - Level 3 will display the VM console logs. With clear VM images, this will
+    show hyperstart's stdout and stderr.

--- a/proxy/api/api.go
+++ b/proxy/api/api.go
@@ -24,6 +24,9 @@ import (
 // It is used to let the proxy know about a new container on the system along
 // with the paths go hyperstart's command and I/O channels (AF_UNIX sockets).
 //
+// Console can be used to indicate the path of a socket linked to the VM
+// console. The proxy can output this data when asked for verbose output.
+//
 //  {
 //    "id": "hello",
 //    "data": {
@@ -36,6 +39,7 @@ type Hello struct {
 	ContainerID string `json:"containerId"`
 	CtlSerial   string `json:"ctlSerial"`
 	IoSerial    string `json:"ioSerial"`
+	Console     string `json:"console,omitempty"`
 }
 
 // The Attach payload can be used to associate clients to an already known VM.

--- a/src/hypervisor.c
+++ b/src/hypervisor.c
@@ -172,7 +172,7 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 	gchar           **arg;
 	gchar            *bytes = NULL;
 	gchar            *console_device = NULL;
-	g_autofree gchar *hypervisor_console = NULL;
+	gchar		 *hypervisor_console = NULL;
 	g_autofree gchar *procsock_device = NULL;
 
 	gboolean          ret = false;
@@ -254,6 +254,8 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 	procsock_device = g_strdup_printf ("socket,id=procsock,path=%s,server,nowait", config->state.procsock_path);
 
 	proxy = config->proxy;
+
+	proxy->vm_console_socket = hypervisor_console;
 
 	proxy->agent_ctl_socket = g_build_path ("/", config->state.runtime_path,
 			CC_OCI_AGENT_CTL_SOCKET, NULL);

--- a/src/oci.h
+++ b/src/oci.h
@@ -514,6 +514,13 @@ struct cc_proxy {
 	 * to/from the agent running in the VM.
 	 */
 	gchar *agent_tty_socket;
+
+	/** Full path to socket connected to the VM console.
+	 *
+	 * We give the console socket the proxy to it can grab debugging output
+	 * from hyperstart when asked for it.
+	 */
+	gchar *vm_console_socket;
 };
 
 /** The main object holding all configuration data.

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -72,6 +72,7 @@ cc_proxy_free (struct cc_proxy *proxy) {
 
 	g_free_if_set (proxy->agent_ctl_socket);
 	g_free_if_set (proxy->agent_tty_socket);
+	g_free_if_set (proxy->vm_console_socket);
 
 	if (proxy->socket) {
 		g_object_unref (proxy->socket);
@@ -614,6 +615,9 @@ cc_proxy_cmd_hello (struct cc_proxy *proxy, const char *container_id)
 
 	json_object_set_string_member (data, "ioSerial",
 			proxy->agent_tty_socket);
+
+	json_object_set_string_member (data, "console",
+			proxy->vm_console_socket);
 
 	json_object_set_object_member (obj, "data", data);
 

--- a/src/state.c
+++ b/src/state.c
@@ -397,6 +397,10 @@ handle_state_proxy_section(GNode* node, struct handler_data* data) {
 		proxy->agent_tty_socket =
 			g_strdup ((gchar *)node->children->data);
 		(*(data->subelements_count))++;
+	} else if (g_strcmp0(node->data, "consoleSocket") == 0) {
+		proxy->vm_console_socket =
+			g_strdup ((gchar *)node->children->data);
+		(*(data->subelements_count))++;
 	} else {
 		g_critical("unknown proxy option: %s", (char*)node->data);
 	}
@@ -655,6 +659,7 @@ cc_oci_state_free (struct oci_state *state)
 	if (state->proxy) {
 		g_free_if_set(state->proxy->agent_ctl_socket);
 		g_free_if_set(state->proxy->agent_tty_socket);
+		g_free_if_set(state->proxy->vm_console_socket);
 		g_free (state->proxy);
 	}
 
@@ -826,6 +831,10 @@ cc_oci_state_file_create (struct cc_oci_config *config,
 	json_object_set_string_member (proxy, "ioSocket",
 			config->proxy->agent_tty_socket ?
 			config->proxy->agent_tty_socket : "");
+
+	json_object_set_string_member (proxy, "consoleSocket",
+			config->proxy->vm_console_socket ?
+			config->proxy->vm_console_socket : "");
 
 	json_object_set_object_member (obj, "proxy", proxy);
 


### PR DESCRIPTION
This PR makes the proxy able to extract the hyperstart logs out of the VM and display then along with the usual proxy tracing, that should help us debug some of the weird interactions we still have with hyperstart:

I haven't added the console path to the state on purpose as I'm not really sure it belongs to the runtime state (I'm not too sure ctl and io socket belong there either tbh). It may belong to a potential proxy state in case we want to upgrade the proxy for instance and need to read back the proxy state from disk.

The result looks like:

```
$ sudo ./cc-proxy -v 3
I1202 11:44:36.079095   10204 proxy.go:332] proxy started
I1202 11:44:44.922280   10204 proxy.go:63] [client #1] client connected
I1202 11:44:45.124991   10204 proxy.go:73] [client #1] hello(containerId=0241be9e1ea9d12def00aebaaf71e736b7b0a613ce3a6167f39e7f5dcb524b0a,ctlSerial=/var/run/cc-oci-runtime/0241be9e1ea9d12def00aebaaf71e736b7b0a613ce3a6167f39e7f5dcb524b0a/ga-ctl.sock,ioSerial=/var/run/cc-oci-runtime/0241be9e1ea9d12def00aebaaf71e736b7b0a613ce3a6167f39e7f5dcb524b0a/ga-tty.sock,console=/var/run/cc-oci-runtime/0241be9e1ea9d12def00aebaaf71e736b7b0a613ce3a6167f39e7f5dcb524b0a/console.sock
I1202 11:44:45.252113   10204 vm.go:110] [vm 0241be9e hyperstart] open hyper channel /dev/vport1p1
I1202 11:44:45.252755   10204 vm.go:110] [vm 0241be9e hyperstart] send ready message
I1202 11:44:45.252836   10204 vm.go:110] [vm 0241be9e hyperstart] hyper send type 8, len 0
I1202 11:44:45.252959   10204 vm.go:110] [vm 0241be9e hyperstart] open hyper channel /dev/vport1p2
I1202 11:44:45.253124   10204 vm.go:110] [vm 0241be9e hyperstart] hyper_init_event hyper channel event 0x61c580, ops 0x61c3e0, fd 3
I1202 11:44:45.253168   10204 vm.go:110] [vm 0241be9e hyperstart] hyper_add_event add event fd 3, 0x61c3e0
I1202 11:44:45.253237   10204 proxy.go:73] [client #1] hyper(cmd=startpod, data={"hostname":"0241be9e1ea9","containers":[],"shareDir":"rootfs","interfaces":[{"device":"enp0s8","newDeviceName":"eth0","ipAddresses":[{"ipAddress":"172.17.0.2","netMask":"255.255.0.0"}]}],"routes":[{"dest":"default","gateway":"172.17.0.1","device":"eth0"},{"dest":"172.17.0.0","device":"eth0"}]})
I1202 11:44:45.253265   10204 vm.go:110] [vm 0241be9e hyperstart] hyper_init_event hyper ttyfd event 0x61c548, ops 0x61c3c0, fd 4
I1202 11:44:45.253272   10204 vm.go:110] [vm 0241be9e hyperstart] hyper_add_event add event fd 4, 0x61c3c0
I1202 11:44:45.254044   10204 vm.go:110] [vm 0241be9e hyperstart] hyper_loop epoll_wait 1
I1202 11:44:45.254067   10204 vm.go:110] [vm 0241be9e hyperstart] hyper_handle_event get event 1, he 0x61c580, fd 3. ops 0x61c3e0
I1202 11:44:45.254096   10204 vm.go:110] [vm 0241be9e hyperstart] hyper_handle_event event EPOLLIN, he 0x61c580, fd 3, 0x61c3e0
I1202 11:44:45.254138   10204 vm.go:110] [vm 0241be9e hyperstart] hyper_channel_read
I1202 11:44:45.254165   10204 vm.go:110] [vm 0241be9e hyperstart] hyper send type 14, len 4
I1202 11:44:45.254231   10204 vm.go:110] [vm 0241be9e hyperstart] get length 303
I1202 11:44:45.254270   10204 vm.go:110] [vm 0241be9e hyperstart] hyper send type 14, len 4
I1202 11:44:45.254363   10204 vm.go:110] [vm 0241be9e hyperstart] 0 0 0 1 0 0 1 2f 7b 22 68 6f 73 74 6e 61 6d 65 22 3a 22 30 32 34 31 62 65 39 65 31 65 61 39 22 2c 22 63 6f 6e 74 61 69 6e 65 72 73 22 3a 5b 5d 2c 22 73 68 61 72 65 44 69 72 22 3a 22 72 6f 6f 74 66 73 22 2c 22 69 6e 74 65 72 66 61 63 65 73 22 3a 5b 7b 22 64 65 76 69 63 65 22 3a 22 65 6e 70 30 73 38 22 2c 22 6e 65 77 44 65 76 69 63 65 4e 61 6d 65 22 3a 22 65 74 68 30 22 2c 22 69 70 41 64 64 72 65 73 73 65 73 22 3a 5b 7b 22 69 70 41 64 64 72 65 73 73 22 3a 22 31 37 32 2e 31 37 2e 30 2e 32 22 2c 22 6e 65 74 4d 61 73 6b 22 3a 22 32 35 35 2e 32 35 35 2e 30 2e 30 22 7d 5d 7d 5d 2c 22 72 6f 75 74 65 73 22 3a 5b 7b 22 64 65 73 74 22 3a 22 64 65 66 61 75 6c 74 22 2c 22 67 61 74 65 77 61 79 22 3a 22 31 37 32 2e 31 37 2e 30 2e 31 22 2c 22 64 65 76 69 63 65 22 3a 22 65 74 68 30 22 7d 2c 7b 22 64 65 73 74 22 3a 22 31 37 32 2e 31 37 2e 30 2e 30 22 2c 22 64 65 76 69 63 65 22 3a 22 65 74 68 30 22 7d 5d 7d 
I1202 11:44:45.254386   10204 vm.go:110] [vm 0241be9e hyperstart]  hyper_channel_handle, type 1, len 303
I1202 11:44:45.254429   10204 vm.go:110] [vm 0241be9e hyperstart] call hyper_start_pod, json {"hostname":"0241be9e1ea9","containers":[],"shareDir":"rootfs","interfaces":[{"device":"enp0s8","newDeviceName":"eth0","ipAddresses":[{"ipAddress":"172.17.0.2","netMask":"255.255.0.0"}]}],"routes":[{"dest":"default","gateway":"172.17.0.1","device":"eth0"},{"dest":"172.17.0.0","device":"eth0"}]}, len 295
````