### PR TITLE
proxy: Simplify fd passing and the message read loop

### DIFF
--- a/proxy/api/client.go
+++ b/proxy/api/client.go
@@ -17,6 +17,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 )
@@ -62,6 +63,39 @@ func (client *Client) sendPayload(id string, payload interface{}) (*Response, er
 	}
 
 	return &resp, nil
+}
+
+// sendPayloadGetFd will send a command payload and get a response back
+// but also an out of band file descriptor.
+func (client *Client) sendPayloadGetFd(id string, payload interface{}) (*Response, *os.File, error) {
+	var err error
+
+	req := Request{}
+	req.ID = id
+	if payload != nil {
+		if req.Data, err = json.Marshal(payload); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	if err := WriteMessage(client.conn, &req); err != nil {
+		return nil, nil, err
+	}
+
+	// I/O fd
+	newFd, err := ReadFd(client.conn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("sendPayloadGetFd: couldn't read fd for request %s", id)
+	}
+
+	ioFile := os.NewFile(uintptr(newFd), "")
+
+	resp := Response{}
+	if err := ReadMessage(client.conn, &resp); err != nil {
+		return nil, nil, err
+	}
+
+	return &resp, ioFile, nil
 }
 
 func errorFromResponse(resp *Response) error {
@@ -114,7 +148,7 @@ func (client *Client) AllocateIo(nStreams int) (ioBase uint64, ioFile *os.File, 
 		NStreams: nStreams,
 	}
 
-	resp, err := client.sendPayload("allocateIO", &allocate)
+	resp, ioFile, err := client.sendPayloadGetFd("allocateIO", &allocate)
 	if err != nil {
 		return
 	}
@@ -130,14 +164,6 @@ func (client *Client) AllocateIo(nStreams int) (ioBase uint64, ioFile *os.File, 
 	}
 
 	ioBase = (uint64)(val.(float64))
-
-	// I/O fd
-	newFd, err := ReadFd(client.conn)
-	if err != nil {
-		return 0, nil, errors.New("allocateio: couldn't read fd")
-	}
-
-	ioFile = os.NewFile(uintptr(newFd), "")
 
 	return
 }

--- a/proxy/protocol.go
+++ b/proxy/protocol.go
@@ -128,14 +128,7 @@ func (proto *protocol) Serve(conn net.Conn, userData interface{}) error {
 		// Execute the corresponding handler
 		resp := proto.handleRequest(ctx, &req, &hr)
 
-		// Send the response back to the client.
-		if err = api.WriteMessage(conn, resp); err != nil {
-			// Something made us unable to write the response back
-			// to the client (could be a disconnection, ...).
-			return err
-		}
-
-		// And send a fd if the handler associated a file with the response
+		// First send an fd if the handler associated a file with the response
 		if hr.file != nil {
 			if err = api.WriteFd(conn.(*net.UnixConn), int(hr.file.Fd())); err != nil {
 				return err
@@ -143,5 +136,11 @@ func (proto *protocol) Serve(conn net.Conn, userData interface{}) error {
 			hr.file.Close()
 		}
 
+		// Then send the response back to the client.
+		if err = api.WriteMessage(conn, resp); err != nil {
+			// Something made us unable to write the response back
+			// to the client (could be a disconnection, ...).
+			return err
+		}
 	}
 }

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -28,6 +28,21 @@
 /* allocate 2 streams, stdio and stderr */
 #define IO_STREAMS_NUMBER 2
 
+/*
+ * 4 bytes for the message length.
+ * 4 bytes for the message flags.
+ */
+#define HEADER_MESSAGE_LENGTH 4
+#define HEADER_MESSAGE_FLAGS  4
+#define MESSAGE_HEADER_LENGTH (HEADER_MESSAGE_LENGTH+HEADER_MESSAGE_FLAGS)
+
+/*
+ * As we can not send OOB data through a stream socket
+ * without sending actual data, the proxy will signal
+ * OOB data by sending a single byte message: 'F'.
+ */
+#define OOB_FD_FLAG 'F'
+
 gboolean cc_proxy_connect (struct cc_proxy *proxy);
 gboolean cc_proxy_disconnect (struct cc_proxy *proxy);
 gboolean cc_proxy_wait_until_ready (struct cc_oci_config *config);


### PR DESCRIPTION
When passing the OOB fd data, we pass the dummy data ('F') and
that simplifies the message reading loop:

- When receiving a message, we no longer need to read the OOB data
  at any point in time, but only at first.

- We only need to read actual data in the read loop, and there we
  can handle EAGAIN more robustly: We retry as long as we don't
  get the whole message length.

Fixes #508

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>