### PR TITLE
tests: show functional tests output in tap format

### DIFF
--- a/data/run-bats.sh.in
+++ b/data/run-bats.sh.in
@@ -25,5 +25,5 @@
 cmd="@BATS_PATH@"
 #Networking is not configured using non-root user
 #run bats functional tests with network namespace unshared
-[ $(id -u) -eq 0 ] && cmd="unshare -n $cmd"
+[ $(id -u) -eq 0 ] && cmd="unshare -n $cmd -t"
 eval "$cmd" $@


### PR DESCRIPTION
This commit makes functional tests to show its output in tap format
(ok and not ok) instead of using ✗ and ✓
This change will help to search for failures.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>