### PR TITLE
tests: fix docker functional tests

### DIFF
--- a/tests/integration/docker/attach.bats
+++ b/tests/integration/docker/attach.bats
@@ -25,17 +25,17 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Check attach functionality" {
-	$DOCKER_EXE run --name containertest -d ubuntu bash -c "sleep 5 && echo 'Hello, World'"
-	$DOCKER_EXE attach containertest > result_file
+	container=$(random_name)
+	$DOCKER_EXE run --name $container -d ubuntu bash -c "sleep 5 && echo 'Hello, World'"
+	$DOCKER_EXE attach $container > result_file
 	grep 'Hello, World' result_file
+	$DOCKER_EXE rm -f $container
 }
 
 teardown() {
-	$DOCKER_EXE rm -f containertest
 	rm result_file
 }

--- a/tests/integration/docker/commit.bats
+++ b/tests/integration/docker/commit.bats
@@ -25,19 +25,22 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Commit a container" {
-	$DOCKER_EXE run -i --name container1 busybox /bin/sh -c "echo hello"
-	$DOCKER_EXE commit -m "test_commit" container1 container/test-container
+	container=$(random_name)
+	$DOCKER_EXE run -i --name $container busybox /bin/sh -c "echo hello"
+	$DOCKER_EXE commit -m "test_commit" $container container/test-container
 	$DOCKER_EXE rmi container/test-container
