### PR TITLE
Networking/sriov

### DIFF
--- a/src/hypervisor.h
+++ b/src/hypervisor.h
@@ -30,5 +30,6 @@ gboolean cc_oci_expand_cmdline (struct cc_oci_config *config,
 		gchar **args);
 void cc_oci_populate_extra_args(struct cc_oci_config *config,
                 GPtrArray **additional_args);
-
+gboolean cc_oci_bind_host (struct cc_oci_device* d_info);
+gboolean cc_oci_switch_iface_to_container (struct cc_oci_device* d_info, GPid pid);
 #endif /* _CC_OCI_HYPERVISOR_H */

--- a/src/networking.h
+++ b/src/networking.h
@@ -34,4 +34,5 @@ gchar * cc_net_get_ip_address(const gint family, const void *const sin_addr);
 gboolean cc_oci_network_discover(struct cc_oci_config *const config,
 			struct netlink_handle *hndl);
 
+JsonArray * cc_oci_network_devices_to_json (const struct cc_oci_config *config);
 #endif /* _CC_OCI_NETWORKING_H */

--- a/src/oci.c
+++ b/src/oci.c
@@ -1816,6 +1816,12 @@ cc_oci_config_update (struct cc_oci_config *config,
 		state->mounts = NULL;
 	}
 
+        if (state->devices) {
+               config->devices = state->devices;
+               state->devices = NULL;
+               g_debug ("cor non-null devices from state");
+        }
+
 	if (state->console) {
 		config->console = state->console;
 		state->console = NULL;

--- a/src/oci.h
+++ b/src/oci.h
@@ -317,6 +317,8 @@ struct cc_oci_net_if_cfg {
         gboolean vf_based;
 
         gchar *bdf;
+
+        gchar *device_driver;
 };
 
 /** cc-specific IPv4 configuration data. */
@@ -375,6 +377,8 @@ struct oci_state {
 	 * so there is no \c oci_cfg_mount type.
 	 */
 	GSList          *mounts;
+
+        GSList          *devices;
 
         /** List of \ref oci_cfg_annotation annotations.
          *
@@ -444,6 +448,11 @@ struct cc_oci_mount {
 	gchar          *directory_created;
 };
 
+struct cc_oci_device {
+        gchar *bdf;
+        gchar *driver;
+};
+
 /** The main object holding all configuration data.
  *
  * \note The main user of this object is "start" - other commands
@@ -462,6 +471,8 @@ struct cc_oci_config {
 
 	/** Network configuration. */
 	struct cc_oci_net_cfg           net;
+
+        GSList *devices;
 
 	/** Container-specific state. */
 	struct cc_oci_container_state  state;

--- a/src/oci.h
+++ b/src/oci.h
@@ -313,6 +313,10 @@ struct cc_oci_net_if_cfg {
 	GSList  *ipv6_addrs;
 
 	/** TODO: Add support for routes */
+
+        gboolean vf_based;
+
+        gchar *bdf;
 };
 
 /** cc-specific IPv4 configuration data. */

--- a/src/process.c
+++ b/src/process.c
@@ -487,6 +487,74 @@ cc_oci_vm_netcfg_get (struct cc_oci_config *config,
 	return true;
 }
 
+GHashTable* mac_hash;
+
+void
+hash_mac_and_store_bdf(GHashTable* hash, gpointer mac, gpointer bdf)
+{
+       g_hash_table_insert(hash, mac, bdf);
+}
+
+void
+build_mac_to_bdf_hash (void)
+{
+      gchar *sym_link = NULL;
+      GError *error = NULL;
+      gchar **tokens = NULL;
+
+
+      mac_hash = g_hash_table_new(g_str_hash, g_str_equal);
+
+      struct dirent *d = opendir("/sys/class/net");
+
+      struct dirent *dir;
+      if (d) {
+
+        while ((dir = readdir(d)) != NULL) {
+             g_debug("cor: %s", dir->d_name);
+             gchar *net_class_path = g_strdup_printf("/sys/class/net/%s/device", dir->d_name);
+             g_debug ("cor: device_path %s", net_class_path);
+             sym_link = g_file_read_link(net_class_path, &error);
+
+             if(!sym_link) {
+                g_debug ("symlink is null");
+                if (error) g_debug ("reading symlink returned error:%s", error->message);
+                //g_error_free (error);
+                continue;
+             }
+
+             if (sym_link) {
+                g_debug ("cor: device sym link path %s", sym_link);
+                tokens = g_strsplit (sym_link, "/", 4);
+             }
+
+             if (tokens && tokens[3]) {
+                 g_debug ("hashing mac of iface with bdf %s", tokens[3]);
+                 gchar *content;
+                 gssize length;
+
+                 gchar *address_file_name =  g_strdup_printf("/sys/class/net/%s/address", dir->d_name);
+                 if ( g_file_get_contents (address_file_name, &content, &length, NULL)) {
+//                     g_debug ("mac address of the iface %s - %s", dir->d_name, content);
+                     gchar **mac_from_file = g_strsplit (content, "\n", -1);
+                     g_debug ("mac address of the iface %s - %s", dir->d_name, mac_from_file[0]);
+                     gchar *mac = g_strdup (mac_from_file[0]);
+                     gchar *bdf = g_strdup (tokens[3]);
+                     hash_mac_and_store_bdf(mac_hash, mac, bdf);
+//                     g_free (content);
+//                     g_free (tokens);
+
+                 } else {
+                    g_debug("cor: reading address file for %s returned error", dir->d_name);
+                 }
+             }
+        }
+        closedir(d);
+      }
+
+      g_debug ("num of mac entries in hash %d", g_hash_table_size(mac_hash));
+}
+
 /*!
  * Start the hypervisor (in a paused state) as a child process.
  *
@@ -559,6 +627,8 @@ cc_oci_vm_launch (struct cc_oci_config *config)
 		g_critical ("failed to set close-exec bit on fd");
 		goto out;
 	}
+
+        build_mac_to_bdf_hash();
 
 	pid = config->state.workload_pid = fork ();
 	if (pid < 0) {


### PR DESCRIPTION
Clear Container SR-IOv integration

This code enables COR to handle docker container life events w.r.t. passing thru the SR-IOv network interface into Clear Container. COR receives the network interface based off of a SR-IOv Virtual Function (VF) in the container namespace on a docker start/run. It passes the underlying VF to the Clear Container. On docker stop, COR makes sure it leaves the VF back in its network interface form in the host default network namespace.