### PR TITLE
Futureproofing api.client.Hello and api.Client.Attach

### DIFF
--- a/proxy/api/client.go
+++ b/proxy/api/client.go
@@ -112,20 +112,38 @@ func errorFromResponse(resp *Response) error {
 	return nil
 }
 
+// HelloOptions holds extra arguments one can pass to the Hello function. See
+// the Hello payload for more details.
+type HelloOptions struct {
+	Console string
+}
+
+// HelloReturn contains the return values from Hello. See the Hello and
+// HelloResult payloads.
+type HelloReturn struct {
+}
+
 // Hello wraps the Hello payload (see payload description for more details)
-func (client *Client) Hello(containerID, ctlSerial, ioSerial string) error {
+func (client *Client) Hello(containerID, ctlSerial, ioSerial string,
+	options *HelloOptions) (*HelloReturn, error) {
 	hello := Hello{
 		ContainerID: containerID,
 		CtlSerial:   ctlSerial,
 		IoSerial:    ioSerial,
 	}
 
-	resp, err := client.sendPayload("hello", &hello)
-	if err != nil {
-		return err
+	if options != nil {
+		hello.Console = options.Console
 	}
 
-	return errorFromResponse(resp)
+	resp, err := client.sendPayload("hello", &hello)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &HelloReturn{}
+
+	return ret, errorFromResponse(resp)
 }
 
 // Attach wraps the Attach payload (see payload description for more details)

--- a/proxy/api/client.go
+++ b/proxy/api/client.go
@@ -146,18 +146,30 @@ func (client *Client) Hello(containerID, ctlSerial, ioSerial string,
 	return ret, errorFromResponse(resp)
 }
 
+// AttachOptions holds extra arguments one can pass to the Attach function. See
+// the Attach payload for more details.
+type AttachOptions struct {
+}
+
+// AttachReturn contains the return values from Hello. See the Hello and
+// AttachResult payloads.
+type AttachReturn struct {
+}
+
 // Attach wraps the Attach payload (see payload description for more details)
-func (client *Client) Attach(containerID string) error {
+func (client *Client) Attach(containerID string, options *AttachOptions) (*AttachReturn, error) {
 	hello := Attach{
 		ContainerID: containerID,
 	}
 
 	resp, err := client.sendPayload("attach", &hello)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return errorFromResponse(resp)
+	ret := &AttachReturn{}
+
+	return ret, errorFromResponse(resp)
 }
 
 // AllocateIo wraps the AllocateIo payload (see payload description for more details)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -289,12 +289,12 @@ func TestAttach(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Attaching to an unknown VM should return an error
-	err = rig.Client.Attach("foo")
+	_, err = rig.Client.Attach("foo", nil)
 	assert.NotNil(t, err)
 
 	// Attaching to an existing VM should work. To test we are effectively
 	// attached, we issue a bye that would error out if not attached.
-	err = rig.Client.Attach(testContainerID)
+	_, err = rig.Client.Attach(testContainerID, nil)
 	assert.Nil(t, err)
 	err = rig.Client.Bye(testContainerID)
 	assert.Nil(t, err)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -212,11 +212,11 @@ func TestHello(t *testing.T) {
 
 	// Register new VM
 	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
-	err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath)
+	_, err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath, nil)
 	assert.Nil(t, err)
 
 	// A new Hello message with the same containerID should error out
-	err = rig.Client.Hello(testContainerID, "fooCtl", "fooIo")
+	_, err = rig.Client.Hello(testContainerID, "fooCtl", "fooIo", nil)
 	assert.NotNil(t, err)
 
 	// Hello should register a new vm object
@@ -245,7 +245,7 @@ func TestBye(t *testing.T) {
 
 	// Register new VM
 	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
-	err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath)
+	_, err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath, nil)
 	assert.Nil(t, err)
 
 	// Bye with a bad containerID
@@ -285,7 +285,7 @@ func TestAttach(t *testing.T) {
 
 	// Register new VM
 	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
-	err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath)
+	_, err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath, nil)
 	assert.Nil(t, err)
 
 	// Attaching to an unknown VM should return an error
@@ -315,7 +315,7 @@ func TestHyperPing(t *testing.T) {
 	rig.Start()
 
 	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
-	err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath)
+	_, err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath, nil)
 	assert.Nil(t, err)
 
 	// Send ping and verify we have indeed received the message on the
@@ -344,7 +344,7 @@ func TestHyperStartpod(t *testing.T) {
 
 	// Register new VM
 	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
-	err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath)
+	_, err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath, nil)
 	assert.Nil(t, err)
 
 	// Send startopd and verify we have indeed received the message on the
@@ -427,7 +427,7 @@ func TestAllocateIo(t *testing.T) {
 
 	// Register new VM
 	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
-	err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath)
+	_, err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath, nil)
 	assert.Nil(t, err)
 
 	// Allocate 2 seq numbers and verify we can use the fd passed from


### PR DESCRIPTION
Those two proxy payloads will have some additional (optional) parameters, sometimes with the corresponding return values. In fact, we already have an optional parameter: the qemu console path that the runtime can provide to the proxy to display hyperstart messages.

So, we need a way to provide those optional parameters. This PR introduces the following pattern:

```
        ret, err := client.Hello(containerID, ctlSocketPath, ioSocketPath,
                &api.HelloOptions{
                        Console: "/path/to/qemu/console",
        })
```

I could have introduced a HelloWithOptions that take that 3rd argument, but thought that might has well change it now while we can (unrelease API only used by unreleased tip of virtcontainers).

This will be used by followup PRs:
  - The introduction of a version field in the Hello/Attach response
  - The introduction of a new parameter for Hello/Attach to return a virtual hyperstart ctl fd