### PR TITLE
Don't include neither the shim nor the proxy in the 2.0 branch

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -273,19 +273,6 @@ cc_proxy_extra_dist =			\
 check-proxy:
 	go test -v -race -timeout 2s $(srcdir)/proxy
 
-libexec_PROGRAMS = cc-shim
-
-cc_shim_SOURCES = \
-	shim/shim.c \
-	shim/shim.h \
-	shim/utils.c \
-	shim/utils.h \
-	shim/log.c \
-	shim/log.h
-
-cc_shim_CFLAGS = \
-	$(AM_CFLAGS)
-
 bats_test_sources = \
 	tests/functional/common.bash.in \
 	data/run-bats.sh.in \

--- a/Makefile.am
+++ b/Makefile.am
@@ -314,13 +314,9 @@ EXTRA_DIST = \
 	tests/data \
 	commit_id \
 	versions.txt \
-	$(documentation_extra_dist) \
 	$(defaults_DATA) \
 	$(cc_image_systemd_files) \
-	$(cc_proxy_sources) \
-	$(cc_proxy_extra_dist) \
 	$(mock_extra_dist) \
-	$(systemdservice_in_files) \
 	data/cc-oci-runtime.sh.in \
 	data/dockerFiles/Dockerfile.fedora.in \
 	data/dockerFiles/Dockerfile.ubuntu.in \

--- a/Makefile.am
+++ b/Makefile.am
@@ -220,9 +220,9 @@ cc_oci_runtime_CFLAGS = \
 	$(LIBMNL_CFLAGS) \
 	$(UUID_CFLAGS)
 
-libexec_SCRIPTS = cc-proxy
+#libexec_SCRIPTS = cc-proxy
 
-CLEANFILES += cc-proxy
+#CLEANFILES += cc-proxy
 
 AM_V_GO    = $(am__v_GO_@AM_V@)
 am__v_GO_  = $(am__v_GO_@AM_DEFAULT_V@)
@@ -237,12 +237,12 @@ systemdservice_files = 		\
 	proxy/cc-proxy.service	\
 	proxy/cc-proxy.socket
 
-CLEANFILES += $(systemdservice_files)
+#CLEANFILES += $(systemdservice_files)
 
 if HAVE_SYSTEMD
-GENERATED_FILES += $(systemdservice_files)
+#GENERATED_FILES += $(systemdservice_files)
 systemdservicedir   = $(systemdsystemunitdir)
-systemdservice_DATA = $(systemdservice_files)
+#systemdservice_DATA = $(systemdservice_files)
 endif
 
 proxy_ldflags = "-X main.socketPath=$(localstatedir)/run/cc-oci-runtime/proxy.sock"
@@ -268,7 +268,7 @@ cc_proxy_extra_dist =			\
 	proxy/README.md			\
 	proxy/COPYING
 
-CHECK_DEPS += check-proxy
+#CHECK_DEPS += check-proxy
 
 check-proxy:
 	go test -v -race -timeout 2s $(srcdir)/proxy

--- a/configure.ac
+++ b/configure.ac
@@ -320,10 +320,6 @@ cc-oci-runtime - $VERSION
        Container image services : $CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH
        Debug build              : $enable_debug
 
- • Proxy:
-
-       Systemd unit directory   : $systemdsystemunitdir
-
  • Tests:
 
        Unit tests               : $enable_tests

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [0.1])
+AC_INIT([cc-oci-runtime], [2.0.0])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -43,10 +43,6 @@ AM_PROG_CC_C_O
 AC_PROG_INSTALL
 AC_PROG_MKDIR_P
 
-# We need go!
-AC_CHECK_PROG(GO,[go],[go],[no])
-test "$GO" == "no" && AC_MSG_ERROR([go is required to build cc-oci-runtime])
-
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h mntent.h stdlib.h string.h sys/mount.h unistd.h uuid/uuid.h gio/gio.h gio/gunixsocketaddress.h])
 


### PR DESCRIPTION
We had those components built and distributed in the 2.0.0 release but we weren't using them. Let's disable building and releasing them with the 2.0 runtime.

This should probably be followed with a 2.0.1 release.