### PR TITLE
namespaces: enable mount namespace

### DIFF
--- a/src/namespace.c
+++ b/src/namespace.c
@@ -167,10 +167,10 @@ cc_oci_ns_setup (struct cc_oci_config *config)
 
 		type = cc_oci_ns_to_str (ns->type);
 
-		/* The network namespace is the only supported one
-		 * (since it's required to setup networking).
+		/* network and mount namespaces are the only supported
+		 * (since it's required to setup networking and mount).
 		 */
-		if (ns->type != OCI_NS_NET) {
+		if (ns->type != OCI_NS_NET && ns->type != OCI_NS_MOUNT) {
 			g_debug ("ignoring %s namespace request",
 					type ? type : "");
 			continue;

--- a/src/oci.c
+++ b/src/oci.c
@@ -58,6 +58,7 @@
 #include "command.h"
 #include "proxy.h"
 #include "pod.h"
+#include "namespace.h"
 
 extern struct start_data start_data;
 
@@ -558,6 +559,15 @@ cc_oci_create (struct cc_oci_config *config)
 			g_critical ("failed to create runtime directory");
 		}
 
+		return false;
+	}
+
+	/* The namespace setup occurs in the parent to ensure
+	 * the hooks run successfully. The child will automatically
+	 * inherit the namespaces.
+	 */
+	if (! cc_oci_ns_setup (config)) {
+		g_critical ("failed to setup namespaces");
 		return false;
 	}
 

--- a/src/process.c
+++ b/src/process.c
@@ -897,14 +897,6 @@ cc_oci_vm_launch (struct cc_oci_config *config)
 
 	config->state.status = OCI_STATUS_CREATED;
 
-	/* The namespace setup occurs in the parent to ensure
-	 * the hooks run successfully. The child will automatically
-	 * inherit the namespaces.
-	 */
-	if (! cc_oci_ns_setup (config)) {
-		goto out;
-	}
-
 	/* Connect to the proxy before launching the shim so that the
 	 * proxy socket fd can be passed to the shim.
 	 */


### PR DESCRIPTION
A new mount namespace MUST be created before mounting anything
since dockerd remounts container's filesystem when certain commands
are executed by docker causing issues like #325

fixes #325

Signed-off-by: Julio Montes <julio.montes@intel.com>