### PR TITLE
Test: Ensure that the name of a replica is not empty

### DIFF
--- a/tests/integration/docker/swarm.bats
+++ b/tests/integration/docker/swarm.bats
@@ -70,7 +70,7 @@ setup() {
 	IPS_REPLICAS=(`$DOCKER_EXE network inspect $name_network --format='{{ range .Containers}} {{ println .IPv4Address}}{{end}}' | head -n -2 | cut -d'/' -f1`)
 	for i in `seq 0 $((number_of_replicas-1))`; do
 		for j in `seq 0 $((number_of_replicas-1))`; do
-			if [ "$i" != "$j" ]; then
+			if [ "$i" != "$j" ] && [ -n "${NAMES_REPLICAS[$i]}" ]; then
 				# here we are performing a ping with the list
 				# of the overlay ips obtained from the replicas
 				$DOCKER_EXE exec ${NAMES_REPLICAS[$i]} bash -c "ping -c $number_of_attemps ${IPS_REPLICAS[$j]}"
@@ -151,7 +151,7 @@ setup() {
 	IPS_REPLICAS=(`$DOCKER_EXE network inspect $name_network --format='{{ range .Containers}} {{ println .IPv4Address}}{{end}}' | head -n -2 | cut -d'/' -f1`)
 	for i in `seq 0 $((number_of_replicas-1))`; do
 		for j in `seq 0 $((number_of_replicas-1))`; do
-			if [ "$i" != "$j" ]; then
+			if [ "$i" != "$j" ] && [ -n "${NAMES_REPLICAS[$i]}" ]; then
 				# here we are performing a ping with the list
 				# of the overlay ips obtained from the replicas
 				$DOCKER_EXE exec ${NAMES_REPLICAS[$i]} bash -c "ping -c $number_of_attemps ${IPS_REPLICAS[$j]}"


### PR DESCRIPTION
This will ensure that we are doing a ping with the non-empty replica
name

Signed-off-by: Cervantes Tellez, Gabriela <gabriela.cervantes.tellez@intel.com>