### PR TITLE
configure: Move to 2.0.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,2 @@
+2.0.1:
+	Disable the cc-shim and cc-proxy build

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.0.0])
+AC_INIT([cc-oci-runtime], [2.0.1])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
2.0.1:
        Disable the cc-shim and cc-proxy build

Shortlog:
57cedac Merge pull request #603 from dlespiau/20170120-2.0-no-shim-no-proxy
f1e5a61 build: Don't compile the shim
28e3ca6 build: Don't distribute the proxy files
f5fdf5f build: Don't require go anymore
6851b65 build: Don't compile the proxy
472a06a build: Update the version in configure.ac to 2.0.0

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>