### PR TITLE
build: Remove the last reference to the hyperstart mock package

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -326,7 +326,6 @@ EXTRA_DIST = \
 	$(cc_image_systemd_files) \
 	$(cc_proxy_sources) \
 	$(cc_proxy_extra_dist) \
-	$(mock_extra_dist) \
 	$(systemdservice_in_files) \
 	data/cc-oci-runtime.sh.in \
 	data/dockerFiles/Dockerfile.fedora.in \


### PR DESCRIPTION
This package has been moved to virtcontainers and this variable wasn't
defined anywhere anymore.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>