### PR TITLE
tests: Fix distcheck errors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,6 +61,7 @@ GENERATED_FILES = \
 	data/dockerFiles/Dockerfile.ubuntu \
 	data/vm.json \
 	tests/functional/common.bash \
+	tests/functional/run-functional-tests.sh \
 	tests/functional/data/config-minimal-cc-oci.json \
 	tests/metrics/density/docker_cpu_usage.sh \
 	tests/metrics/density/docker_memory_usage.sh \
@@ -87,6 +88,7 @@ $(GENERATED_FILES): %: %.in Makefile
 		-e 's|[@]DOCKER_ENGINE_FEDORA_VERSION[@]|$(DOCKER_ENGINE_FEDORA_VERSION)|g' \
 		-e 's|[@]DOCKER_UBUNTU_VERSION[@]|$(DOCKER_UBUNTU_VERSION)|g' \
 		-e 's|[@]DOCKER_ENGINE_UBUNTU_VERSION[@]|$(DOCKER_ENGINE_UBUNTU_VERSION)|g' \
+		-e 's|[@]ABS_BUILDDIR[@]|$(abs_builddir)|g' \
 		"$<" > "$@"
 
 if FUNCTIONAL_TESTS
@@ -332,6 +334,7 @@ EXTRA_DIST = \
 	data/dockerFiles/Dockerfile.ubuntu.in \
 	data/dockerFiles/Dockerfile.clearlinux \
 	$(bats_test_sources) \
+	tests/functional/run-functional-tests.sh.in \
 	tests/integration \
 	tests/lib \
 	tests/metrics/density/docker_cpu_usage.sh.in \
@@ -359,19 +362,7 @@ functional-tests: $(FUNCTIONAL_TESTS_DEPS)
 				ln -s $$f $(builddir)/tests/functional/ ; \
 			done; \
 		fi
-		@echo -e \
-		"export PROXY_SOCKET_PATH=\"$(abs_top_srcdir)/tests/functional/proxy.sock\" \n" \
-		"export SHIM_PATH=\"$(abs_top_srcdir)/cc-shim\" \n" \
-		"echo 'Running a new instance of cc-proxy' \n" \
-		"$(abs_top_srcdir)/cc-proxy -socket-path=\"\$${PROXY_SOCKET_PATH}\" & \n" \
-		"p=\$$! \n" \
-		"sleep 1 \n" \
-		"bash $(builddir)/data/run-bats.sh $(builddir)/tests/functional/ \n" \
-		"echo 'killing own cc-proxy instance' \n" \
-		"kill -9 \$$p \n" \
-		"rm -f \$${PROXY_SOCKET_PATH} \n" > $(abs_top_srcdir)/tests/functional/run_functional_tests.sh
-		@bash -f $(abs_top_srcdir)/tests/functional/run_functional_tests.sh
-		@rm -f $(abs_top_srcdir)/tests/functional/run_functional_tests.sh
+		@bash -f $(abs_builddir)/tests/functional/run-functional-tests.sh
 endif
 
 if DOCKER_TESTS

--- a/tests/functional/run-functional-tests.sh.in
+++ b/tests/functional/run-functional-tests.sh.in
@@ -1,0 +1,30 @@
+#!/bin/bash
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2017 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+export PROXY_SOCKET_PATH="@ABS_BUILDDIR@/tests/functional/proxy.sock"
+export SHIM_PATH="@ABS_BUILDDIR@/cc-shim"
+echo 'Running a new instance of cc-proxy'
+@ABS_BUILDDIR@/cc-proxy -socket-path="${PROXY_SOCKET_PATH}" &
+p=$!
+sleep 1
+bash @ABS_BUILDDIR@/data/run-bats.sh @ABS_BUILDDIR@/tests/functional/
+echo 'killing cc-proxy instance'
+kill -9 $p 2> /dev/null
+rm -f ${PROXY_SOCKET_PATH}


### PR DESCRIPTION
This patch replaces builddir and abs_top_srcdir with abs_builddir
to run cc-proxy and cc-shim since these binaries are placed
in that directory(abs_builddir) when they are compiled

Errors fixed:
* ../cc-oci-runtime-2.1.0-rc.4/_build/sub/../../cc-proxy: No such file or directory
* ../tests/functional/run_functional_tests.sh: line 9: kill: (7575) - No such process

Signed-off-by: Julio Montes <julio.montes@intel.com>