### PR TITLE
vendor: Revendor virtcontainers to 0.2.3 to fix a panic

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -21,7 +21,7 @@
 	},
 	"github.com/containers/virtcontainers": {
 		"url": "https://github.com/containers/virtcontainers.git",
-		"version": "v0.2.1",
+		"version": "v0.2.3",
 		"license": "Apache 2.0"
 	},
 	"github.com/stretchr/testify": {

--- a/vendor/github.com/containers/virtcontainers/README.md
+++ b/vendor/github.com/containers/virtcontainers/README.md
@@ -1,7 +1,7 @@
-[![Build Status](https://travis-ci.org/sameo/virtcontainers.svg?branch=master)](https://travis-ci.org/sameo/virtcontainers)
-[![Go Report Card](https://goreportcard.com/badge/github.com/sameo/virtcontainers)](https://goreportcard.com/report/github.com/sameo/virtcontainers)
-[![Coverage Status](https://coveralls.io/repos/github/sameo/virtcontainers/badge.svg?branch=sameo%2Ftopic%2Funit)](https://coveralls.io/github/sameo/virtcontainers)
-[![GoDoc](https://godoc.org/github.com/sameo/virtcontainers?status.svg)](https://godoc.org/github.com/sameo/virtcontainers)
+[![Build Status](https://travis-ci.org/containers/virtcontainers.svg?branch=master)](https://travis-ci.org/containers/virtcontainers)
+[![Go Report Card](https://goreportcard.com/badge/github.com/containers/virtcontainers)](https://goreportcard.com/report/github.com/containers/virtcontainers)
+[![Coverage Status](https://coveralls.io/repos/github/sameo/virtcontainers/badge.svg?branch=master)](https://coveralls.io/github/sameo/virtcontainers?branch=master)
+[![GoDoc](https://godoc.org/github.com/containers/virtcontainers?status.svg)](https://godoc.org/github.com/containers/virtcontainers)
 
 # virtcontainers
 

--- a/vendor/github.com/containers/virtcontainers/hyperstart/mock/hyperstart.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart/mock/hyperstart.go
@@ -30,51 +30,44 @@ import (
 
 // Control command string IDs
 const (
-	Version          = "version"
-	StartPod         = "startpod"
-	GetPod           = "getpod"
-	DestroyPod       = "destroypod"
-	RestartContainer = "restartcontainer"
-	ExecCmd          = "execcmd"
-	FinishCmd        = "finishcmd"
-	Ready            = "ready"
-	Ack              = "ack"
-	Error            = "error"
-	WinSize          = "winsize"
-	Ping             = "ping"
-	FinishPod        = "finishpod"
-	Next             = "next"
-	WriteFile        = "writefile"
-	ReadFile         = "readfile"
-	NewContainer     = "newcontainer"
-	KillContainer    = "killcontainer"
-	OnlineCPUMem     = "onlinecpumem"
-	SetupInterface   = "setupinterface"
-	SetupRoute       = "setuproute"
+	Version        = "version"
+	StartPod       = "startpod"
+	DestroyPod     = "destroypod"
+	ExecCmd        = "execcmd"
+	Ready          = "ready"
+	Ack            = "ack"
+	Error          = "error"
+	WinSize        = "winsize"
+	Ping           = "ping"
+	FinishPod      = "finishpod"
+	Next           = "next"
+	WriteFile      = "writefile"
+	ReadFile       = "readfile"
+	NewContainer   = "newcontainer"
+	KillContainer  = "killcontainer"
+	OnlineCPUMem   = "onlinecpumem"
+	SetupInterface = "setupinterface"
+	SetupRoute     = "setuproute"
 )
 
 var codeList = map[int]string{
-	hyper.INIT_VERSION:          Version,
-	hyper.INIT_STARTPOD:         StartPod,
-	hyper.INIT_GETPOD:           GetPod,
-	hyper.INIT_DESTROYPOD:       DestroyPod,
-	hyper.INIT_RESTARTCONTAINER: RestartContainer,
-	hyper.INIT_EXECCMD:          ExecCmd,
-	hyper.INIT_FINISHCMD:        FinishCmd,
-	hyper.INIT_READY:            Ready,
-	hyper.INIT_ACK:              Ack,
-	hyper.INIT_ERROR:            Error,
-	hyper.INIT_WINSIZE:          WinSize,
-	hyper.INIT_PING:             Ping,
-	hyper.INIT_FINISHPOD:        FinishPod,
-	hyper.INIT_NEXT:             Next,
-	hyper.INIT_WRITEFILE:        WriteFile,
-	hyper.INIT_READFILE:         ReadFile,
-	hyper.INIT_NEWCONTAINER:     NewContainer,
-	hyper.INIT_KILLCONTAINER:    KillContainer,
-	hyper.INIT_ONLINECPUMEM:     OnlineCPUMem,
-	hyper.INIT_SETUPINTERFACE:   SetupInterface,
-	hyper.INIT_SETUPROUTE:       SetupRoute,
+	hyper.INIT_VERSION:        Version,
+	hyper.INIT_STARTPOD:       StartPod,
+	hyper.INIT_DESTROYPOD:     DestroyPod,
+	hyper.INIT_EXECCMD:        ExecCmd,
+	hyper.INIT_READY:          Ready,
+	hyper.INIT_ACK:            Ack,
+	hyper.INIT_ERROR:          Error,
+	hyper.INIT_WINSIZE:        WinSize,
+	hyper.INIT_PING:           Ping,
+	hyper.INIT_NEXT:           Next,
+	hyper.INIT_WRITEFILE:      WriteFile,
+	hyper.INIT_READFILE:       ReadFile,
+	hyper.INIT_NEWCONTAINER:   NewContainer,
+	hyper.INIT_KILLCONTAINER:  KillContainer,
+	hyper.INIT_ONLINECPUMEM:   OnlineCPUMem,
+	hyper.INIT_SETUPINTERFACE: SetupInterface,
+	hyper.INIT_SETUPROUTE:     SetupRoute,
 }
 
 // Hyperstart is an object mocking the hyperstart agent.


### PR DESCRIPTION
Let's vendor virtcontainers 0.2.3, it's a good version if we want to
minimize the changes while grabbing a fix for a panic that happens if
the shim disappears underneath us.

It's debatable if we should jump straight away to 0.3.0. That version
would also need us to re-vendor the runv package. It will have to
happen, eventually, but we can control when.

An benefit of going slowly on the updates is that we can revert a later
vendoring to 0.3.0 if we find out it introduces regressions.

Fixes: https://github.com/01org/cc-oci-runtime/issues/463

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>