### PR TITLE
ci: Add ineffassign to the go static checks

### DIFF
--- a/.ci/ci-go-static-checks.sh
+++ b/.ci/ci-go-static-checks.sh
@@ -66,6 +66,7 @@ function install_package {
 install_package github.com/fzipp/gocyclo
 install_package github.com/client9/misspell/cmd/misspell
 install_package github.com/golang/lint/golint
+install_package github.com/gordonklaus/ineffassign
 
 echo Doing go static checks on packages: $go_packages
 
@@ -86,5 +87,8 @@ go list -f '{{.Dir}}' $go_packages | xargs gocyclo -over 15
 
 echo "Running golint..."
 for p in $go_packages; do golint -set_exit_status $p; done
+
+echo "Running ineffassign..."
+go list -f '{{.Dir}}' $go_packages | xargs -L 1 ineffassign
 
 echo "All Good!"


### PR DESCRIPTION
The readme of that tool is a bit terse "Detect ineffectual assignments
in Go code." but this is useful to catch improper assigments of errors
(for instance).

This test is also part of goreport (https://goreportcard.com/) so it's a
good idea to include it and be good go citizens:

  https://goreportcard.com/report/github.com/01org/cc-oci-runtime

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>