### PR TITLE
Tests: Add tests results in JSON

### DIFF
--- a/tests/helpers/reporter/metric/metric.go
+++ b/tests/helpers/reporter/metric/metric.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+//GetEnvironment detects the envieronment and return its struct
+func GetEnvironment() Environment {
+	environment := Environment{}
+	var osRelease = "/usr/lib/os-release"
+	var id, versionID string
+	if _, err := os.Stat(osRelease); err != nil {
+		osRelease = "/etc/os-release"
+	}
+
+	scanner, inFile := readFile(osRelease)
+	for scanner.Scan() {
+		info := strings.Split(scanner.Text(), "=")
+		switch value := info[0]; value {
+		case "ID":
+			id = info[1]
+		case "VERSION_ID":
+			versionID = info[1]
+		}
+	}
+	defer inFile.Close()
+
+	containerImage, _ :=
+		os.Readlink("/usr/share/clear-containers/clear-containers.img")
+
+	vm, _ :=
+		os.Readlink("/usr/share/clear-containers/vmlinux.container")
+	environment.Name =
+		id + versionID + "-" + containerImage
+	environment.Description =
+		id + " " + versionID + " - " + containerImage + " " + vm
+	os.Readlink("/usr/share/clear-containers/clear-containers.img")
+	return environment
+}
+
+func readFile(logfile string) (*bufio.Scanner, *os.File) {
+	inFile, err := os.Open(logfile)
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	scanner := bufio.NewScanner(inFile)
+	scanner.Split(bufio.ScanLines)
+
+	return scanner, inFile
+
+}
+
+func getValue(logFile, testRegex, ignore string) string {
+	re := regexp.MustCompile(testRegex)
+	scanner, inFile := readFile(logFile)
+	for scanner.Scan() {
+		if re.FindAllStringSubmatch(scanner.Text(), -1) != nil {
+			result := strings.Replace(scanner.Text(), testRegex, "", -1)
+			result = strings.Replace(result, ignore, "", -1)
+			defer inFile.Close()
+			return result
+		}
+	}
+	defer inFile.Close()
+	return ""
+}
+
+func compareReturnCode(returnCode string) bool {
+	if strings.Compare(returnCode, "0") == 0 {
+		return true
+	}
+	return false
+
+}
+
+//WriteJSON writes a JSON file, it receives the JSON filename and it's content
+func WriteJSON(jsonFile string, jsonContent interface{}) {
+	//Replace JSON file underscores and add .json extension
+	jsonFile = strings.Replace(jsonFile, " ", "_", -1) + ".json"
+	environment := GetEnvironment()
+	directory := environment.Name
+	if _, err := os.Stat(directory); os.IsNotExist(err) {
+		os.Mkdir(directory, 0644)
+	}
+
+	identedJSON, err := json.MarshalIndent(jsonContent, "", "\t")
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	ioutil.WriteFile(directory+"/"+jsonFile, identedJSON, 0644)
+}
+
+func getCount(logFile, testRegex, ignoreString string) int {
+
+	var counter = 0
+	re := regexp.MustCompile(testRegex)
+	scanner, inFile := readFile(logFile)
+	for scanner.Scan() {
+		if re.FindAllStringSubmatch(scanner.Text(), -1) != nil {
+			if strings.Contains(scanner.Text(), ignoreString) {
+				if len(ignoreString) > 0 {
+					continue
+				}
+			}
+			counter++
+
+		}
+	}
+	defer inFile.Close()
+	return counter
+}
+
+//GetTestResult query the received logfile and returns the number of occurences
+func GetTestResult(tr TestRegex, testResult Test) Test {
+
+	testResult.Params.Pass =
+		getCount(tr.LogFile, tr.PassField, tr.SkipField)
+	testResult.Params.Fail =
+		getCount(tr.LogFile, tr.FailField, "")
+	testResult.Params.Skip =
+		getCount(tr.LogFile, tr.SkipField, "")
+	return testResult
+
+}
+
+//GetCodeCoverage finds the code coverage from CodeRegex
+func GetCodeCoverage(tr CodeRegex, codeCoverage Code) Code {
+
+	codeCoverage.Params.Line, _ = strconv.ParseFloat(
+		getValue(tr.LogFile, tr.LineCoverageField, "%"), 64)
+	codeCoverage.Params.Function, _ = strconv.ParseFloat(
+		getValue(tr.LogFile, tr.FunctionCoverageField, "%"), 64)
+
+	return codeCoverage
+
+}
+
+//GetJSONReturnCode finds the return code from the regex
+func GetJSONReturnCode(logFile, name, regex string) Build {
+	build := Build{
+		Name: name,
+		Type: "boolean",
+	}
+	var returnCode = getValue(logFile, regex, "")
+	build.Params.Success = compareReturnCode(returnCode)
+	return build
+}
+
+//WriteJSONReturnCode writes the JSON return code File
+func (build Build) WriteJSONReturnCode() {
+	WriteJSON(build.Name, build)
+}
+
+//WriteJSONTestResult writes the JSON test result
+func (testResult Test) WriteJSONTestResult() {
+	WriteJSON(testResult.Name, testResult)
+}
+
+//WriteJSONEnvironment writes the JSON environment
+func (environment Environment) WriteJSONEnvironment(logFile string) {
+	WriteJSON(logFile, environment)
+}
+
+//WriteJSONCodeCoverage writes the JSON code coverage
+func (codeCoverage Code) WriteJSONCodeCoverage() {
+	WriteJSON(codeCoverage.Name, codeCoverage)
+}

