### PR TITLE
Better feedback when running go static checks

### DIFF
--- a/.ci/ci-go-static-checks.sh
+++ b/.ci/ci-go-static-checks.sh
@@ -69,12 +69,22 @@ install_package github.com/golang/lint/golint
 
 echo Doing go static checks on packages: $go_packages
 
+echo "Running misspell..."
 go list -f '{{.Dir}}/*.go' $go_packages |\
     xargs -I % bash -c "misspell -error %"
+
+echo "Running go vet..."
 go vet $go_packages
+
+echo "Running gofmt..."
 go list -f '{{.Dir}}' $go_packages |\
     xargs gofmt -s -l | wc -l |\
     xargs -I % bash -c "test % -eq 0"
+
+echo "Running cyclo..."
 go list -f '{{.Dir}}' $go_packages | xargs gocyclo -over 15
 
+echo "Running golint..."
 for p in $go_packages; do golint -set_exit_status $p; done
+
+echo "All Good!"

--- a/.ci/ci-go-static-checks.sh
+++ b/.ci/ci-go-static-checks.sh
@@ -78,8 +78,8 @@ go vet $go_packages
 
 echo "Running gofmt..."
 go list -f '{{.Dir}}' $go_packages |\
-    xargs gofmt -s -l | wc -l |\
-    xargs -I % bash -c "test % -eq 0"
+    xargs gofmt -s -l | tee /dev/tty | \
+    wc -l | xargs -I % bash -c "test % -eq 0"
 
 echo "Running cyclo..."
 go list -f '{{.Dir}}' $go_packages | xargs gocyclo -over 15


### PR DESCRIPTION
We don't really have information on which test is running and which has failed. On top of that, the gofmt check was consuming stdout and so we were losing the list of guilty files failing the format check.

Running the checks now displays something like:

```
Doing go static checks on packages: ./proxy ./proxy/api
Running misspell...
Running go vet...
Running gofmt...
/home/damien/go/src/github.com/01org/cc-oci-runtime/proxy/fdleak_test.go
Makefile:5230: recipe for target 'check-go' failed
```