### PR TITLE
ci: Split go static checks so developers can invoke them

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -63,16 +63,4 @@ fi
  && sudo make install \
  && make check)
 
-# go checks
-export go_packages=$(go list ./... | grep -v cc-oci-runtime/vendor |\
-    sed -e 's#.*/cc-oci-runtime/#./#')
-
-go list -f '{{.Dir}}/*.go' $go_packages |\
-    xargs -I % bash -c "misspell -error %"
-go vet $go_packages
-go list -f '{{.Dir}}' $go_packages |\
-    xargs gofmt -s -l | wc -l |\
-    xargs -I % bash -c "test % -eq 0"
-go list -f '{{.Dir}}' $go_packages | xargs gocyclo -over 15
-
-for p in $go_packages; do golint -set_exit_status $p; done
+$(dirname "$0")/ci-go-static-checks.sh

--- a/.ci/ci-go-static-checks.sh
+++ b/.ci/ci-go-static-checks.sh
@@ -33,6 +33,18 @@ go_packages=$*
 		    sed -e 's#.*/cc-oci-runtime/#./#')
 }
 
+function install_package {
+	url="$1"
+	name=${url##*/}
+
+	echo Updating $name...
+	go get -u $url
+}
+
+install_package github.com/fzipp/gocyclo
+install_package github.com/client9/misspell/cmd/misspell
+install_package github.com/golang/lint/golint
+
 echo Doing go static checks on packages: $go_packages
 
 go list -f '{{.Dir}}/*.go' $go_packages |\

--- a/.ci/ci-go-static-checks.sh
+++ b/.ci/ci-go-static-checks.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+set -e
+
+# Perform go static tests.
+#
+#   .ci/ci-go-static-checks.sh [packages]
+#
+# One can specify the list of packages to test on the command line. If no #
+# packages are specified, defaults to ./...
+
+go_packages=$*
+
+[ -z "$go_packages" ] && {
+	go_packages=$(go list ./... | grep -v cc-oci-runtime/vendor |\
+		    sed -e 's#.*/cc-oci-runtime/#./#')
+}
+
+echo Doing go static checks on packages: $go_packages
+
+go list -f '{{.Dir}}/*.go' $go_packages |\
+    xargs -I % bash -c "misspell -error %"
+go vet $go_packages
+go list -f '{{.Dir}}' $go_packages |\
+    xargs gofmt -s -l | wc -l |\
+    xargs -I % bash -c "test % -eq 0"
+go list -f '{{.Dir}}' $go_packages | xargs gocyclo -over 15
+
+for p in $go_packages; do golint -set_exit_status $p; done

--- a/.ci/ci-setup.sh
+++ b/.ci/ci-setup.sh
@@ -64,10 +64,6 @@ cp -r vendor/* "$GOPATH/src"
 mkdir -p "$GOPATH/src/github.com/01org/"
 ln -s $PWD "$GOPATH/src/github.com/01org/"
 
-go get github.com/fzipp/gocyclo
-go get github.com/client9/misspell/cmd/misspell
-go get github.com/golang/lint/golint
-
 #
 # Install cc-oci-runtime dependencies
 #

--- a/Makefile.am
+++ b/Makefile.am
@@ -276,6 +276,9 @@ CHECK_DEPS += check-proxy
 check-proxy:
 	go test -v -race -timeout 2s $(srcdir)/proxy
 
+check-go:
+	@$(top_srcdir)/.ci/ci-go-static-checks.sh
+
 libexec_PROGRAMS = cc-shim
 
 cc_shim_SOURCES = \


### PR DESCRIPTION
Instead of waiting for travis to tell me I've done something wrong, fix
it and try my luck again with the other static tests, it'll be faster to
run them locally beforehand. To be used as:

  # .ci/ci-go-static-checks.sh

Or

  # .ci/ci-go-static-checks.sh ./proxy

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>