### PR TITLE
proxy: Remove unused vm.CloseIO() method

### DIFF
--- a/proxy/vm.go
+++ b/proxy/vm.go
@@ -270,21 +270,6 @@ func (session *ioSession) Close() {
 	session.wg.Wait()
 }
 
-func (vm *vm) CloseIo(seq uint64) {
-	vm.Lock()
-	session := vm.ioSessions[seq]
-	if session == nil {
-		vm.Unlock()
-		return
-	}
-	for i := 0; i < session.nStreams; i++ {
-		delete(vm.ioSessions, seq+uint64(i))
-	}
-	vm.Unlock()
-
-	session.Close()
-}
-
 func (vm *vm) Close() {
 	vm.hyperHandler.CloseSockets()
 	if vm.console.conn != nil {


### PR DESCRIPTION
Looking at coverage pointed out that this method may not be used
anywhere and indeed it wasn't.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>