### PR TITLE
cppcheck: fix cppcheck errors

### DIFF
--- a/src/semver.c
+++ b/src/semver.c
@@ -363,25 +363,6 @@ cc_oci_semver_2_0_0_cmp (const char *version_a, const char *version_b,
 }
 
 /*!
- * Fully compare two Semantic version (SemVer) strings.
- *
- * \param version_a First SemVer string.
- * \param version_b Second SemVer string.
- *
- * Return values match those of \c strcmp(3).
- *
- * \note Handles SemVer 2.0.0-format strings.
- *
- * \return \c 0 if \p version_a == \p version_b, \c <0 if \p version_a <
- * \p version_b or \c >0 if \p version_a > \p version_b.
- */
-gint
-cc_oci_semver_cmp_full (const char *version_a, const char *version_b)
-{
-	return cc_oci_semver_2_0_0_cmp (version_a, version_b, false);
-}
-
-/*!
  * Compare two Semantic version (SemVer) strings for
  * backwards-compatibility.
  *

--- a/src/semver.h
+++ b/src/semver.h
@@ -24,7 +24,6 @@
 #include <glib.h>
 
 gint cc_oci_semver_cmp (const char *version_a, const char *version_b);
-gint cc_oci_semver_cmp_full (const char *version_a, const char *version_b);
 gboolean cc_oci_string_is_numeric (const char *str);
 
 #endif /* _CC_OCI_SEMVER_H */

--- a/tests/semver_test.c
+++ b/tests/semver_test.c
@@ -27,36 +27,6 @@
 #include "test_common.h"
 #include "../src/semver.h"
 
-START_TEST(test_cc_oci_semver_cmp) {
-	ck_assert (cc_oci_semver_cmp_full ("1.9.0", "1.10.0") < 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.9.0", "1.11.0") < 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.10.0", "1.11.0") < 0);
-
-	ck_assert (cc_oci_semver_cmp_full ("1.10.0", "1.9.0") > 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.11.0", "1.10.0") > 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.11.0", "1.9.0") > 0);
-
-	ck_assert (cc_oci_semver_cmp_full ("1.0.0-alpha", "1.0.0") < 0);
-
-	ck_assert (cc_oci_semver_cmp_full ("0.0-alpha", "1.0.0-alpha.1") < 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.0.0-alpha.1", "1.0.0-alpha.beta") < 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.0.0-alpha.beta", "1.0.0-beta") < 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.0.0-beta", "1.0.0-beta.2") < 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.0.0-beta.2", "1.0.0-beta.11") < 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.0.0-beta.11", "1.0.0-rc.1") < 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.0.0-rc.1", "1.0.0") < 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.0.0-a.b.c.d", "1.0.0") < 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.0.0-9.8.7.6foo", "1.0.0") < 0);
-	ck_assert (cc_oci_semver_cmp_full ("0.0-alpha", "1.0.0") < 0);
-
-	ck_assert (cc_oci_semver_cmp_full ("0.0.0", "0.0.0") == 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.0.0", "1.0.0") == 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.1.0", "1.1.0") == 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.1.1", "1.1.1") == 0);
-	ck_assert (cc_oci_semver_cmp_full ("1.0.0-rc1", "1.0.0-rc1") == 0);
-
-} END_TEST
-
 START_TEST(test_cc_oci_semver_cmp_compat) {
 	ck_assert (cc_oci_semver_cmp ("1.9.0", "1.10.0") == 0);
 	ck_assert (cc_oci_semver_cmp ("1.9.7", "1.10.5") == 0);
@@ -79,7 +49,6 @@ START_TEST(test_cc_oci_string_is_numeric) {
 Suite* make_semver_suite(void) {
 	Suite* s = suite_create(__FILE__);
 
-	ADD_TEST(test_cc_oci_semver_cmp, s);
 	ADD_TEST(test_cc_oci_semver_cmp_compat, s);
 	ADD_TEST(test_cc_oci_string_is_numeric, s);
 


### PR DESCRIPTION
This patch removes cc_oci_semver_cmp_full
to make cppcheck happy again

Signed-off-by: Julio Montes <julio.montes@intel.com>