--- a/tests/helpers/reporter/metric/types.go
+++ b/tests/helpers/reporter/metric/types.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+//Environment struct for the environment JSON
+type Environment struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+//Result struct for the tests JSON
+type Result struct {
+	Pass int `json:"pass"`
+	Fail int `json:"fail"`
+	Skip int `json:'skip"`
+}
+
+//Test struct for the tests JSON
+type Test struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+	Params      Result
+}
+
+//TestRegex struct to find regex from the logfile
+type TestRegex struct {
+	LogFile   string
+	SkipField string
+	FailField string
+	PassField string
+}
+
+//CodeRegex struct to find regex from the logfile
+type CodeRegex struct {
+	LogFile               string
+	LineCoverageField     string
+	FunctionCoverageField string
+}
+
+//ReturnCode struct for  the build JSON
+type ReturnCode struct {
+	Success bool `json:"succes"`
+}
+
+//Build struct for the build JSON
+type Build struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Params ReturnCode
+}
+
+//Coverage struct for the code JSON
+type Coverage struct {
+	Line     float64 `json:"line"`
+	Function float64 `json:"function"`
+}
+
+//Code struct for the code JSON
+type Code struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Params Coverage
+}

--- a/tests/helpers/reporter/reporter.go
+++ b/tests/helpers/reporter/reporter.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/01org/cc-oci-runtime/tests/helpers/reporter/metric"
+)
+
+var LogPath string
+
+func writeJSONEnvironment() {
+	const JSONFile = "environment"
+	environment := metric.GetEnvironment()
+	environment.WriteJSONEnvironment(JSONFile)
+}
+
+func writeTestResult() {
+
+	//Write JSON for Docker Test Results
+
+	dockerTestRegex := metric.TestRegex{
+		LogFile: LogPath + "docker-integration-tests.html",
+		//		JSONFile:  "docker_test_result.json",
+		SkipField: "# skip",
+		FailField: ">not ok ",
+		PassField: ">ok ",
+	}
+
+	dockerTestResult := metric.Test{
+		Name:        "docker test result",
+		Description: "docker test result for cc-oci-runtime",
+		Type:        "integration tests",
+	}
+
+	dockerTest :=
+		metric.GetTestResult(dockerTestRegex, dockerTestResult)
+	dockerTest.WriteJSONTestResult()
+
+	//Write JSON for Unit Test Results
+
+	unitTestRegex := metric.TestRegex{
+		LogFile: LogPath + "unit_tests.log",
+		//		JSONFile:  "unit_test_result.json",
+		SkipField: "^SKIP",
+		FailField: "^FAIL",
+		PassField: "^PASS",
+	}
+
+	unitTestResult := metric.Test{
+		Name:        "unit test result",
+		Description: "unit tests for cc-oci-runtime",
+		Type:        "unit tests",
+	}
+
+	unitTest := metric.GetTestResult(unitTestRegex, unitTestResult)
+	unitTest.WriteJSONTestResult()
+
+	//Write JSON for Functional Test Results
+	functionalTestsRegex := metric.TestRegex{
+		LogFile: LogPath + "functional_tests.log",
+		//		JSONFile:  "functional_test_result.json",
+		SkipField: "# skip",
+		FailField: "^not ok",
+		PassField: "^ok ",
+	}
+
+	testResult := metric.Test{
+		Name:        "functional test result",
+		Description: "functional tests result for cc-oci-runtime",
+		Type:        "functional tests",
+	}
+
+	functionalTest :=
+		metric.GetTestResult(functionalTestsRegex, testResult)
+	functionalTest.WriteJSONTestResult()
+
+	//Write JSON for Valgrind test results
+	valgrindRegex := metric.TestRegex{
+		LogFile: LogPath + "valgrind_tests.log",
+		//		JSONFile:  "valgrind_test_result.json",
+		SkipField: "^SKIP:",
+		FailField: "^FAIL:",
+		PassField: "^PASS:",
+	}
+
+	valgrindResult := metric.Test{
+		Name:        "valgrind test result",
+		Description: "valgrind for cc-oci-runtime",
+		Type:        "valgrind tests",
+	}
+
+	valgrind := metric.GetTestResult(valgrindRegex, valgrindResult)
+	valgrind.WriteJSONTestResult()
+
+	//Write JSON for code Coverage
+	codeCoverageRegex := metric.CodeRegex{
+		LogFile: LogPath + "test_summary.log",
+		//	JsonFile:
+		LineCoverageField:     "Lines Coverage: ",
+		FunctionCoverageField: "Functions Coverage: ",
+	}
+
+	codeCoverageResult := metric.Code{
+		Name: "code_coverage",
+		Type: "Code coverage",
+	}
+
+	codeCoverage :=
+		metric.GetCodeCoverage(codeCoverageRegex, codeCoverageResult)
+	codeCoverage.WriteJSONCodeCoverage()
+}
+
+func writeReturnCode() {
+
+	//Return codes are stored in the test_summary.log
+
+	var LogFile = LogPath + "test_summary.log"
+	const (
+		CppcheckRE         = "cppcheck return code: "
+		CppcheckName       = "ccpcheck"
+		AutogenRE          = "autogen return code: "
+		AutogenName        = "autogen"
+		MakeRE             = "make return code: "
+		MakeName           = "make"
+		MakeInstallRE      = "make install return code: "
+		MakeInstallName    = "make_install"
+		ProxyTestName      = "check_proxy"
+		ProxyTestRE        = "check-proxy return code: "
+		UnitTestName       = "unit_test"
+		UnitTestRE         = "unit tests return code: "
+		FunctionalTestRE   = "functional tests return code: "
+		FunctionalTestName = "functional_test"
+		ValgrindName       = "valgrind"
+		ValgrindRE         = "valgrind tests return code: "
+		CoverageName       = "coverage"
+		CoverageRE         = "coverage return code: "
+		DockerTestName     = "docker_test"
+		DockerTestRE       = "docker tests return code: "
+	)
+
+	//Write ccpcheck JSON file
+	cppcheck :=
+		metric.GetJSONReturnCode(LogFile, CppcheckName, CppcheckRE)
+	cppcheck.WriteJSONReturnCode()
+
+	//Write autogen JSON file
+	autogen := metric.GetJSONReturnCode(LogFile, AutogenName, AutogenRE)
+	autogen.WriteJSONReturnCode()
+
+	//Write make JSON file
+	make := metric.GetJSONReturnCode(LogFile, MakeName, MakeRE)
+	make.WriteJSONReturnCode()
+
+	//Write make install JSON file
+	makeInstall :=
+		metric.GetJSONReturnCode(
+			LogFile, MakeInstallName, MakeInstallRE)
+	makeInstall.WriteJSONReturnCode()
+
+	//Write Proxy Test JSON file
+	proxyTest :=
+		metric.GetJSONReturnCode(LogFile, ProxyTestName, ProxyTestRE)
+	proxyTest.WriteJSONReturnCode()
+
+	//Write Unit Test Name JSON file
+	unitTest :=
+		metric.GetJSONReturnCode(LogFile, UnitTestName, UnitTestRE)
+	unitTest.WriteJSONReturnCode()
+
+	//Write Functional Test JSON file
+	functionalTest :=
+		metric.GetJSONReturnCode(
+			LogFile, FunctionalTestName, FunctionalTestRE)
+	functionalTest.WriteJSONReturnCode()
+
+	//Write Valgrind JSON file
+	valgrind :=
+		metric.GetJSONReturnCode(LogFile, ValgrindName, ValgrindRE)
+	valgrind.WriteJSONReturnCode()
+
+	//Write Code Coverage JSON file
+	coverage :=
+		metric.GetJSONReturnCode(LogFile, CoverageName, CoverageRE)
+	coverage.WriteJSONReturnCode()
+
+	//Write Docker JSON file
+	docker :=
+		metric.GetJSONReturnCode(LogFile, DockerTestName, DockerTestRE)
+	docker.WriteJSONReturnCode()
+
+}
+
+func main() {
+
+	LogPath = "../test_logs/"
+	writeJSONEnvironment()
+	writeReturnCode()
+	writeTestResult()
+}


### PR DESCRIPTION
This commit is an enhancement of the test-campaign.sh script,
and will genereate the  following JSON files from the log files:

autogen.json
ccpcheck.json
check_proxy.json
code_coverage.json
coverage.json
docker_test.json
environment.json
funtional_test.json
make_install.json
make.json
unit_test.json
valgrind.json

Signed-off-by: Jesus Ornelas Aguayo <jesus.ornelas.aguayo@intel.com>