### PR TITLE
proxy: Fix the VM lost detection site

### DIFF
--- a/proxy/vm.go
+++ b/proxy/vm.go
@@ -135,8 +135,6 @@ func (vm *vm) ioHyperToClients() {
 	for {
 		msg, err := vm.hyperHandler.ReadIoMessage()
 		if err != nil {
-			// VM process is gone
-			vm.signalVMLost()
 			break
 		}
 
@@ -158,6 +156,8 @@ func (vm *vm) ioHyperToClients() {
 		}
 	}
 
+	// Having an error on read/write is interpreted as having lost the VM.
+	vm.signalVMLost()
 	vm.wg.Done()
 }
 


### PR DESCRIPTION
I placed the signal that we've lost the VM when the read() on the I/O
socket was failing. That was missing the rest of hyper to client I/O
copy loop: there are other places where having lost the VM will result
in this goroutine returning.

So, instead, place the VM lost signal at the end of the goroutine, we'll
signal we've lost the VM in all circumstances that way.

Fixes: https://github.com/01org/cc-oci-runtime/issues/622
Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>