### PR TITLE
proxy: Reorder response and fd

### DIFF
--- a/proxy/api/client.go
+++ b/proxy/api/client.go
@@ -17,7 +17,6 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net"
 	"os"
 )
@@ -63,39 +62,6 @@ func (client *Client) sendPayload(id string, payload interface{}) (*Response, er
 	}
 
 	return &resp, nil
-}
-
-// sendPayloadGetFd will send a command payload and get a response back
-// but also an out of band file descriptor.
-func (client *Client) sendPayloadGetFd(id string, payload interface{}) (*Response, *os.File, error) {
-	var err error
-
-	req := Request{}
-	req.ID = id
-	if payload != nil {
-		if req.Data, err = json.Marshal(payload); err != nil {
-			return nil, nil, err
-		}
-	}
-
-	if err := WriteMessage(client.conn, &req); err != nil {
-		return nil, nil, err
-	}
-
-	// I/O fd
-	newFd, err := ReadFd(client.conn)
-	if err != nil {
-		return nil, nil, fmt.Errorf("sendPayloadGetFd: couldn't read fd for request %s", id)
-	}
-
-	ioFile := os.NewFile(uintptr(newFd), "")
-
-	resp := Response{}
-	if err := ReadMessage(client.conn, &resp); err != nil {
-		return nil, nil, err
-	}
-
-	return &resp, ioFile, nil
 }
 
 func errorFromResponse(resp *Response) error {
@@ -148,7 +114,7 @@ func (client *Client) AllocateIo(nStreams int) (ioBase uint64, ioFile *os.File, 
 		NStreams: nStreams,
 	}
 
-	resp, ioFile, err := client.sendPayloadGetFd("allocateIO", &allocate)
+	resp, err := client.sendPayload("allocateIO", &allocate)
 	if err != nil {
 		return
 	}
@@ -164,6 +130,14 @@ func (client *Client) AllocateIo(nStreams int) (ioBase uint64, ioFile *os.File, 
 	}
 
 	ioBase = (uint64)(val.(float64))
+
+	// I/O fd
+	newFd, err := ReadFd(client.conn)
+	if err != nil {
+		return 0, nil, errors.New("allocateio: couldn't read fd")
+	}
+
+	ioFile = os.NewFile(uintptr(newFd), "")
 
 	return
 }

--- a/proxy/protocol.go
+++ b/proxy/protocol.go
@@ -128,7 +128,14 @@ func (proto *protocol) Serve(conn net.Conn, userData interface{}) error {
 		// Execute the corresponding handler
 		resp := proto.handleRequest(ctx, &req, &hr)
 
-		// First send an fd if the handler associated a file with the response
+		// Send the response back to the client.
+		if err = api.WriteMessage(conn, resp); err != nil {
+			// Something made us unable to write the response back
+			// to the client (could be a disconnection, ...).
+			return err
+		}
+
+		// And send a fd if the handler associated a file with the response
 		if hr.file != nil {
 			if err = api.WriteFd(conn.(*net.UnixConn), int(hr.file.Fd())); err != nil {
 				return err
@@ -136,11 +143,5 @@ func (proto *protocol) Serve(conn net.Conn, userData interface{}) error {
 			hr.file.Close()
 		}
 
-		// Then send the response back to the client.
-		if err = api.WriteMessage(conn, resp); err != nil {
-			// Something made us unable to write the response back
-			// to the client (could be a disconnection, ...).
-			return err
-		}
 	}
 }

--- a/proxy/protocol.go
+++ b/proxy/protocol.go
@@ -138,6 +138,7 @@ func (proto *protocol) Serve(conn net.Conn, userData interface{}) error {
 		// And send a fd if the handler associated a file with the response
 		if hr.file != nil {
 			if err = api.WriteFd(conn.(*net.UnixConn), int(hr.file.Fd())); err != nil {
+				hr.file.Close()
 				return err
 			}
 			hr.file.Close()


### PR DESCRIPTION
In:

  commit 50d42dc434f283ccb6e5daa17ea98d376b86fc4c
  Author: Samuel Ortiz <sameo@linux.intel.com>
  Date:   Mon Dec 19 15:00:25 2016 +0100

      proxy: Simplify fd passing and the message read loop

Samuel changed the order to send the fd before the response and simplify
the reading loop.

In this commit, I put it back the other way: response, then fd. It
allows for a more natural checking of the response status before trying
to receive the fd. If the allocateIO fails, we don't even try to read a
fd from the proxy.

That change is motivated by another one: we now have a
cc_proxy_receive_fd() function that is orthogonal to reading the
response back from the proxy. That means we can use it several times in
a row to retrieve more than one fd, a useful feature we'd like to use
very soon.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>