### PR TITLE
proxy: Fix a fd leak in an error path

### DIFF
--- a/proxy/protocol.go
+++ b/proxy/protocol.go
@@ -131,6 +131,7 @@ func (proto *protocol) Serve(conn net.Conn, userData interface{}) error {
 		// First send an fd if the handler associated a file with the response
 		if hr.file != nil {
 			if err = api.WriteFd(conn.(*net.UnixConn), int(hr.file.Fd())); err != nil {
+				hr.file.Close()
 				return err
 			}
 			hr.file.Close()


### PR DESCRIPTION
When failing to send a fd to the client, we were forgetting to close the
fd we were trying to send.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>