### PR TITLE
Version the proxy protocol

### DIFF
--- a/proxy/api/api.go
+++ b/proxy/api/api.go
@@ -20,6 +20,12 @@ import (
 	"encoding/json"
 )
 
+// Version encodes the proxy protocol version.
+//
+// List of changes:
+// • version 1: initial version released with Clear Containers 2.1
+const Version = 1
+
 // The Hello payload is issued first after connecting to the proxy socket.
 // It is used to let the proxy know about a new container on the system along
 // with the paths go hyperstart's command and I/O channels (AF_UNIX sockets).
@@ -42,6 +48,19 @@ type Hello struct {
 	Console     string `json:"console,omitempty"`
 }
 
+// HelloResult is the result from a successful Hello.
+//
+//  {
+//    "success": true,
+//    "data": {
+//      "version": 1
+//    }
+//  }
+type HelloResult struct {
+	// The version of the proxy protocol
+	Version int `json:"version"`
+}
+
 // The Attach payload can be used to associate clients to an already known VM.
 // attach cannot be issued if a hello for this container hasn't been issued
 // beforehand.
@@ -54,6 +73,19 @@ type Hello struct {
 //  }
 type Attach struct {
 	ContainerID string `json:"containerId"`
+}
+
+// AttachResult is the result from a successful Attach.
+//
+//  {
+//    "success": true,
+//    "data": {
+//      "version": 1
+//    }
+//  }
+type AttachResult struct {
+	// The version of the proxy protocol
+	Version int `json:"version"`
 }
 
 // The Bye payload does the opposite of what hello does, indicating to the

--- a/proxy/api/client.go
+++ b/proxy/api/client.go
@@ -121,6 +121,7 @@ type HelloOptions struct {
 // HelloReturn contains the return values from Hello. See the Hello and
 // HelloResult payloads.
 type HelloReturn struct {
+	Version int
 }
 
 // Hello wraps the Hello payload (see payload description for more details)
@@ -143,6 +144,12 @@ func (client *Client) Hello(containerID, ctlSerial, ioSerial string,
 
 	ret := &HelloReturn{}
 
+	val, ok := resp.Data["version"]
+	if !ok {
+		return nil, errors.New("hello: no version in response")
+	}
+	ret.Version = int(val.(float64))
+
 	return ret, errorFromResponse(resp)
 }
 
@@ -154,6 +161,7 @@ type AttachOptions struct {
 // AttachReturn contains the return values from Hello. See the Hello and
 // AttachResult payloads.
 type AttachReturn struct {
+	Version int
 }
 
 // Attach wraps the Attach payload (see payload description for more details)
@@ -168,6 +176,12 @@ func (client *Client) Attach(containerID string, options *AttachOptions) (*Attac
 	}
 
 	ret := &AttachReturn{}
+
+	val, ok := resp.Data["version"]
+	if !ok {
+		return nil, errors.New("attach: no version in response")
+	}
+	ret.Version = int(val.(float64))
 
 	return ret, errorFromResponse(resp)
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -122,6 +122,8 @@ func helloHandler(data []byte, userData interface{}, response *handlerResponse) 
 
 	client.vm = vm
 
+	response.AddResult("version", api.Version)
+
 	// We start one goroutine per-VM to monitor the qemu process
 	proxy.wg.Add(1)
 	go func() {
@@ -154,6 +156,8 @@ func attachHandler(data []byte, userData interface{}, response *handlerResponse)
 	client.infof(1, "attach(containerId=%s)", attach.ContainerID)
 
 	client.vm = vm
+
+	response.AddResult("version", api.Version)
 }
 
 // "bye"

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -212,8 +212,12 @@ func TestHello(t *testing.T) {
 
 	// Register new VM
 	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
-	_, err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath, nil)
+	ret, err := rig.Client.Hello(testContainerID, ctlSocketPath, ioSocketPath, nil)
 	assert.Nil(t, err)
+	assert.NotNil(t, ret)
+
+	// Check that Hello returns the protocol version
+	assert.Equal(t, api.Version, ret.Version)
 
 	// A new Hello message with the same containerID should error out
 	_, err = rig.Client.Hello(testContainerID, "fooCtl", "fooIo", nil)
@@ -294,8 +298,12 @@ func TestAttach(t *testing.T) {
 
 	// Attaching to an existing VM should work. To test we are effectively
 	// attached, we issue a bye that would error out if not attached.
-	_, err = rig.Client.Attach(testContainerID, nil)
+	ret, err := rig.Client.Attach(testContainerID, nil)
 	assert.Nil(t, err)
+
+	// Check that Attach returns the protocol version
+	assert.Equal(t, api.Version, ret.Version)
+
 	err = rig.Client.Bye(testContainerID)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
This PR adds a version field in the responses of Hello and Attach. See last commit for more details.

The 2 first commits are part of PR https://github.com/01org/cc-oci-runtime/pull/595 but included here as well as dependencies.