### PR TITLE
start: Delay shim execution until start has been called for runtime.

### DIFF
--- a/src/oci.c
+++ b/src/oci.c
@@ -753,6 +753,17 @@ cc_oci_start (struct cc_oci_config *config,
 		}
 	}
 
+	/* The shim was left in stopped state after 'create', so now let it
+	 * continue after container has started running inside the pod.
+	 *
+	 * This way the shim  sends/receives I/O only after the container 
+	 * has started.
+	 *
+	 * This is to accomodate change introduced with docker 1.12.4 to attach the stdio streams
+	 * before create: https://github.com/docker/docker/pull/26744
+	 */
+	kill(state->pid, SIGCONT);
+
 	/* Now the VM is running */
 	config->state.status = OCI_STATUS_RUNNING;
 


### PR DESCRIPTION
Docker introduced the change to attach stdio streams before create
with this change : https://github.com/docker/docker/pull/26744.
Before this change, the streams were attached after the post-start hooks
were executed.

This caused the shim to read stdin and send it to hyperstart before
the container was started, causing the input to be dropped.

So, put the shim in paused state after create and have the runtime
start it only after the container has been started.

Fixes #566.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>