### PR TITLE
CRI exec fixes

### DIFF
--- a/src/oci.c
+++ b/src/oci.c
@@ -1050,6 +1050,16 @@ cc_oci_exec (struct cc_oci_config *config,
 		}
 	}
 
+	/*
+	 * We need an accurate pod pointer in order
+	 * to attach to the right VM
+	 */
+	if (state->pod) {
+		cc_pod_free (config->pod);
+		config->pod = state->pod;
+		state->pod = NULL;
+	}
+
 	if (! cc_oci_vm_connect (config)) {
 		g_critical ("failed to connect to VM");
 		goto out;

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1606,7 +1606,9 @@ cc_proxy_hyper_exec_command (struct cc_oci_config *config)
 		json_array_add_object_element (envs, env_var);
 	}
 
-	json_object_set_string_member (process_node, "workdir", process->cwd);
+	if (process->cwd[0]) {
+		json_object_set_string_member (process_node, "workdir", process->cwd);
+	}
 	json_object_set_array_member (process_node, "args", args);
 	json_object_set_array_member (process_node, "envs", envs);
 	json_object_set_object_member (payload,

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -1091,6 +1091,7 @@ START_TEST(test_cc_oci_exec) {
 	struct cc_oci_config config = { { 0 } };
 	struct oci_state state;
 	char  *process_json = NULL;
+	state.pod = NULL;
 	ck_assert(! cc_oci_exec(NULL, NULL, NULL));
 	ck_assert(! cc_oci_exec(&config, &state, NULL));
 	ck_assert(! cc_oci_exec(&config, &state, process_json));


### PR DESCRIPTION
Support for CRI-O exec was broken:

- The config pod pointer is empty when calling exec on cc-oci-runtime. Therefore, we can not know which VM to attach to when being called from CRI-O
- CRI-O calls exec without a process.json file and thus we're giving hyperstart a process with an empty CWD to exec and that fails.

This PR fixes both issues.