### PR TITLE
2.1.0-rc.3 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,7 @@
+2.1.0-rc.3:
+    Added docker tests for handling pipe input
+    Added pprof data export through HTTP
+    Fixed CRI-O exec support
+    Fixed shim atexit return value
+    Fixed docker pipe inout handling (Issue #506)
+    Fixed version functional test

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [v2.1.0-rc.2])
+AC_INIT([cc-oci-runtime], [2.1.0-rc.3])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
- Added docker tests for handling pipe input
- Added pprof data export through HTTP
- Fixed CRI-O exec support
- Fixed shim atexit return value
- Fixed docker pipe inout handling (Issue #506)
- Fixed version functional test

Shortlog:

c22f33f proxy: Do not set the process CWD if it's empty
dbc634d oci: Build an accurate pod pointer before exec'ing
42acfd9 tests: Add explicit checking for stdout and stderr redirection tests.
a5a4f2d tests: Add docker test for handling stdin from pipe.
ba6e92d proxy: Add a way to serve pprof data over HTTP
80ceb96 shim: Add file descriptors at specifix index.
5d7ac88 shim: Handle stdin in non-tty case.
73e7d95 shim: atexit returns 0 if successful
baca26f test: Fix version functional test
6be54d4 tests: fix cc_oci_setup_shim test

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>