### PR TITLE
Fix docker exec and test memory leak

### DIFF
--- a/src/commands/exec.c
+++ b/src/commands/exec.c
@@ -165,8 +165,13 @@ handler_exec (const struct subcommand *sub,
 
 	process->user.uid = start_data.user.uid;
 	process->user.gid = start_data.user.gid;
-	process->terminal = (start_data.console != NULL ? true : false);
 	process->env = env;
+	if ((start_data.console != NULL) && (start_data.console[0])) {
+		process->terminal = true;
+	} else {
+		process->terminal = false;
+	}
+
 	if (cwd){
 		if (snprintf (process->cwd, sizeof(process->cwd),
 		    "%s", cwd) < 0) {

--- a/src/oci.c
+++ b/src/oci.c
@@ -1050,11 +1050,6 @@ cc_oci_exec (struct cc_oci_config *config,
 		}
 	}
 
-	/* Update config so that the pod pointer is accurate. */
-	if (! cc_oci_config_update (config, state)) {
-		goto out;
-	}
-
 	if (! cc_oci_vm_connect (config)) {
 		g_critical ("failed to connect to VM");
 		goto out;

--- a/tests/pod_test.c
+++ b/tests/pod_test.c
@@ -29,6 +29,7 @@
 #include "logging.h"
 #include "pod.h"
 #include "oci.h"
+#include "oci-config.h"
 
 const gchar *cc_pod_container_id(struct cc_oci_config *config);
 gboolean cc_pod_is_sandbox(struct cc_oci_config *config);
@@ -36,6 +37,7 @@ gboolean cc_pod_is_vm(struct cc_oci_config *config);
 
 START_TEST(test_cc_pod_container_id) {
 	struct cc_oci_config *config = NULL;
+
 	ck_assert(!cc_pod_container_id(config));
 
 	config = cc_oci_config_create ();
@@ -48,18 +50,20 @@ START_TEST(test_cc_pod_container_id) {
 	config->pod = g_malloc0 (sizeof (struct cc_pod));
 	ck_assert(config->pod);
 
-	config->pod->sandbox_name = "sandbox1";
+	config->pod->sandbox_name = g_strdup("sandbox1");
 	config->pod->sandbox = false;
 	ck_assert(! g_strcmp0(cc_pod_container_id(config), "sandbox1"));
 
 	config->pod->sandbox = true;
 	ck_assert(! g_strcmp0(cc_pod_container_id(config), "pod1"));
 
-        g_free(config->pod);
+	/* clean up */
+	cc_oci_config_free (config);
 } END_TEST
 
 START_TEST(test_cc_pod_is_sandbox) {
 	struct cc_oci_config *config = NULL;
+
 	ck_assert(!cc_pod_is_sandbox(config));
 
 	config = cc_oci_config_create ();
@@ -74,10 +78,14 @@ START_TEST(test_cc_pod_is_sandbox) {
 
 	config->pod->sandbox = true;
 	ck_assert(cc_pod_is_sandbox(config));
+
+	/* clean up */
+	cc_oci_config_free (config);
 } END_TEST
 
 START_TEST(test_cc_pod_is_vm) {
 	struct cc_oci_config *config = NULL;
+
 	ck_assert(cc_pod_is_vm(config));
 
 	config = cc_oci_config_create ();
@@ -92,6 +100,9 @@ START_TEST(test_cc_pod_is_vm) {
 
 	config->pod->sandbox = true;
 	ck_assert(cc_pod_is_vm(config));
+
+	/* clean up */
+	cc_oci_config_free (config);
 } END_TEST
 
 Suite* make_pod_suite(void) {


### PR DESCRIPTION
The CRI-O merge broke docker exec and introduced a test memory leak.
We only saw these issues when using cc-oci-runtime directly and not cc-oci-runtime.sh.

The console argument we receive is not NULL but empty (to signal us that we simply got `--console`) is set. So we need to check for the argument being non NULL and not empty to determine that we're using a terminal.

With the CRI-O merge we introduced a pointless config update that was breaking the interactive docker exec use case.

The `pod_test.c` tests were allocating a config pointer without releasing it. This is fixed as well.