### PR TITLE
proxy: Update package locations according to virtcontainers

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/01org/cc-oci-runtime/proxy/api"
-	"github.com/containers/virtcontainers/hyperstart/mock"
+	"github.com/containers/virtcontainers/pkg/hyperstart/mock"
 
 	hyper "github.com/hyperhq/runv/hyperstart/api/json"
 	"github.com/stretchr/testify/assert"

--- a/proxy/vm.go
+++ b/proxy/vm.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/containers/virtcontainers/hyperstart"
+	"github.com/containers/virtcontainers/pkg/hyperstart"
 	"github.com/golang/glog"
 )
 


### PR DESCRIPTION
Virtcontainers moved all its packages under the same directory pkg
and this commit updates the proxy accordingly.