### PR TITLE
tty:Do not set current tty as controlling tty for shim in standalone mode

### DIFF
--- a/tests/process_test.c
+++ b/tests/process_test.c
@@ -257,7 +257,7 @@ START_TEST(test_cc_oci_setup_shim) {
 
 	config.oci.process.terminal = true;
 	config.console = g_strdup("/dev/ptmx");
-	ck_assert (! cc_oci_setup_shim (&config, tmpf1_fd, tmpf2_fd));
+	ck_assert (cc_oci_setup_shim (&config, tmpf1_fd, tmpf2_fd));
 
 	g_free (config.console);
 	cc_oci_rm_rf (tmpf1);


### PR DESCRIPTION
Added detailed explanation in the comments. This is to prevent the shell
from losing its controlling tty. I thought of overcoming this problem by
having the runtime gain control of the tty once the shim has ended.
But if the runtime is sent a SIGKILL in standalone, the shell would
never get its tty back.

In any case, I feel we should not be causing any ill effects on the
user's running shell. We should have the runtime create a slave pts in
standalone mode and pass that to the shim in 3.0(runc creates a tty as well
and prevents the current shell from being used)

A limitation introduced with this change is that the shim does not
get the SIGWINCH signals and these are not propogated to hyperstart.
I plan to add this limitation to the wiki once this is approved.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>