### PR TITLE
CRI-O integration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -174,6 +174,7 @@ common_sources = \
 	src/json.c src/json.h \
 	src/proxy.c src/proxy.h \
 	src/spec_handler.c src/spec_handler.h \
+	src/pod.c src/pod.h \
 	src/common.h \
 	src/command.c src/command.h \
 	src/commands/create.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -440,6 +440,7 @@ TESTS = \
 	namespace_test \
 	oci_config_test \
 	oci_test \
+	pod_test \
 	priv_test \
 	proxy_test \
 	process_test \
@@ -739,6 +740,17 @@ sh_hooks_test_CFLAGS = \
 	$(TEST_COMMON_CFLAGS)
 
 sh_hooks_test_LDADD = \
+	$(TEST_COMMON_LDADD)
+
+## pod.c test ##
+pod_test_SOURCES = \
+	$(TEST_COMMON_SOURCES) \
+	tests/pod_test.c
+
+pod_test_CFLAGS = \
+	$(TEST_COMMON_CFLAGS)
+
+pod_test_LDADD = \
 	$(TEST_COMMON_LDADD)
 
 CLEANFILES += tests/*~ tests/*.log tests/*.trs

--- a/src/command.c
+++ b/src/command.c
@@ -197,10 +197,6 @@ handle_command_stop (const struct subcommand *sub,
 
 	g_free_node(root);
 
-	/* move the mounts to the config object to allow unmounting */
-	config->oci.mounts = state->mounts;
-	state->mounts = NULL;
-
 	ret = cc_oci_stop (config, state);
 	if (! ret) {
 		goto out;

--- a/src/hypervisor.c
+++ b/src/hypervisor.c
@@ -172,6 +172,7 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 	gchar           **arg;
 	gchar            *bytes = NULL;
 	gchar            *console_device = NULL;
+	gchar            *workload_dir;
 	gchar		 *hypervisor_console = NULL;
 	g_autofree gchar *procsock_device = NULL;
 
@@ -207,6 +208,12 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 
 	/* We're about to launch the hypervisor so validate paths.*/
 
+	workload_dir = cc_oci_get_workload_dir(config);
+	if (! workload_dir) {
+		g_critical ("No workload");
+		goto out;
+	}
+
 	if ((!config->vm->image_path[0])
 		|| stat (config->vm->image_path, &st) < 0) {
 		g_critical ("image file: %s does not exist",
@@ -221,10 +228,10 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 		return false;
 	}
 
-	if (!(config->oci.root.path[0]
-		&& g_file_test (config->oci.root.path, G_FILE_TEST_EXISTS|G_FILE_TEST_IS_DIR))) {
+	if (!(workload_dir[0]
+		&& g_file_test (workload_dir, G_FILE_TEST_IS_DIR))) {
 		g_critical ("workload directory: %s does not exist",
-			    config->oci.root.path);
+			    workload_dir);
 		return false;
 	}
 
@@ -276,7 +283,7 @@ cc_oci_expand_cmdline (struct cc_oci_config *config,
 		const gchar* name;
 		const gchar* value;
 	} special_tags[] = {
-		{ "@WORKLOAD_DIR@"      , config->oci.root.path      },
+		{ "@WORKLOAD_DIR@"      , workload_dir               },
 		{ "@KERNEL@"            , config->vm->kernel_path    },
 		{ "@KERNEL_PARAMS@"     , config->vm->kernel_params  },
 		{ "@KERNEL_NET_PARAMS@" , kernel_net_params          },

--- a/src/mount.c
+++ b/src/mount.c
@@ -221,8 +221,14 @@ cc_oci_handle_mounts (struct cc_oci_config *config)
 	gchar* dirname_dest = NULL;
 	gchar* dirname_parent_dest = NULL;
 	gchar* c = NULL;
+	gchar* workload_dir;
 
 	if (! config) {
+		return false;
+	}
+
+	workload_dir = cc_oci_get_workload_dir(config);
+	if (! workload_dir) {
 		return false;
 	}
 
@@ -236,7 +242,7 @@ cc_oci_handle_mounts (struct cc_oci_config *config)
 
 		g_snprintf (m->dest, sizeof (m->dest),
 				"%s%s",
-				config->oci.root.path, m->mnt.mnt_dir);
+				workload_dir, m->mnt.mnt_dir);
 
 		if (m->mnt.mnt_fsname[0] == '/') {
 			if (stat (m->mnt.mnt_fsname, &st)) {

--- a/src/oci-config.c
+++ b/src/oci-config.c
@@ -157,6 +157,11 @@ cc_oci_config_free (struct cc_oci_config *config)
 		g_free (config->vm);
 	}
 
+	if (config->pod) {
+		g_free_if_set (config->pod->sandbox_name);
+		g_free (config->pod);
+	}
+
 	if (config->oci.process.args) {
 		g_strfreev (config->oci.process.args);
 	}

--- a/src/oci.c
+++ b/src/oci.c
@@ -146,7 +146,7 @@ cc_oci_get_workload_dir (struct cc_oci_config *config)
 		return NULL;
 	}
 
-	if (config->pod && config->pod->sandbox) {
+	if (config->pod) {
 		return config->pod->sandbox_workloads;
 	}
 

--- a/src/oci.c
+++ b/src/oci.c
@@ -238,6 +238,19 @@ cc_oci_kill (struct cc_oci_config *config,
 	/* save current status */
 	last_status = config->state.status;
 
+	/* A sandbox is not a running container, nothing to kill here */
+	if (cc_pod_is_sandbox(config)) {
+		config->state.status = OCI_STATUS_STOPPED;
+
+		/* update state file */
+		if (! cc_oci_state_file_create (config, state->create_time)) {
+			g_critical ("failed to recreate state file");
+			goto error;
+		}
+
+		return true;
+	}
+
 	/* stopping container */
 	config->state.status = OCI_STATUS_STOPPING;
 

--- a/src/oci.c
+++ b/src/oci.c
@@ -130,6 +130,29 @@ cc_oci_get_bundlepath_file (const gchar *bundle_path,
 	return g_build_path ("/", bundle_path, file, NULL);
 }
 
+/**
+ * Get the workload directory for a given container.
+ * For pod sandboxes, this is the sandbox workloads directory,
+ * while for regular containers this is the OCI root path.
+ *
+ * \param config Container configuration.
+ *
+ * \return The container workload full path.
+ */
+gchar *
+cc_oci_get_workload_dir (struct cc_oci_config *config)
+{
+	if (! config) {
+		return NULL;
+	}
+
+	if (config->pod && config->pod->sandbox) {
+		return config->pod->sandbox_workloads;
+	}
+
+	return config->oci.root.path;
+}
+
 /*!
  * Determine the containers config file, its configuration
  * and state.

--- a/src/oci.c
+++ b/src/oci.c
@@ -537,9 +537,18 @@ cc_oci_create (struct cc_oci_config *config)
 		return true;
 	}
 
-	if (! cc_oci_vm_launch (config)) {
-		g_critical ("failed to launch VM");
-		goto out;
+	/* Either start a standalone container or a pod sandbox */
+	if (! config->pod || config->pod->sandbox == true) {
+		if (! cc_oci_vm_launch (config)) {
+			g_critical ("failed to launch VM");
+			goto out;
+		}
+	} else {
+		/* We want to start a container within a pod */
+		if (! cc_pod_new_container (config)) {
+			g_critical ("failed to launch pod container");
+			goto out;
+		}
 	}
 
 	ret = true;

--- a/src/oci.c
+++ b/src/oci.c
@@ -57,6 +57,7 @@
 #include "spec_handler.h"
 #include "command.h"
 #include "proxy.h"
+#include "pod.h"
 
 extern struct start_data start_data;
 
@@ -644,7 +645,7 @@ cc_oci_start (struct cc_oci_config *config,
 	 *
 	 * Do not wait when console is empty.
 	 */
-	if ((isatty (STDIN_FILENO) && ! config->detached_mode)) {
+	if ((isatty (STDIN_FILENO) && ! config->detached_mode && ! config->pod)) {
 		wait = true;
 	}
 
@@ -681,7 +682,8 @@ cc_oci_start (struct cc_oci_config *config,
 		}
 	}
 
-	if (! cc_proxy_hyper_new_container (config)) {
+	if (((! config->pod) || (config->pod && ! config->pod->sandbox)) &&
+	    (! cc_proxy_hyper_new_container (config))) {
 	    ret = false;
 	    goto out;
 	}
@@ -1408,6 +1410,12 @@ cc_oci_config_update (struct cc_oci_config *config,
 		cc_proxy_free (config->proxy);
 		config->proxy = state->proxy;
 		state->proxy = NULL;
+	}
+
+	if (state->pod) {
+		cc_pod_free (config->pod);
+		config->pod = state->pod;
+		state->pod = NULL;
 	}
 
 	if (state->procsock_path) {

--- a/src/oci.c
+++ b/src/oci.c
@@ -1050,6 +1050,11 @@ cc_oci_exec (struct cc_oci_config *config,
 		}
 	}
 
+	/* Update config so that the pod pointer is accurate. */
+	if (! cc_oci_config_update (config, state)) {
+		goto out;
+	}
+
 	if (! cc_oci_vm_connect (config)) {
 		g_critical ("failed to connect to VM");
 		goto out;

--- a/src/oci.c
+++ b/src/oci.c
@@ -574,7 +574,7 @@ cc_oci_create (struct cc_oci_config *config)
 	}
 
 	/* Either start a standalone container or a pod sandbox */
-	if (! config->pod || config->pod->sandbox) {
+	if (cc_pod_is_vm(config)) {
 		if (! cc_oci_vm_launch (config)) {
 			g_critical ("failed to launch VM");
 			goto out;
@@ -737,7 +737,7 @@ cc_oci_start (struct cc_oci_config *config,
 						config->optarg_container_id,
 						config->optarg_container_id,
 						"rootfs", config->optarg_container_id);
-	} else if (config->pod && ! config->pod->sandbox) {
+	} else if (! cc_pod_is_sandbox(config)) {
 		if (! cc_pod_container_start (config)) {
 			ret = false;
 			goto out;

--- a/src/oci.h
+++ b/src/oci.h
@@ -523,6 +523,23 @@ struct cc_proxy {
 	gchar *vm_console_socket;
 };
 
+/**
+ * Tracks the relationship between a container and
+ * a pod: Is this container part of a Pod ? Is it
+ * a sandbox ? What is the sandbox ID this container
+ * belongs to ?
+ */
+struct cc_pod {
+	/** If \c true, this is a sandbox container. */
+	gboolean sandbox;
+
+	/**
+	 * The sandbox name holds the container ID for the
+	 * sandbox container.
+	 */
+	gchar    *sandbox_name;
+};
+
 /** The main object holding all configuration data.
  *
  * \note The main user of this object is "start" - other commands
@@ -544,6 +561,9 @@ struct cc_oci_config {
 
 	/** Container-specific state. */
 	struct cc_oci_container_state  state;
+
+	/** Pod-specific configuration. */
+	struct cc_pod                  *pod;
 
 	/** Path to directory containing OCI bundle to run. */
 	gchar *bundle_path;

--- a/src/oci.h
+++ b/src/oci.h
@@ -432,6 +432,7 @@ struct oci_state {
 
 	struct cc_oci_vm_cfg *vm;
 	struct cc_proxy      *proxy;
+	struct cc_pod        *pod;
 
 	/* Needed by start to create a new container workload  */
 	struct oci_cfg_process *process;

--- a/src/oci.h
+++ b/src/oci.h
@@ -539,6 +539,14 @@ struct cc_pod {
 	 * sandbox container.
 	 */
 	gchar    *sandbox_name;
+
+	/**
+	 * The sandbox workloads is where all pod containers rootfs
+	 * will be bind mounted.
+	 * A container rootfs will be bind mounted under
+	 * /sandbox_workloads/<container_id>/rootfs.
+	 */
+	gchar    sandbox_workloads[PATH_MAX];
 };
 
 /** The main object holding all configuration data.
@@ -600,6 +608,7 @@ gboolean cc_oci_run (struct cc_oci_config *config);
 void cc_oci_config_free (struct cc_oci_config *config);
 gchar *cc_oci_get_bundlepath_file (const gchar *bundle_path,
 		const gchar *file);
+gchar *cc_oci_get_workload_dir (struct cc_oci_config *config);
 gboolean cc_oci_get_config_and_state (gchar **config_file,
 		struct cc_oci_config *config,
 		struct oci_state **state);

--- a/src/pod.c
+++ b/src/pod.c
@@ -18,6 +18,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+/* Sandbox rootfs */
+#define CC_POD_SANDBOX_ROOTFS "workloads"
+
 /* CRI-O/ocid namespaces */
 #define CC_POD_OCID_NAMESPACE "ocid/"
 #define CC_POD_OCID_NAMESPACE_SIZE 5
@@ -77,6 +80,20 @@ cc_pod_handle_annotations(struct cc_oci_config *config, struct oci_cfg_annotatio
 		if (g_strcmp0(annotation->value, CC_POD_OCID_SANDBOX) == 0) {
 			config->pod->sandbox = true;
 			config->pod->sandbox_name = g_strdup(config->optarg_container_id);
+
+			g_snprintf (config->pod->sandbox_workloads,
+				    sizeof (config->pod->sandbox_workloads),
+				    "%s/%s/%s",
+				    CC_OCI_RUNTIME_DIR_PREFIX,
+				    config->optarg_container_id,
+				    CC_POD_SANDBOX_ROOTFS);
+
+			if (g_mkdir_with_parents (config->pod->sandbox_workloads, CC_OCI_DIR_MODE)) {
+				g_critical ("failed to create directory %s: %s",
+					    config->pod->sandbox_workloads, strerror (errno));
+
+				return -errno;
+			}
 		}
 	} else if (g_strcmp0(annotation->key, CC_POD_OCID_SANDBOX_NAME) == 0) {
 		if (config->pod->sandbox_name) {

--- a/src/pod.c
+++ b/src/pod.c
@@ -147,6 +147,8 @@ cc_pod_handle_annotations(struct cc_oci_config *config, struct oci_cfg_annotatio
 				    CC_OCI_RUNTIME_DIR_PREFIX,
 				    config->optarg_container_id,
 				    CC_POD_SANDBOX_ROOTFS);
+		} else if (g_strcmp0(annotation->value, CC_POD_OCID_CONTAINER) == 0) {
+			config->pod->sandbox = false;
 		}
 	} else if (g_strcmp0(annotation->key, CC_POD_OCID_SANDBOX_NAME) == 0) {
 		if (config->pod->sandbox_name) {
@@ -186,7 +188,7 @@ cc_pod_free (struct cc_pod *pod) {
 	g_free (pod);
 }
 
-/*!
+/**
  * Start a container within a pod.
  *
  * \param config \ref cc_oci_config.
@@ -343,4 +345,30 @@ out:
 	if (shim_socket_fd != -1) close (shim_socket_fd);
 
 	return ret;
+}
+
+/**
+ * Returns the pod container ID for any container.
+ * For a pod or for a standalone container, it
+ * simply returns config->optarg_container_id.
+ * For a container running within a pod, this will
+ * return the pod container ID.
+ *
+ * \param config \ref cc_oci_config.
+ *
+ * \return the pod container ID on success, else \c NULL.
+ */
+const gchar *
+cc_pod_container_id(struct cc_oci_config *config)
+{
+	if (! config) {
+		return NULL;
+	}
+
+	/* This is a container running within a pod */
+	if (config->pod && ! config->pod->sandbox) {
+		return config->pod->sandbox_name;
+	}
+
+	return config->optarg_container_id;
 }

--- a/src/pod.c
+++ b/src/pod.c
@@ -292,7 +292,14 @@ cc_pod_new_container (struct cc_oci_config *config)
 
 	/* save ioBase */
 	config->oci.process.stdio_stream = ioBase;
-	config->oci.process.stderr_stream = ioBase + 1;
+	if ( config->oci.process.terminal) {
+		/* For tty, pass stderr seq as 0, so that stdout and
+		 * and stderr are redirected to the terminal
+		 */
+		config->oci.process.stderr_stream = 0;
+	} else {
+		config->oci.process.stderr_stream = ioBase + 1;
+	}
 
 	close (shim_args_fd);
 	shim_args_fd = -1;

--- a/src/pod.c
+++ b/src/pod.c
@@ -372,3 +372,21 @@ cc_pod_container_id(struct cc_oci_config *config)
 
 	return config->optarg_container_id;
 }
+
+/**
+ * cc_pod_sandbox tells if a container is a pod
+ * sandbox or not.
+ *
+ * \param config \ref cc_oci_config.
+ *
+ * \return \c true if the container is a pod sanbox, \c fals otherwise
+ */
+gboolean
+cc_pod_is_sandbox(struct cc_oci_config *config)
+{
+	if (config && config->pod && config->pod->sandbox) {
+		return true;
+	}
+
+	return false;
+}

--- a/src/pod.c
+++ b/src/pod.c
@@ -1,0 +1,100 @@
+/*
+ * This file is part of cc-oci-runtime.
+ *
+ * Copyright (C) 2016 Intel Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/* CRI-O/ocid namespaces */
+#define CC_POD_OCID_NAMESPACE "ocid/"
+#define CC_POD_OCID_NAMESPACE_SIZE 5
+
+#define CC_POD_OCID_CONTAINER_TYPE "ocid/container_type"
+#define CC_POD_OCID_SANDBOX        "sandbox"
+#define CC_POD_OCID_CONTAINER      "container"
+
+#define CC_POD_OCID_SANDBOX_NAME "ocid/sandbox_name"
+
+#include <errno.h>
+#include <string.h>
+
+#include "pod.h"
+
+/**
+ * Handle pod related OCI annotations.
+ * This routine will build the config->pod structure
+ * based on the pod related OCI annotations.
+ *
+ * \param OCI config \ref cc_oci_config.
+ * \param OCI annotation \ref oci_state.
+ *
+ * \return 0 on success, and a negative \c errno on failure.
+ */
+int
+cc_pod_handle_annotations(struct cc_oci_config *config, struct oci_cfg_annotation *annotation)
+{
+	if (! (config && annotation)) {
+		return -EINVAL;
+	}
+
+	if (! (annotation->key && annotation->value)) {
+		return -EINVAL;
+	}
+
+	/* We only handle CRI-O/ocid annotations for now */
+	if (strncmp(annotation->key, CC_POD_OCID_NAMESPACE,
+		    CC_POD_OCID_NAMESPACE_SIZE) != 0) {
+		return 0;
+	}
+
+	if (! config->pod) {
+		config->pod = g_malloc0 (sizeof (struct cc_pod));
+		if (! config->pod) {
+			return -ENOMEM;
+		}
+	}
+
+	if (g_strcmp0(annotation->key, CC_POD_OCID_CONTAINER_TYPE) == 0) {
+		if (g_strcmp0(annotation->value, CC_POD_OCID_SANDBOX) == 0) {
+			config->pod->sandbox = true;
+			config->pod->sandbox_name = g_strdup(config->optarg_container_id);
+		}
+	} else if (g_strcmp0(annotation->key, CC_POD_OCID_SANDBOX_NAME) == 0) {
+		if (config->pod->sandbox_name) {
+			g_free(config->pod->sandbox_name);
+		}
+		config->pod->sandbox_name = g_strdup(annotation->value);
+	}
+
+	return 0;
+}
+
+/**
+ * Free resources associated with \p CRI-O/ocid
+ *
+ * \param ocid \ref cc_ocid.
+ *
+ */
+void
+cc_pod_free (struct cc_pod *pod) {
+	if (! pod) {
+		return;
+	}
+
+	g_free_if_set (pod->sandbox_name);
+
+	g_free (pod);
+}

--- a/src/pod.c
+++ b/src/pod.c
@@ -189,14 +189,14 @@ cc_pod_free (struct cc_pod *pod) {
 }
 
 /**
- * Start a container within a pod.
+ * Create a container within a pod.
  *
  * \param config \ref cc_oci_config.
  *
  * \return \c true on success, else \c false.
  */
 gboolean
-cc_pod_new_container (struct cc_oci_config *config)
+cc_pod_container_create (struct cc_oci_config *config)
 {
 	gboolean           ret = false;
 	ssize_t            bytes;
@@ -328,12 +328,6 @@ cc_pod_new_container (struct cc_oci_config *config)
 		goto out;
 	}
 
-	if (! cc_proxy_run_hyper_new_container (config,
-						config->optarg_container_id,
-						"rootfs", config->optarg_container_id)) {
-		goto out;
-	}
-
 	/* We can now disconnect from the proxy (but the shim
 	 * remains connected).
 	 */
@@ -345,6 +339,35 @@ out:
 	if (shim_socket_fd != -1) close (shim_socket_fd);
 
 	return ret;
+}
+
+/**
+ * Start a container within a pod.
+ *
+ * \param config \ref cc_oci_config.
+ *
+ * \return \c true on success, else \c false.
+ */
+gboolean
+cc_pod_container_start (struct cc_oci_config *config)
+{
+	const gchar *pod_id;
+
+	if (! (config && config->pod && ! config->pod->sandbox)) {
+		return false;
+	}
+
+	pod_id = cc_pod_container_id(config);
+	if (! pod_id) {
+		return false;
+	}
+
+	g_debug("Attaching to pod %s", pod_id);
+
+	return cc_proxy_hyper_new_pod_container(config,
+						config->optarg_container_id,
+						pod_id,
+						"rootfs", config->optarg_container_id);
 }
 
 /**

--- a/src/pod.h
+++ b/src/pod.h
@@ -35,5 +35,6 @@ gboolean cc_pod_container_create (struct cc_oci_config *config);
 gboolean cc_pod_container_start (struct cc_oci_config *config);
 const gchar *cc_pod_container_id(struct cc_oci_config *config);
 gboolean cc_pod_is_sandbox(struct cc_oci_config *config);
+gboolean cc_pod_is_vm(struct cc_oci_config *config);
 
 #endif /* _CC_POD_H */

--- a/src/pod.h
+++ b/src/pod.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of cc-oci-runtime.
+ *
+ * Copyright (C) 2016 Intel Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef _CC_POD_H
+#define _CC_POD_H
+
+#include <stdbool.h>
+
+#include <glib.h>
+
+#include "util.h"
+#include "oci.h"
+
+int cc_pod_handle_annotations(struct cc_oci_config *config, struct oci_cfg_annotation *annotation);
+void cc_pod_free (struct cc_pod *pod);
+
+#endif /* _CC_POD_H */

--- a/src/pod.h
+++ b/src/pod.h
@@ -30,5 +30,6 @@
 
 int cc_pod_handle_annotations(struct cc_oci_config *config, struct oci_cfg_annotation *annotation);
 void cc_pod_free (struct cc_pod *pod);
+gboolean cc_pod_new_container (struct cc_oci_config *config);
 
 #endif /* _CC_POD_H */

--- a/src/pod.h
+++ b/src/pod.h
@@ -33,5 +33,6 @@ struct cc_oci_mount *cc_pod_mount_point(struct cc_oci_config *config);
 void cc_pod_free (struct cc_pod *pod);
 gboolean cc_pod_new_container (struct cc_oci_config *config);
 const gchar *cc_pod_container_id(struct cc_oci_config *config);
+gboolean cc_pod_is_sandbox(struct cc_oci_config *config);
 
 #endif /* _CC_POD_H */

--- a/src/pod.h
+++ b/src/pod.h
@@ -29,6 +29,7 @@
 #include "oci.h"
 
 int cc_pod_handle_annotations(struct cc_oci_config *config, struct oci_cfg_annotation *annotation);
+struct cc_oci_mount *cc_pod_mount_point(struct cc_oci_config *config);
 void cc_pod_free (struct cc_pod *pod);
 gboolean cc_pod_new_container (struct cc_oci_config *config);
 

--- a/src/pod.h
+++ b/src/pod.h
@@ -31,7 +31,8 @@
 int cc_pod_handle_annotations(struct cc_oci_config *config, struct oci_cfg_annotation *annotation);
 struct cc_oci_mount *cc_pod_mount_point(struct cc_oci_config *config);
 void cc_pod_free (struct cc_pod *pod);
-gboolean cc_pod_new_container (struct cc_oci_config *config);
+gboolean cc_pod_container_create (struct cc_oci_config *config);
+gboolean cc_pod_container_start (struct cc_oci_config *config);
 const gchar *cc_pod_container_id(struct cc_oci_config *config);
 gboolean cc_pod_is_sandbox(struct cc_oci_config *config);
 

--- a/src/pod.h
+++ b/src/pod.h
@@ -32,5 +32,6 @@ int cc_pod_handle_annotations(struct cc_oci_config *config, struct oci_cfg_annot
 struct cc_oci_mount *cc_pod_mount_point(struct cc_oci_config *config);
 void cc_pod_free (struct cc_pod *pod);
 gboolean cc_pod_new_container (struct cc_oci_config *config);
+const gchar *cc_pod_container_id(struct cc_oci_config *config);
 
 #endif /* _CC_POD_H */

--- a/src/process.c
+++ b/src/process.c
@@ -64,6 +64,7 @@
 #include "common.h"
 #include "logging.h"
 #include "netlink.h"
+#include "pod.h"
 #include "proxy.h"
 #include "command.h"
 
@@ -1504,6 +1505,7 @@ cc_oci_vm_connect (struct cc_oci_config *config)
 	int         ioBase = -1;
 	int         proxy_io_fd = -1;
 	gint        exit_code = -1;
+	const gchar *container_id;
 
 	if(! config){
 		goto out;
@@ -1513,7 +1515,12 @@ cc_oci_vm_connect (struct cc_oci_config *config)
 		goto out;
 	}
 
-	if (! cc_proxy_attach (config->proxy, config->optarg_container_id)) {
+	container_id = cc_pod_container_id(config);
+	if (! container_id) {
+		goto out;
+	}
+
+	if (! cc_proxy_attach (config->proxy, container_id)) {
 		goto out;
 	}
 

--- a/src/process.c
+++ b/src/process.c
@@ -549,8 +549,8 @@ cc_oci_vm_netcfg_get (struct cc_oci_config *config,
  *
  * \return a GSocketConnection on success, else NULL.
  */
-private GSocketConnection *
-socket_connection_from_fd (int fd)
+GSocketConnection *
+cc_oci_socket_connection_from_fd (int fd)
 {
 	GError            *error = NULL;
 	GSocket           *socket = NULL;
@@ -600,7 +600,7 @@ out:
  *
  * \return \c true on success, else \c false.
  */
-private gboolean
+gboolean
 cc_shim_launch (struct cc_oci_config *config,
 		int *child_err_fd,
 		int *shim_args_fd,
@@ -695,7 +695,7 @@ cc_shim_launch (struct cc_oci_config *config,
 		}
 
 		/* read proxy IO fd from socket out-of-band */
-		connection = socket_connection_from_fd(shim_socket[0]);
+		connection = cc_oci_socket_connection_from_fd(shim_socket[0]);
 		if (!connection) {
 			g_critical ("failed to read proxy IO fd");
 			goto child_failed;
@@ -1198,7 +1198,7 @@ child_failed:
 	}
 
 	/* send proxy IO fd to cc-shim child */
-	shim_socket_connection = socket_connection_from_fd(shim_socket_fd);
+	shim_socket_connection = cc_oci_socket_connection_from_fd(shim_socket_fd);
 	if (! shim_socket_connection) {
 		g_critical("failed to create a socket connection to send proxy IO fd");
 		goto out;
@@ -1429,7 +1429,7 @@ cc_oci_exec_shim (struct cc_oci_config *config, int ioBase, int proxy_io_fd,
 	}
 
 	/* send proxy IO fd to cc-shim child */
-	shim_socket_connection = socket_connection_from_fd(shim_socket_fd);
+	shim_socket_connection = cc_oci_socket_connection_from_fd(shim_socket_fd);
 	if (! shim_socket_connection) {
 		g_critical("failed to create a socket connection to send proxy IO fd");
 		goto out;

--- a/src/process.h
+++ b/src/process.h
@@ -28,4 +28,12 @@ gboolean cc_run_hooks(GSList* hooks, const gchar* state_file_path,
 
 gboolean cc_oci_vm_connect (struct cc_oci_config *config);
 
+gboolean cc_shim_launch (struct cc_oci_config *config,
+			int *child_err_fd,
+			int *shim_args_fd,
+			int *shim_socket_fd,
+			gboolean initial_workload);
+
+GSocketConnection *cc_oci_socket_connection_from_fd (int fd);
+
 #endif /* _CC_OCI_PROCESS_H */

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -26,6 +26,7 @@
 #include "oci.h"
 #include "json.h"
 #include "common.h"
+#include "pod.h"
 #include "proxy.h"
 #include "util.h"
 #include "networking.h"
@@ -1433,14 +1434,21 @@ cc_proxy_hyper_kill_container (struct cc_oci_config *config, int signum)
 	JsonObject *killcontainer_payload;
 	char       *signum_str = NULL;
 	gboolean    ret = false;
+	const gchar *container_id;
 
 	if (! (config && config->proxy)) {
 		return false;
 	}
+
+	container_id = cc_pod_container_id(config);
+	if (! container_id) {
+		return false;
+	}
+
 	if (! cc_proxy_connect (config->proxy)) {
 		return false;
 	}
-	if (! cc_proxy_attach (config->proxy, config->optarg_container_id)) {
+	if (! cc_proxy_attach (config->proxy, container_id)) {
 		return false;
 	}
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1265,7 +1265,7 @@ out:
 gboolean
 cc_proxy_run_hyper_new_container (struct cc_oci_config *config,
 				  const char *container_id,
-				  char *rootfs)
+				  const char *rootfs, const char *image)
 {
 	JsonObject *newcontainer_payload= NULL;
 	JsonObject *process = NULL;
@@ -1312,7 +1312,7 @@ cc_proxy_run_hyper_new_container (struct cc_oci_config *config,
 				container_id);
 	json_object_set_string_member (newcontainer_payload, "rootfs", rootfs);
 
-	json_object_set_string_member (newcontainer_payload, "image", "");
+	json_object_set_string_member (newcontainer_payload, "image", image);
 	/*json_object_set_string_member (newcontainer_payload, "image",
 	  config->optarg_container_id);
 	  */
@@ -1406,7 +1406,7 @@ cc_proxy_hyper_new_container (struct cc_oci_config *config)
 	}
 
 	if (! cc_proxy_run_hyper_new_container (config,
-						config->optarg_container_id, "")) {
+						config->optarg_container_id, "", "")) {
 		goto out;
 	}
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1378,14 +1378,20 @@ cc_proxy_run_hyper_new_container (struct cc_oci_config *config,
 
 /**
  * Request \ref CC_OCI_PROXY to start a new container
- * using intial worload from \ref cc_oci_config
+ * within a pod, using intial worload from \ref cc_oci_config
  *
- * \param config
+ * \param config \ref cc_oci_config.
+ * \param container_id container ID
+ * \param pod_id pod container ID
+ * \param rootfs container rootfs path
+ * \param image container image name
  *
  * \return \c true on success, else \c false.
  */
 gboolean
-cc_proxy_hyper_new_container (struct cc_oci_config *config)
+cc_proxy_hyper_new_pod_container(struct cc_oci_config *config,
+				 const char *container_id, const char *pod_id,
+				 const char *rootfs, const char *image)
 {
 	gboolean ret = false;
 
@@ -1396,7 +1402,7 @@ cc_proxy_hyper_new_container (struct cc_oci_config *config)
 	if (! cc_proxy_connect (config->proxy)) {
 		goto out;
 	}
-	if (! cc_proxy_attach (config->proxy, config->optarg_container_id)) {
+	if (! cc_proxy_attach (config->proxy, pod_id)) {
 		goto out;
 	}
 
@@ -1407,7 +1413,8 @@ cc_proxy_hyper_new_container (struct cc_oci_config *config)
 	}
 
 	if (! cc_proxy_run_hyper_new_container (config,
-						config->optarg_container_id, "", "")) {
+						container_id,
+						rootfs, image)) {
 		goto out;
 	}
 
@@ -1418,6 +1425,23 @@ out:
 	}
 
 	return ret;
+}
+/**
+ * Request \ref CC_OCI_PROXY to start a new standalone
+ * container (e.g. a Docker one) using intial worload
+ * from \ref cc_oci_config.
+ *
+ * \param config
+ *
+ * \return \c true on success, else \c false.
+ */
+gboolean
+cc_proxy_hyper_new_container (struct cc_oci_config *config)
+{
+	return cc_proxy_hyper_new_pod_container(config,
+						config->optarg_container_id,
+						config->optarg_container_id,
+						"", "");
 }
 
 /**

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -56,7 +56,7 @@ cc_proxy_hyper_kill_container (struct cc_oci_config *config, int signum);
 gboolean cc_proxy_hyper_destroy_pod (struct cc_oci_config *config);
 gboolean cc_proxy_run_hyper_new_container (struct cc_oci_config *config,
 					const char *container_id,
-					char *rootfs);
+					const char *rootfs, const char *image);
 gboolean cc_proxy_hyper_new_container (struct cc_oci_config *config);
 void cc_proxy_free (struct cc_proxy *proxy);
 gboolean cc_proxy_attach (struct cc_proxy *proxy, const char *container_id);

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -57,6 +57,9 @@ gboolean cc_proxy_hyper_destroy_pod (struct cc_oci_config *config);
 gboolean cc_proxy_run_hyper_new_container (struct cc_oci_config *config,
 					const char *container_id,
 					const char *rootfs, const char *image);
+gboolean cc_proxy_hyper_new_pod_container(struct cc_oci_config *config,
+					const char *container_id, const char *pod_id,
+					const char *rootfs, const char *image);
 gboolean cc_proxy_hyper_new_container (struct cc_oci_config *config);
 void cc_proxy_free (struct cc_proxy *proxy);
 gboolean cc_proxy_attach (struct cc_proxy *proxy, const char *container_id);

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -45,6 +45,7 @@
 
 gboolean cc_proxy_connect (struct cc_proxy *proxy);
 gboolean cc_proxy_disconnect (struct cc_proxy *proxy);
+gboolean cc_proxy_attach (struct cc_proxy *proxy, const char *container_id);
 gboolean cc_proxy_wait_until_ready (struct cc_oci_config *config);
 gboolean cc_proxy_hyper_pod_create (struct cc_oci_config *config);
 gboolean cc_proxy_cmd_bye (struct cc_proxy *proxy, const char *container_id);
@@ -53,6 +54,9 @@ gboolean cc_proxy_cmd_allocate_io (struct cc_proxy *proxy, int *proxy_io_fd,
 gboolean
 cc_proxy_hyper_kill_container (struct cc_oci_config *config, int signum);
 gboolean cc_proxy_hyper_destroy_pod (struct cc_oci_config *config);
+gboolean cc_proxy_run_hyper_new_container (struct cc_oci_config *config,
+					const char *container_id,
+					char *rootfs);
 gboolean cc_proxy_hyper_new_container (struct cc_oci_config *config);
 void cc_proxy_free (struct cc_proxy *proxy);
 gboolean cc_proxy_attach (struct cc_proxy *proxy, const char *container_id);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -107,7 +107,7 @@ cc_oci_runtime_dir_setup (struct cc_oci_config *config)
 
 	g_debug ("creating directory %s", config->state.runtime_path);
 
-	return ! g_mkdir (config->state.runtime_path, CC_OCI_DIR_MODE);
+	return ! g_mkdir_with_parents (config->state.runtime_path, CC_OCI_DIR_MODE);
 }
 
 /*!

--- a/src/spec_handlers/annotations.c
+++ b/src/spec_handlers/annotations.c
@@ -18,7 +18,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include <string.h>
+
 #include "spec_handler.h"
+#include "pod.h"
 
 static void
 handle_annotation (GNode* root, struct cc_oci_config* config)
@@ -47,6 +50,13 @@ handle_annotation (GNode* root, struct cc_oci_config* config)
 	a->key = g_strdup (key);
 	if (value && *value) {
 		a->value = g_strdup (value);
+	}
+
+	g_debug ("New annotation: [%s]:[%s]", a->key, a->value ? a->value : "N/A");
+
+	if (cc_pod_handle_annotations(config, a) < 0) {
+		g_critical("Could not handle pod annotation [%s]:[%s]",
+			   a->key, a->value);
 	}
 
 	config->oci.annotations = g_slist_prepend

--- a/tests/pod_test.c
+++ b/tests/pod_test.c
@@ -32,6 +32,7 @@
 
 const gchar *cc_pod_container_id(struct cc_oci_config *config);
 gboolean cc_pod_is_sandbox(struct cc_oci_config *config);
+gboolean cc_pod_is_vm(struct cc_oci_config *config);
 
 START_TEST(test_cc_pod_container_id) {
 	struct cc_oci_config *config = NULL;
@@ -75,11 +76,30 @@ START_TEST(test_cc_pod_is_sandbox) {
 	ck_assert(cc_pod_is_sandbox(config));
 } END_TEST
 
+START_TEST(test_cc_pod_is_vm) {
+	struct cc_oci_config *config = NULL;
+	ck_assert(cc_pod_is_vm(config));
+
+	config = cc_oci_config_create ();
+	ck_assert(config);
+	ck_assert(cc_pod_is_vm(config));
+
+	config->pod = g_malloc0 (sizeof (struct cc_pod));
+	ck_assert(config->pod);
+
+	config->pod->sandbox = false;
+	ck_assert(!cc_pod_is_vm(config));
+
+	config->pod->sandbox = true;
+	ck_assert(cc_pod_is_vm(config));
+} END_TEST
+
 Suite* make_pod_suite(void) {
 	Suite* s = suite_create(__FILE__);
 
 	ADD_TEST (test_cc_pod_container_id, s);
 	ADD_TEST (test_cc_pod_is_sandbox, s);
+	ADD_TEST (test_cc_pod_is_vm, s);
 
 	return s;
 }

--- a/tests/pod_test.c
+++ b/tests/pod_test.c
@@ -31,6 +31,7 @@
 #include "oci.h"
 
 const gchar *cc_pod_container_id(struct cc_oci_config *config);
+gboolean cc_pod_is_sandbox(struct cc_oci_config *config);
 
 START_TEST(test_cc_pod_container_id) {
 	struct cc_oci_config *config = NULL;
@@ -56,11 +57,29 @@ START_TEST(test_cc_pod_container_id) {
         g_free(config->pod);
 } END_TEST
 
+START_TEST(test_cc_pod_is_sandbox) {
+	struct cc_oci_config *config = NULL;
+	ck_assert(!cc_pod_is_sandbox(config));
+
+	config = cc_oci_config_create ();
+	ck_assert(config);
+	ck_assert(!cc_pod_is_sandbox(config));
+
+	config->pod = g_malloc0 (sizeof (struct cc_pod));
+	ck_assert(config->pod);
+
+	config->pod->sandbox = false;
+	ck_assert(!cc_pod_is_sandbox(config));
+
+	config->pod->sandbox = true;
+	ck_assert(cc_pod_is_sandbox(config));
+} END_TEST
+
 Suite* make_pod_suite(void) {
 	Suite* s = suite_create(__FILE__);
 
 	ADD_TEST (test_cc_pod_container_id, s);
-//	ADD_TEST (test_cc_proxy_disconnect, s);
+	ADD_TEST (test_cc_pod_is_sandbox, s);
 
 	return s;
 }

--- a/tests/pod_test.c
+++ b/tests/pod_test.c
@@ -1,0 +1,89 @@
+/*
+ * This file is part of cc-oci-runtime.
+ * 
+ * Copyright (C) 2016 Intel Corporation
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <check.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include "test_common.h"
+#include "logging.h"
+#include "pod.h"
+#include "oci.h"
+
+const gchar *cc_pod_container_id(struct cc_oci_config *config);
+
+START_TEST(test_cc_pod_container_id) {
+	struct cc_oci_config *config = NULL;
+	ck_assert(!cc_pod_container_id(config));
+
+	config = cc_oci_config_create ();
+	ck_assert (config);
+
+	config->optarg_container_id = "pod1";
+
+	ck_assert(! g_strcmp0(cc_pod_container_id(config), "pod1"));
+
+	config->pod = g_malloc0 (sizeof (struct cc_pod));
+	ck_assert(config->pod);
+
+	config->pod->sandbox_name = "sandbox1";
+	config->pod->sandbox = false;
+	ck_assert(! g_strcmp0(cc_pod_container_id(config), "sandbox1"));
+
+	config->pod->sandbox = true;
+	ck_assert(! g_strcmp0(cc_pod_container_id(config), "pod1"));
+
+        g_free(config->pod);
+} END_TEST
+
+Suite* make_pod_suite(void) {
+	Suite* s = suite_create(__FILE__);
+
+	ADD_TEST (test_cc_pod_container_id, s);
+//	ADD_TEST (test_cc_proxy_disconnect, s);
+
+	return s;
+}
+
+int main (void) {
+	int number_failed;
+	Suite* s;
+	SRunner* sr;
+	struct cc_log_options options = { 0 };
+
+	options.enable_debug = true;
+	options.use_json = false;
+	options.filename = g_strdup ("pod_test_debug.log");
+	(void)cc_oci_log_init(&options);
+
+	s = make_pod_suite();
+	sr = srunner_create(s);
+
+	srunner_run_all(sr, CK_VERBOSE);
+	number_failed = srunner_ntests_failed(sr);
+	srunner_free(sr);
+
+	cc_oci_log_free (&options);
+
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/process_test.c
+++ b/tests/process_test.c
@@ -42,13 +42,13 @@ gboolean cc_run_hook (struct oci_cfg_hook* hook,
 gboolean cc_oci_setup_shim (struct cc_oci_config *config,
 		int proxy_fd,
 		int proxy_io_fd);
-GSocketConnection *socket_connection_from_fd (int fd);
+GSocketConnection *cc_oci_socket_connection_from_fd (int fd);
 gboolean cc_oci_setup_child (struct cc_oci_config *config);
 gboolean cc_oci_vm_netcfg_get (struct cc_oci_config *config,
 		struct netlink_handle *hndl);
 gboolean
 cc_shim_launch (struct cc_oci_config *config, int *child_err_fd,
-		int *shim_args_fd, int *shim_socket_fd);
+		int *shim_args_fd, int *shim_socket_fd, gboolean initial_workload);
 
 extern GMainLoop *hook_loop;
 
@@ -225,12 +225,12 @@ START_TEST(test_cc_oci_setup_shim) {
 START_TEST(test_socket_connection_from_fd) {
 	int sockets[2] = { -1, -1 };
 	GSocketConnection *conn = NULL;
-	ck_assert (! socket_connection_from_fd (-1));
+	ck_assert (! cc_oci_socket_connection_from_fd (-1));
 
 	ck_assert (socketpair(PF_UNIX, SOCK_STREAM, 0, sockets) == 0);
 	close (sockets[0]);
 
-	conn = socket_connection_from_fd (sockets[1]);
+	conn = cc_oci_socket_connection_from_fd (sockets[1]);
 	ck_assert (conn);
 	g_object_unref (conn);
 	close(sockets[1]);


### PR DESCRIPTION
This pull request make Clear Containers work with the latest [CRI-O](https://github.com/kubernetes-incubator/cri-o) code.

CRI-O is a [Kubernetes CRI](https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/container-runtime-interface-v1.md) implementation for OCI compatible runtimes.
CRI-O only manages [Kubernetes pods](http://kubernetes.io/docs/user-guide/pods/) composed of 1 or more containers. In order to have COR embrace that concept, we add a pod structure to our config and state structures. This structure is also marshalled into our container state.json file.

```C
struct cc_pod {
	/** If \c true, this is a sandbox container. */
	gboolean sandbox;

	/**
	 * The sandbox name holds the container ID for the
	 * sandbox container.
	 */
	gchar    *sandbox_name;

	/**
	 * The sandbox workloads is where all pod containers rootfs
	 * will be bind mounted.
	 * A container rootfs will be bind mounted under
	 * /sandbox_workloads/<container_id>/rootfs.
	 */
	gchar    sandbox_workloads[PATH_MAX];
};
```

This structure allows us to track if any given container:
1) Is a pod sandbox container, i.e. a container that will define the namespaces and cgroup where all the containers running within that pod will live. For COR, a pod sandbox container is the virtual machine.
2) Is a intra pod container, i.e. a container running within a pod VM.
3) Is neither a sandbox container nor an intra pod container. This is the regular docker container, outside of kubernetes.

Eventually, we would like to propose removing case 3, and only see it as an intra pod container. This will simplify the current code flow.

### TODO

- [X] Create tests for the pod.c code