### PR TITLE
Tests to verify exit codes and terminal setup

### DIFF
--- a/tests/integration/docker/exit-code.bats
+++ b/tests/integration/docker/exit-code.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# *-*- Mode: sh; sh-basic-offset: 8; indent-tabs-mode: nil -*-*
+
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+# Based on docker commands
+
+SRC="${BATS_TEST_DIRNAME}/../../lib/"
+exit_status=55
+
+setup() {
+	source $SRC/test-common.bash
+	clean_docker_ps
+	runtime_docker
+}
+
+@test "Exit Code from container process when running non-interactive" {
+	run $DOCKER_EXE run ubuntu /usr/bin/perl -e "exit $exit_status"
+	[ "${status}" -eq "$exit_status" ]
+}
+
+@test "Exit Code from container process when running interactive" {
+	run $DOCKER_EXE run -ti ubuntu /usr/bin/perl -e "exit $exit_status"
+	[ "${status}" -eq "$exit_status" ]
+}

--- a/tests/integration/docker/terminal.bats
+++ b/tests/integration/docker/terminal.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# *-*- Mode: sh; sh-basic-offset: 8; indent-tabs-mode: nil -*-*
+
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+# Based on docker commands
+
+SRC="${BATS_TEST_DIRNAME}/../../lib/"
+term_var="TERM=.*"
+tty_dev="/dev/pts/.*"
+
+setup() {
+	source $SRC/test-common.bash
+	clean_docker_ps
+	runtime_docker
+}
+
+@test "TERM env variable is set when allocating a tty" {
+	$DOCKER_EXE run -t ubuntu env | grep -q "$term_var"
+}
+
+@test "TERM env variable is not set when not allocating a tty" {
+	run bash -c "$DOCKER_EXE run ubuntu env | grep -q $term_var"
+	# Expecting RC=1 from the grep command since
+	# the TERM env variable should not exist.
+	[ "${status}" -eq 1 ]
+}
+
+@test "Check that pseudo tty is setup properly when allocating a tty" {
+	run $DOCKER_EXE run -ti ubuntu tty
+	echo "${output}" | grep "$tty_dev"
+}


### PR DESCRIPTION
This PR contains two commits that add integration tests to verify exit codes and terminal setup:

integration tests: Add tests to verify that 
    1. a pseudo tty is properly setup when it is requested
    2. TERM environment variable is set when a tty is requested
    3. TERM environment variable is not set when a tty is not requested

integration tests: Add test to verify exit code from a container
Add tests to verify that a container returns the correct exit code of the executed process.