### PR TITLE
configure: Move to 2.1.0-rc.5

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+2.1.0.rc.5:
+    Added SELinux configuration for proxy
+    Added environment and image docker tests
+    Added virtualization support check
+    Added ineffassign CI tests
+    Added proxy protocol extensions
+    Fixed a potential proxy panic
+    Fixed umount function
+    Fixed support for latest Docker streams
+    Fixed a proxy fd leak
+
 2.1.0.rc.4:
     Added mount namespace creation
     Added functional test tap output

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.0-rc.4])
+AC_INIT([cc-oci-runtime], [2.1.0-rc.5])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
2.1.0.rc.5:
    Added SELinux configuration for proxy
    Added environment and image docker tests
    Added virtualization support check
    Added ineffassign CI tests
    Added proxy protocol extensions
    Fixed a potential proxy panic
    Fixed umount function
    Fixed support for latest Docker streams
    Fixed a proxy fd leak

Shortlog:

754877f selinux: Initial commit for cc-proxy selinux module
e5a7837 docs: Remove the section about starting the hypervisor
013b0a9 docs: Add a section about contributing to Go code
0b681a8 docs: Update the coding style section
4428e60 docs: Add proxy and shim to the Code layout section
4f49acb mount: fix umount function
7eb940c runtime: add namespace to oci_state struct
e376fb6 runtime: refactor namespace file
b683f66 tests: Unskip environment test as issue #324 has been resolved.
3201a9a Tests: Enable tests that were blocked and update for popular containers images
bd06c5f proxy: Fix a fd leak in an error path
d35a3c7 tests: unskip tests for docker images blocked by #318
b3c17d4 image: Update minimum container image in versions.txt.
57c004b tests: add support for multiple interfaces in swarm test
d171f74 tests: Add docker test to check environment.
8304fd5 runtime: verify if the system supports virtualization
67c2590 cppcheck: fix cppcheck errors
54c68af build: Remove the last reference to the hyperstart mock package
3beec06 proxy: Make Hello and Attach return the current api version
e8c5746 proxy: Add a debug message to print the proxy socket path
1d3a3ad proxy: Support build the proxy without linker flags
ddab651 test: Add docker build integration test
5feef66 proxy: Make the client.Attach() function future proof
8ee1e0e proxy: Make the client.Hello() function future proof
820e74b vendor: Revendor virtcontainers to 0.2.3 to fix a potential panic
6b53ace start: Delay shim execution until start has been called for runtime.
efe448c proxy: Fix a fd leak in an error path
e1e4ab0 proxy: Reorder response and fd
0046df6 ci: Add ineffassign to the go static checks

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>