+	$DOCKER_EXE rm -f $container
 }
 
 @test "Commit a container with new configurations" {
-	$DOCKER_EXE run -i --name container2 busybox /bin/sh -c "echo hello"
-	$DOCKER_EXE inspect -f "{{ .Config.Env }}" container2
-	$DOCKER_EXE commit --change "ENV DEBUG true" container2 test/container-test
+	container=$(random_name)
+	$DOCKER_EXE run -i --name $container busybox /bin/sh -c "echo hello"
+	$DOCKER_EXE inspect -f "{{ .Config.Env }}" $container
+	$DOCKER_EXE commit --change "ENV DEBUG true" $container test/container-test
 	$DOCKER_EXE rmi test/container-test
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/cp.bats
+++ b/tests/integration/docker/cp.bats
@@ -25,17 +25,18 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Check mounted files at /etc after a docker cp" {
+	container=$(random_name)
 	content="test"
 	testfile=$(mktemp --tmpdir="$BATS_TMPDIR" --suffix=-cor-test)
-	$DOCKER_EXE run --name containertest -tid ubuntu bash
+	$DOCKER_EXE run --name $container -tid ubuntu bash
 	echo $content > $testfile
-	$DOCKER_EXE cp $testfile containertest:/root/
-	$DOCKER_EXE exec -i containertest bash -c "ls /root/$(basename $testfile)"
-	$DOCKER_EXE exec -i containertest bash -c "[ -s /etc/resolv.conf ]"
+	$DOCKER_EXE cp $testfile $container:/root/
+	$DOCKER_EXE exec -i $container bash -c "ls /root/$(basename $testfile)"
+	$DOCKER_EXE exec -i $container bash -c "[ -s /etc/resolv.conf ]"
 	rm -f $testfile
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/create.bats
+++ b/tests/integration/docker/create.bats
@@ -25,13 +25,14 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Create a container" {
-	$DOCKER_EXE create -ti --name container1 busybox true
-	$DOCKER_EXE ps -a | grep "container1"
+	container=$(random_name)
+	$DOCKER_EXE create -ti --name $container busybox true
+	$DOCKER_EXE ps -a | grep $container
+	$DOCKER_EXE rm -f $container
 }
 
 @test "Create network" {

--- a/tests/integration/docker/env.bats
+++ b/tests/integration/docker/env.bats
@@ -25,18 +25,21 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Verify LANG is not set in env" {
-	run $DOCKER_EXE run -i ubuntu env
+	container=$(random_name)
+	run $DOCKER_EXE run --name $container -i ubuntu env
 	echo "${output}" | grep -v "LANG"
+	$DOCKER_EXE rm -f $container
 }
 
 @test "Check that required env variables are set" {
-	run $DOCKER_EXE run -i ubuntu env
+	container=$(random_name)
+	run $DOCKER_EXE run --name $container -i ubuntu env
 	echo "${output}" | grep "PATH"
 	echo "${output}" | grep "HOSTNAME"
 	echo "${output}" | grep "HOME"
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/exec.bats
+++ b/tests/integration/docker/exec.bats
@@ -25,42 +25,57 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "modifying a container with exec" {
-	$DOCKER_EXE run --name containertest -d ubuntu bash -c "sleep 50"
+	container=$(random_name)
+	$DOCKER_EXE run --name $container -d ubuntu bash -c "sleep 50"
 	$DOCKER_EXE ps -a | grep "sleep 50"
-	$DOCKER_EXE exec -d containertest bash -c "echo 'hello world' > file"
-	$DOCKER_EXE exec containertest bash -c "cat /file"
+	$DOCKER_EXE exec -d $container bash -c "echo 'hello world' > file"
+	$DOCKER_EXE exec $container bash -c "cat /file"
+	$DOCKER_EXE rm -f $container
 }
 
 @test "exec a container with privileges" {
-	$DOCKER_EXE run -d --name containertest ubuntu bash -c "sleep 30"
-	$DOCKER_EXE exec -i --privileged containertest bash -c "mount -t tmpfs none /mnt"
-	$DOCKER_EXE exec containertest bash -c "df -h | grep "/mnt""
+	container=$(random_name)
+	$DOCKER_EXE run -d --name $container ubuntu bash -c "sleep 30"
+	$DOCKER_EXE exec -i --privileged $container bash -c "mount -t tmpfs none /mnt"
+	$DOCKER_EXE exec $container bash -c "df -h | grep "/mnt""
+	$DOCKER_EXE rm -f $container
 }
 
 @test "copying file from host to container using exec" {
+	container=$(random_name)
 	content="hello world"
-	$DOCKER_EXE run --name containertest -d ubuntu bash -c "sleep 30"
-	echo $content | $DOCKER_EXE exec -i containertest bash -c "cat > /home/file.txt"
-	$DOCKER_EXE exec -i containertest bash -c "cat /home/file.txt" | grep "$content"
+	$DOCKER_EXE run --name $container -d ubuntu bash -c "sleep 30"
+	echo $content | $DOCKER_EXE exec -i $container bash -c "cat > /home/file.txt"
+	$DOCKER_EXE exec -i $container bash -c "cat /home/file.txt" | grep "$content"
+	$DOCKER_EXE rm -f $container
 }
 
 @test "stdout forwarded using exec" {
-	$DOCKER_EXE run --name containertest -d ubuntu bash -c "sleep 30"
-	$DOCKER_EXE exec -ti containertest ls /etc/resolv.conf 2>/dev/null | grep "/etc/resolv.conf" 
+	container=$(random_name)
+	$DOCKER_EXE run --name $container -d ubuntu bash -c "sleep 30"
+	$DOCKER_EXE exec -ti $container ls /etc/resolv.conf 2>/dev/null | grep "/etc/resolv.conf" 
+	$DOCKER_EXE rm -f $container
 }
 
 @test "stderr forwarded using exec" {
-        $DOCKER_EXE run --name containertest -d ubuntu bash -c "sleep 30"
-        if $DOCKER_EXE exec containertest ls /etc/foo >/dev/null; then false; else true; fi	
+	container=$(random_name)
+	$DOCKER_EXE run --name $container -d ubuntu bash -c "sleep 30"
+	if $DOCKER_EXE exec $container ls /etc/foo >/dev/null; then
+		false;
+	else
+		true;
+	fi
+	$DOCKER_EXE rm -f $container
 }
 
 @test "check exit code using exec" {
-	$DOCKER_EXE run --name containertest -d ubuntu bash -c "sleep 30"
-	run $DOCKER_EXE exec containertest bash -c "exit 42"
+	container=$(random_name)
+	$DOCKER_EXE run --name $container -d ubuntu bash -c "sleep 30"
+	run $DOCKER_EXE exec $container bash -c "exit 42"
 	[ "$status" -eq 42 ]
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/exit-code.bats
+++ b/tests/integration/docker/exit-code.bats
@@ -26,16 +26,19 @@ exit_status=55
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Exit Code from container process when running non-interactive" {
-	run $DOCKER_EXE run ubuntu /usr/bin/perl -e "exit $exit_status"
+	container=$(random_name)
+	run $DOCKER_EXE run --name $container ubuntu /usr/bin/perl -e "exit $exit_status"
 	[ "${status}" -eq "$exit_status" ]
+	$DOCKER_EXE rm -f $container
 }
 
 @test "Exit Code from container process when running interactive" {
-	run $DOCKER_EXE run -ti ubuntu /usr/bin/perl -e "exit $exit_status"
+	container=$(random_name)
+	run $DOCKER_EXE run --name $container -ti ubuntu /usr/bin/perl -e "exit $exit_status"
 	[ "${status}" -eq "$exit_status" ]
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/export.bats
+++ b/tests/integration/docker/export.bats
@@ -25,16 +25,17 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Export a container" {
-	$DOCKER_EXE run -ti -d --name container1 busybox
-	$DOCKER_EXE export container1 > latest.tar
+	container=$(random_name)
+	$DOCKER_EXE run -ti -d --name $container busybox
+	$DOCKER_EXE export $container > latest.tar
 	if [ ! -f latest.tar ]; then
 		exit 1
 	fi
+	$DOCKER_EXE rm -f $container
 }
 
 teardown () {

--- a/tests/integration/docker/info.bats
+++ b/tests/integration/docker/info.bats
@@ -25,11 +25,12 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Container info" {
-	$DOCKER_EXE run -itd --name container1 busybox
+	container=$(random_name)
+	$DOCKER_EXE run -itd --name $container busybox
 	$DOCKER_EXE info| grep "Containers: 1"
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/inspect.bats
+++ b/tests/integration/docker/inspect.bats
@@ -25,21 +25,26 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Inspect a container ip address" {
-	$DOCKER_EXE run -ti -d --name container1 busybox
-	$DOCKER_EXE inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' container1
+	container=$(random_name)
+	$DOCKER_EXE run -ti -d --name $container busybox
+	$DOCKER_EXE inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $container
+	$DOCKER_EXE rm -f $container
 }
 
 @test "Inspect a container with json format" {
-	$DOCKER_EXE run -ti -d --name container2 busybox
-	$DOCKER_EXE inspect --format='{{json .Config}}' container2
+	container=$(random_name)
+	$DOCKER_EXE run -ti -d --name $container busybox
+	$DOCKER_EXE inspect --format='{{json .Config}}' $container
+	$DOCKER_EXE rm -f $container
 }
 
 @test "Inspect a container to get instance's log path" {
-	$DOCKER_EXE run -ti -d --name container3 busybox
-	$DOCKER_EXE inspect --format='{{.LogPath}}' container3
+	container=$(random_name)
+	$DOCKER_EXE run -ti -d --name $container busybox
+	$DOCKER_EXE inspect --format='{{.LogPath}}' $container
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/kill.bats
+++ b/tests/integration/docker/kill.bats
@@ -25,11 +25,12 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Kill a container" {
-	$DOCKER_EXE run -d -ti --name container1 busybox sh
-	$DOCKER_EXE kill container1
+	container=$(random_name)
+	$DOCKER_EXE run -d -ti --name $container busybox sh
+	$DOCKER_EXE kill $container
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/load.bats
+++ b/tests/integration/docker/load.bats
@@ -25,15 +25,16 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Load container" {
-	$DOCKER_EXE run -itd --name=container1 busybox
-	$DOCKER_EXE commit container1 mynewimage
+	container=$(random_name)
+	$DOCKER_EXE run -itd --name $container busybox
+	$DOCKER_EXE commit $container mynewimage
 	$DOCKER_EXE save mynewimage> /tmp/mynewimage.tar
 	$DOCKER_EXE load < /tmp/mynewimage.tar
 	$DOCKER_EXE images | grep "mynewimage"
 	$DOCKER_EXE rmi mynewimage
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/logs.bats
+++ b/tests/integration/docker/logs.bats
@@ -25,11 +25,12 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Retrieve logs from container" {
-	$DOCKER_EXE run -d -ti --name container1 ubuntu /bin/bash -c "echo 'hello world' > file; cat file"
-	$DOCKER_EXE logs container1
+	container=$(random_name)
+	$DOCKER_EXE run -d -ti --name $container ubuntu /bin/bash -c "echo 'hello world' > file; cat file"
+	$DOCKER_EXE logs $container
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/network.bats
+++ b/tests/integration/docker/network.bats
@@ -25,18 +25,21 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "HostName is passed to the container" {
+	container=$(random_name)
 	hostName=clr-container
-	$DOCKER_EXE run -h $hostName -i ubuntu hostname | grep $hostName
+	$DOCKER_EXE run --name $container -h $hostName -i ubuntu hostname | grep $hostName
+	$DOCKER_EXE rm -f $container
 }
 
 @test "Verify connectivity between 2 containers" {
-	contName='pingTest'
-	$DOCKER_EXE run -tid --name "$contName" ubuntu bash
-	ip_addr=$($DOCKER_EXE inspect --format '{{ .NetworkSettings.IPAddress }}' "$contName")
-	$DOCKER_EXE run -i debian ping -c 1 "$ip_addr" | grep -q '1 packets received'
+	container=$(random_name)
+	container2=$(random_name)
+	$DOCKER_EXE run -tid --name $container ubuntu bash
+	ip_addr=$($DOCKER_EXE inspect --format '{{ .NetworkSettings.IPAddress }}' $container)
+	$DOCKER_EXE run --name $container2 -i debian ping -c 1 "$ip_addr" | grep -q '1 packets received'
+	$DOCKER_EXE rm -f $container $container2
 }

--- a/tests/integration/docker/port.bats
+++ b/tests/integration/docker/port.bats
@@ -25,11 +25,12 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Port a container" {
-	$DOCKER_EXE run -tid -p 8080:8080 --name container1 busybox
-	$DOCKER_EXE port container1 8080/tcp
+	container=$(random_name)
+	$DOCKER_EXE run -tid -p 8080:8080 --name $container busybox
+	$DOCKER_EXE port $container 8080/tcp
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/restart.bats
+++ b/tests/integration/docker/restart.bats
@@ -25,15 +25,16 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Restart a container" {
-	$DOCKER_EXE run -ti -d --name container1 busybox
+	container=$(random_name)
+	$DOCKER_EXE run -ti -d --name $container busybox
 	$DOCKER_EXE ps -a | grep "Up"
-	$DOCKER_EXE stop container1
+	$DOCKER_EXE stop $container
 	$DOCKER_EXE ps -a | grep "Exited"
-	$DOCKER_EXE restart container1
+	$DOCKER_EXE restart $container
 	$DOCKER_EXE ps -a | grep "Up"
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/run.bats
+++ b/tests/integration/docker/run.bats
@@ -29,29 +29,39 @@ setup() {
 }
 
 @test "Run shell echo" {
-	run $DOCKER_EXE run busybox sh -c "echo Passed"
+	container=$(random_name)
+	run $DOCKER_EXE run --name $container busybox sh -c "echo Passed"
 	[ "${status}" -eq 0 ]
 	[[ "${output}" == 'Passed'* ]]
+	$DOCKER_EXE rm -f $container
 }
 
 @test "stdout using run" {
-	run bash -c "$DOCKER_EXE run busybox ls /etc/resolv.conf"
+	container=$(random_name)
+	container2=$(random_name)
+	run $DOCKER_EXE run --name $container busybox ls /etc/resolv.conf
 	[[ "${output}" =~ "/etc/resolv.conf" ]]
-	run bash -c "$DOCKER_EXE run busybox ls /etc/resolv.conf 1>/dev/null"
+	run bash -c "$DOCKER_EXE run --name $container2 busybox ls /etc/resolv.conf 1>/dev/null"
 	[ -z "${output}" ]
+	$DOCKER_EXE rm -f $container $container2
 }
 
 @test "stderr using run" {
-	run bash -c "$DOCKER_EXE run busybox ls /etc/foo"
+	container=$(random_name)
+	container2=$(random_name)
+	run $DOCKER_EXE run --name $container busybox ls /etc/foo
 	[[ "${output}" =~ "ls: /etc/foo: No such file or directory" ]]
-	run bash -c "$DOCKER_EXE run busybox ls /etc/foo 2>/dev/null"
+	run bash -c "$DOCKER_EXE run --name $container2 busybox ls /etc/foo 2>/dev/null"
 	[ -z "${output}" ]
+	$DOCKER_EXE rm -f $container $container2
 }
 
 @test "stdin from pipe" {
-	run bash -c "echo hello | $DOCKER_EXE run -i busybox"
+	container=$(random_name)
+	run bash -c "echo hello | $DOCKER_EXE run --name $container -i busybox"
 	echo status: "${status}"
 	echo output: "${output}"
 	[[ "${status}" == 127 ]]
 	[[ "${output}" =~ "sh: hello: not found" ]]
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/swarm.bats
+++ b/tests/integration/docker/swarm.bats
@@ -53,7 +53,6 @@ function clean_swarm_status() {
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 	clean_swarm_status
 	interfaces=($(readlink /sys/class/net/* | grep -i pci | xargs basename -a))

--- a/tests/integration/docker/tag.bats
+++ b/tests/integration/docker/tag.bats
@@ -25,13 +25,14 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "Tag a container" {
-	$DOCKER_EXE run -i busybox true
-	$DOCKER_EXE tag busybox container1
+	container=$(random_name)
+	$DOCKER_EXE run --name $container -i busybox true
+	$DOCKER_EXE tag busybox "container1"
 	$DOCKER_EXE images | grep "container1"
-	$DOCKER_EXE rmi container1
+	$DOCKER_EXE rmi "container1"
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/terminal.bats
+++ b/tests/integration/docker/terminal.bats
@@ -27,22 +27,27 @@ tty_dev="/dev/pts/.*"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 }
 
 @test "TERM env variable is set when allocating a tty" {
-	$DOCKER_EXE run -t ubuntu env | grep -q "$term_var"
+	container=$(random_name)
+	$DOCKER_EXE run --name $container -t ubuntu env | grep -q "$term_var"
+	$DOCKER_EXE rm -f $container
 }
 
 @test "TERM env variable is not set when not allocating a tty" {
-	run bash -c "$DOCKER_EXE run ubuntu env | grep -q $term_var"
+	container=$(random_name)
+	run bash -c "$DOCKER_EXE run --name $container ubuntu env | grep -q $term_var"
 	# Expecting RC=1 from the grep command since
 	# the TERM env variable should not exist.
 	[ "${status}" -eq 1 ]
+	$DOCKER_EXE rm -f $container
 }
 
 @test "Check that pseudo tty is setup properly when allocating a tty" {
-	run $DOCKER_EXE run -ti ubuntu tty
+	container=$(random_name)
+	run $DOCKER_EXE run --name $container -ti ubuntu tty
 	echo "${output}" | grep "$tty_dev"
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/user.bats
+++ b/tests/integration/docker/user.bats
@@ -29,19 +29,25 @@ setup() {
 }
 
 @test "Run as non-root user" {
-	run $DOCKER_EXE run -u postgres postgres whoami
+	container=$(random_name)
+	run $DOCKER_EXE run --name $container -u postgres postgres whoami
 	[ "${status}" -eq 0 ]
 	[[ "${output}" == 'postgres'* ]]
+	$DOCKER_EXE rm -f $container
 }
 
 @test "Groups for non-root user" {
-	run $DOCKER_EXE run -u postgres postgres groups
+	container=$(random_name)
+	run $DOCKER_EXE run --name $container -u postgres postgres groups
 	[ "${status}" -eq 0 ]
 	[[ "${output}" == 'postgres ssl-cert'* ]]
+	$DOCKER_EXE rm -f $container
 }
 
 @test "Run as root user" {
-	run $DOCKER_EXE run -u root:root postgres whoami
+	container=$(random_name)
+	run $DOCKER_EXE run --name $container -u root:root postgres whoami
 	[ "${status}" -eq 0 ]
 	[[ "${output}" == 'root'* ]]
+	$DOCKER_EXE rm -f $container
 }

--- a/tests/integration/docker/volume.bats
+++ b/tests/integration/docker/volume.bats
@@ -25,7 +25,6 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 
 setup() {
 	source $SRC/test-common.bash
-	clean_docker_ps
 	runtime_docker
 	volName='volume1'
 }
@@ -40,36 +39,40 @@ setup() {
 }
 
 @test "Volume - use volume in a container" {
+	container=$(random_name)
+	container2=$(random_name)
 	testFile='hello_world'
 	containerPath='/attached_vol'
-	run bash -c "$DOCKER_EXE run -i -v $volName:$containerPath busybox touch $containerPath/$testFile"
+	run bash -c "$DOCKER_EXE run --name $container -i -v $volName:$containerPath busybox touch $containerPath/$testFile"
 	[ $status -eq 0 ]
-	run bash -c "$DOCKER_EXE run -i -v $volName:$containerPath busybox ls $containerPath | grep $testFile"
-	$DOCKER_EXE rm $($DOCKER_EXE ps -qa)
+	run bash -c "$DOCKER_EXE run --name $container2 -i -v $volName:$containerPath busybox ls $containerPath | grep $testFile"
+	run $DOCKER_EXE rm -f $container $container2
 	[ $status -eq 0 ]
 }
 
 @test "Volume - bind-mount a directory" {
+	container=$(random_name)
 	dir_path="$(pwd)/sharedSpace"
 	test_file="foo"
 	containerPath="/root/sharedSpace"
 	mkdir "$dir_path"
 	touch "$dir_path/$test_file"
-	run bash -c "$DOCKER_EXE run -i -v $dir_path:$containerPath busybox ls $containerPath | grep $test_file"
+	run bash -c "$DOCKER_EXE run --name $container -i -v $dir_path:$containerPath busybox ls $containerPath | grep $test_file"
 	rm -r "$dir_path"
-	$DOCKER_EXE rm $($DOCKER_EXE ps -qa)
+	run $DOCKER_EXE rm -f $container
 	[ $status -eq 0 ]
 
 }
 
 @test "Volume - bind-mount a single file" {
+	container=$(random_name)
 	test_file="$(pwd)/foo"
 	file_content="bar"
 	echo "$file_content" >  "$test_file"
 	containerPath="/root/foo"
-	run bash -c "$DOCKER_EXE run -i -v $test_file:$containerPath busybox cat $containerPath | grep $file_content"
+	run bash -c "$DOCKER_EXE run --name $container -i -v $test_file:$containerPath busybox cat $containerPath | grep $file_content"
 	rm "$test_file"
-	$DOCKER_EXE rm $($DOCKER_EXE ps -qa)
+	run $DOCKER_EXE rm -f $container
 	[ $status -eq 0 ]
 }
 

--- a/tests/lib/test-common.bash
+++ b/tests/lib/test-common.bash
@@ -23,12 +23,6 @@ DOCKER_SERVICE="docker-cor"
 SCRIPT_PATH=$(dirname $(readlink -f $0))
 RESULT_DIR="${SCRIPT_PATH}/../results"
 
-# Cleaning test environment
-function clean_docker_ps(){
-	"$DOCKER_EXE" ps -q | xargs -r "$DOCKER_EXE" kill
-	"$DOCKER_EXE" ps -aq | xargs -r "$DOCKER_EXE" rm -f
-}
-
 # Restarting test environment
 function start_docker_service(){
 	systemctl status "$DOCKER_SERVICE" | grep 'running'
@@ -93,4 +87,8 @@ function get_average(){
 	done
 	echo "Average: " >> "$test_file"
 	echo "scale=2; $total / $count" | bc >> "$test_file"
+}
+
+function random_name() {
+	echo $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
 }


### PR DESCRIPTION
Before this patch some containers were not deleted in the test
where them were created causing random failures into the next tests
With this patch all container will be deleted where them were created

The main issue was this line:

```
"$DOCKER_EXE" ps -q | xargs -r "$DOCKER_EXE" kill
```

for example:
One container called 'tequila' is running.
When ```"$DOCKER_EXE" ps -q``` is executed the word 'tequila' is returned
but immediately 'tequila' dies ;( .
When ```xarg -r "$DOCKER_EXE" kill``` is executed docker tries
to kill to 'tequila' but it is already dead causing issue #593

"""Error response from daemon: Cannot kill container 'tequila'"""

RIP 'tequila'

fixes #593

Signed-off-by: Julio Montes <julio.montes@intel.com>