### PR TITLE
proxy fd leak & fd leak detector

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -259,6 +259,7 @@ cc_proxy_sources =			\
 	proxy/api/fdpassing.go		\
 	proxy/api/fdpassing_test.go	\
 	proxy/api/protocol.go		\
+	proxy/fdleak_test.go		\
 	proxy/protocol.go		\
 	proxy/protocol_test.go		\
 	proxy/proxy.go			\

--- a/proxy/fdleak_test.go
+++ b/proxy/fdleak_test.go
@@ -1,0 +1,493 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func fcntl(fd int, cmd int, arg int) (val int, err error) {
+	r0, _, errno := syscall.Syscall(
+		syscall.SYS_FCNTL, uintptr(fd), uintptr(cmd), uintptr(arg))
+	val = int(r0)
+	if errno != 0 {
+		err = errno
+	}
+	return
+}
+
+// FdLeakDetector detects fd leaks by letting its user take snapshots of the
+// list of opened fds at key points in the profiled program and compare two
+// snapshots.
+type FdLeakDetector struct {
+}
+
+type FdInfo struct {
+	Fd          int
+	Flags       int
+	CloseOnExec bool
+	Text        string
+}
+
+func (info *FdInfo) dump(w io.Writer) {
+	flags := make([]string, 5)
+
+	if info.CloseOnExec {
+		flags = append(flags, "cloexec")
+	}
+
+	// file status
+	if info.Flags&syscall.O_APPEND != 0 {
+		flags = append(flags, "append")
+	}
+	if info.Flags&syscall.O_NONBLOCK != 0 {
+		flags = append(flags, "nonblock")
+	}
+
+	// acc mode
+	if info.Flags&syscall.O_RDONLY != 0 {
+		flags = append(flags, "read-only")
+	}
+	if info.Flags&syscall.O_RDWR != 0 {
+		flags = append(flags, "read-write")
+	}
+	if info.Flags&syscall.O_WRONLY != 0 {
+		flags = append(flags, "write-only")
+	}
+	if info.Flags&syscall.O_DSYNC != 0 {
+		flags = append(flags, "dsync")
+	}
+	if info.Flags&syscall.O_RSYNC != 0 {
+		flags = append(flags, "rsync")
+	}
+	if info.Flags&syscall.O_SYNC != 0 {
+		flags = append(flags, "sync")
+	}
+
+	fmt.Fprintf(w, "  %d: %s (%s)\n", info.Fd, info.Text,
+		strings.Join(flags, ""))
+}
+
+func (info *FdInfo) equal(other *FdInfo) bool {
+	return reflect.DeepEqual(info, other)
+}
+
+type FdSnapshot struct {
+	Fds []FdInfo
+}
+
+// ByFd implements sort.Interface for []FdInfo based on the Fd field.
+type ByFd []FdInfo
+
+func (a ByFd) Len() int           { return len(a) }
+func (a ByFd) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByFd) Less(i, j int) bool { return a[i].Fd < a[j].Fd }
+
+func newFdSnapshot() *FdSnapshot {
+	return &FdSnapshot{}
+}
+
+func (snap *FdSnapshot) FdInfo(i int) *FdInfo {
+	return &snap.Fds[i]
+}
+
+func (snap *FdSnapshot) dump(w io.Writer) {
+	for _, info := range snap.Fds {
+		info.dump(w)
+	}
+}
+
+// NewFdLeadDetector creates a new FdLeakDetector
+func NewFdLeadDetector() *FdLeakDetector {
+	return &FdLeakDetector{}
+}
+
+const selfFdPath = "/proc/self/fd"
+
+// Snapshot captures the list of opened file descriptors of the current
+// process
+func (d *FdLeakDetector) Snapshot() (snap *FdSnapshot, err error) {
+	root, err := os.Open(selfFdPath)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+
+	infos, err := root.Readdir(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	snap = newFdSnapshot()
+	for _, info := range infos {
+		fd, err := strconv.Atoi(info.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		// Don't capture the fd used to list /proc/self/fd
+		if fd == int(root.Fd()) {
+			continue
+		}
+
+		flags, err := fcntl(fd, syscall.F_GETFL, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		fdFlags, err := fcntl(fd, syscall.F_GETFD, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		// readlink on /proc/self/fd gives nice textual information
+		// about the fd
+		rl, err := os.Readlink(fmt.Sprintf("%s/%d", selfFdPath, fd))
+		if err != nil {
+			return nil, err
+		}
+
+		snap.Fds = append(snap.Fds, FdInfo{
+			Fd:          fd,
+			Flags:       flags,
+			CloseOnExec: fdFlags&syscall.FD_CLOEXEC != 0,
+			Text:        rl,
+		})
+	}
+
+	sort.Sort(ByFd(snap.Fds))
+
+	return
+}
+
+// Compare writes to w the differences between the a and b snaphots.
+// true will be returned if the two snapshots are equal, false otherwise.
+func (d *FdLeakDetector) Compare(w io.Writer, a, b *FdSnapshot) bool {
+	equal := true
+
+	i := 0
+	j := 0
+
+	for i < len(a.Fds) && j < len(b.Fds) {
+		aInfo := a.FdInfo(i)
+		bInfo := b.FdInfo(j)
+
+		if aInfo.Fd == bInfo.Fd {
+			// File descriptor found in both snapshots
+			equal = aInfo.equal(bInfo)
+			i++
+			j++
+
+			if !equal {
+				fmt.Fprintf(w, "- fd %d\n", aInfo.Fd)
+				aInfo.dump(w)
+				fmt.Fprintf(w, "+ fd %d\n", bInfo.Fd)
+				bInfo.dump(w)
+			}
+		} else if aInfo.Fd < bInfo.Fd {
+			// File descriptor present in a but not in b
+			equal = false
+			i++
+
+			fmt.Fprintf(w, "- fd %d\n", aInfo.Fd)
+			aInfo.dump(w)
+		} else {
+			// File descriptor present in b but not in a
+			equal = false
+			j++
+
+			fmt.Fprintf(w, "+ fd %d\n", bInfo.Fd)
+			bInfo.dump(w)
+		}
+	}
+
+	for ; i < len(a.Fds); i++ {
+		// File descriptor present in a but not in b
+		equal = false
+		aInfo := a.FdInfo(i)
+
+		fmt.Fprintf(w, "- fd %d\n", aInfo.Fd)
+		aInfo.dump(w)
+	}
+
+	for ; j < len(b.Fds); j++ {
+		// File descriptor present in b but not in a
+		equal = false
+		bInfo := b.FdInfo(j)
+
+		fmt.Fprintf(w, "+ fd %d\n", bInfo.Fd)
+		bInfo.dump(w)
+	}
+
+	return equal
+}
+
+func TestFdDetectorNoLeak(t *testing.T) {
+	detector := NewFdLeadDetector()
+
+	old, err := detector.Snapshot()
+	if err != nil {
+		t.Error(err)
+	}
+
+	new, err := detector.Snapshot()
+	if err != nil {
+		t.Error(err)
+	}
+
+	buffer := bytes.NewBuffer(nil)
+	equal := detector.Compare(buffer, old, new)
+	if buffer.Len() != 0 {
+		fmt.Print(buffer.String())
+		t.Fatal()
+	}
+	if !equal {
+		fmt.Print(buffer.String())
+		t.Fatal()
+	}
+}
+
+func TestFdDetectorLeak(t *testing.T) {
+	detector := NewFdLeadDetector()
+
+	old, err := detector.Snapshot()
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = os.Open("/dev/null")
+	if err != nil {
+		t.Error(err)
+	}
+
+	new, err := detector.Snapshot()
+	if err != nil {
+		t.Error(err)
+	}
+
+	buffer := bytes.NewBuffer(nil)
+	equal := detector.Compare(buffer, old, new)
+	if equal {
+		fmt.Print(buffer.String())
+		t.Fatal()
+	}
+}
+
+func TestFdDetectorCompare(t *testing.T) {
+	tests := []struct {
+		old, new *FdSnapshot
+		equal    bool
+	}{
+		// Same fds
+		{
+			old: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDWR,
+					},
+					{
+						Fd:    1,
+						Flags: syscall.O_RDWR,
+						Text:  "/foo",
+					},
+				},
+			},
+			new: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDWR,
+					},
+					{
+						Fd:    1,
+						Flags: syscall.O_RDWR,
+						Text:  "/foo",
+					},
+				},
+			},
+			equal: true,
+		},
+
+		// Same fd number, different flags
+		{
+			old: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDWR,
+					},
+					{
+						Fd:    1,
+						Flags: syscall.O_RDWR,
+						Text:  "/foo",
+					},
+				},
+			},
+			new: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDWR,
+					},
+					{
+						Fd:    1,
+						Flags: syscall.O_RDONLY,
+						Text:  "/foo",
+					},
+				},
+			},
+			equal: false,
+		},
+
+		// Same fd number, different close on exec status
+		{
+			old: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDWR,
+					},
+					{
+						Fd:          1,
+						Flags:       syscall.O_RDWR,
+						CloseOnExec: true,
+						Text:        "/foo",
+					},
+				},
+			},
+			new: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDWR,
+					},
+					{
+						Fd:    1,
+						Flags: syscall.O_RDWR,
+						Text:  "/foo",
+					},
+				},
+			},
+			equal: false,
+		},
+
+		// Same fd number, different readlink
+		{
+			old: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDWR,
+					},
+					{
+						Fd:    1,
+						Flags: syscall.O_RDWR,
+						Text:  "/foo",
+					},
+				},
+			},
+			new: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDWR,
+					},
+					{
+						Fd:    1,
+						Flags: syscall.O_RDWR,
+						Text:  "/bar",
+					},
+				},
+			},
+			equal: false,
+		},
+
+		// old has more fds
+		{
+			old: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDWR,
+					},
+					{
+						Fd:    1,
+						Flags: syscall.O_RDWR,
+						Text:  "/foo",
+					},
+				},
+			},
+			new: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDWR,
+					},
+				},
+			},
+			equal: false,
+		},
+
+		// new has more fds
+		{
+			old: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDWR,
+					},
+				},
+			},
+			new: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDWR,
+					},
+					{
+						Fd:    1,
+						Flags: syscall.O_RDWR,
+						Text:  "/foo",
+					},
+				},
+			},
+			equal: false,
+		},
+	}
+
+	detector := NewFdLeadDetector()
+
+	for i, test := range tests {
+		buffer := bytes.NewBuffer(nil)
+
+		equal := detector.Compare(buffer, test.old, test.new)
+		if equal != test.equal {
+			test.old.dump(os.Stderr)
+			test.new.dump(os.Stderr)
+			fmt.Print(buffer.String())
+			t.Fatal(fmt.Sprintf("Failed test #%d", i))
+		}
+	}
+}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -178,6 +178,10 @@ func (rig *testRig) Stop() {
 	rig.Hyperstart.Stop()
 
 	rig.wg.Wait()
+
+	if rig.proxy != nil {
+		rig.proxy.wg.Wait()
+	}
 }
 
 const testContainerID = "0987654321"

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -268,7 +268,7 @@ func TestAttach(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// Attaching to an existing VM should work. To test we are effectively
-	// attached, we issue a bye that would error out if not attatched.
+	// attached, we issue a bye that would error out if not attached.
 	err = rig.Client.Attach(testContainerID)
 	assert.Nil(t, err)
 	err = rig.Client.Bye(testContainerID)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -80,7 +80,11 @@ func (rig *testRig) Start() {
 	rig.Hyperstart.Start()
 
 	// Explicitly send READY message from hyperstart mock
-	go rig.Hyperstart.SendMessage(int(hyper.INIT_READY), []byte{})
+	rig.wg.Add(1)
+	go func() {
+		rig.Hyperstart.SendMessage(int(hyper.INIT_READY), []byte{})
+		rig.wg.Done()
+	}()
 
 	// we can either "start" the proxy in process or spawn a proxy process.
 	// Spawning the process (through TestLaunchProxy).

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -460,5 +460,7 @@ func TestAllocateIo(t *testing.T) {
 	assert.Equal(t, 1, len(data))
 	assert.Equal(t, uint8(17), data[0])
 
+	ioFile.Close()
+
 	rig.Stop()
 }


### PR DESCRIPTION
@devimc noticed a fd leak when killing the proxy savagely, it was due to the proxy never receiving the Bye payload.

Instead, the proxy now cleans up the per-VM resources when it detects the qemu process is gone.

I've added a generic "fd leak detector" that can help catch fd leaks and instrumented the proxy unit tests to check for those. A neat little thing that can be reused in other go projects:

  https://github.com/dlespiau/cc-oci-runtime/blob/20170109-fd-leak-detector/proxy/fdleak_test.go

This leaves the case where the qemu process never goes away. It shouldn't happen, but we may want to improve our robustness with a mechanism killing qemu "after some time". It's not quite clear at this point if we should do that, it'd hide bugs and we'd have to decide where to put that mechanism (delete of the runtime? proxy?)