### PR TITLE
 mount: fix umount function

### DIFF
--- a/src/mount.c
+++ b/src/mount.c
@@ -27,6 +27,7 @@
 
 #include "mount.h"
 #include "common.h"
+#include "namespace.h"
 
 /** Mounts that will be ignored.
  *
@@ -330,9 +331,36 @@ gboolean
 cc_oci_handle_unmounts (const struct cc_oci_config *config)
 {
 	GSList  *l;
+	struct oci_cfg_namespace *ns;
+	gboolean mountns = false;
 
 	if (! config) {
 		return false;
+	}
+
+	/**
+	 * At this point qemu is not running if there is
+	 * a mount namespace with a path we have join
+	 * it and umount all mounted resources
+	 */
+	for (l = config->oci.oci_linux.namespaces;
+			l && l->data;
+			l = g_slist_next (l)) {
+		ns = (struct oci_cfg_namespace *)l->data;
+
+		if (ns->type == OCI_NS_MOUNT && ns->path) {
+			mountns = cc_oci_ns_join (ns);
+			break;
+		}
+	}
+
+	/**
+	 * if there is NOT a specific mount namespace return true
+	 * since namespace created by unshare in \ref cc_oci_ns_setup
+	 * is destroyed when qemu ends
+	 */
+	if (! mountns) {
+		return true;
 	}
 
 	/* umount files and directories */

--- a/src/namespace.h
+++ b/src/namespace.h
@@ -25,5 +25,8 @@ void cc_oci_ns_free (struct oci_cfg_namespace *ns);
 gboolean cc_oci_ns_setup (struct cc_oci_config *config);
 const char *cc_oci_ns_to_str (enum oci_namespace ns);
 enum oci_namespace cc_oci_str_to_ns (const char *str);
+JsonArray *
+cc_oci_ns_to_json (const struct cc_oci_config *config);
+gboolean cc_oci_ns_join(struct oci_cfg_namespace *ns);
 
 #endif /* _CC_OCI_NAMESPACE_H */

--- a/src/oci.c
+++ b/src/oci.c
@@ -1490,6 +1490,11 @@ cc_oci_config_update (struct cc_oci_config *config,
 		state->mounts = NULL;
 	}
 
+	if (state->namespaces) {
+		config->oci.oci_linux.namespaces = state->namespaces;
+		state->namespaces = NULL;
+	}
+
 	if(state->process && ! config->oci.process.args) {
 		config->oci.process = *state->process;
 		g_free_if_set (state->process);

--- a/src/oci.h
+++ b/src/oci.h
@@ -427,6 +427,9 @@ struct oci_state {
          */
         GSList          *annotations;
 
+	/** List of \ref oci_cfg_namespace namespaces */
+	GSList          *namespaces;
+
 	/* See member of same name in \ref cc_oci_config. */
 	gchar           *console;
 

--- a/tests/mount_test.c
+++ b/tests/mount_test.c
@@ -108,7 +108,11 @@ START_TEST(test_cc_oci_handle_umounts) {
 	mounts_spec_handler.handle_section(
 	    node_find_child(node, mounts_spec_handler.name), config);
 
-	ck_assert(! cc_oci_handle_unmounts(config));
+	/**
+	 * cc_oci_handle_unmounts returns true when there
+	 * is not a mount namespace with path
+	 */
+	ck_assert(cc_oci_handle_unmounts(config));
 
 	cc_oci_config_free(config);
 	g_free_node(node);


### PR DESCRIPTION
support for mount namespace was add in PR #577 to fix #325
all resources mounted by the runtime are part of a new
mount namespace hence when delete is called the runtime is
unable to unmount them. This patch fixes that issue joining
to the namespace and unmounting all resources

fixes #593

Signed-off-by: Julio Montes <julio.montes@intel.com>