### PR TITLE
proxy: Don't quit the hyper->client IO goroutine when a shim dies

### DIFF
--- a/proxy/vm.go
+++ b/proxy/vm.go
@@ -150,13 +150,15 @@ func (vm *vm) ioHyperToClients() {
 
 		err = hyperstart.SendIoMessageWithConn(session.client, msg)
 		if err != nil {
-			fmt.Fprintf(os.Stderr,
-				"error writing I/O data to client: %v\n", err)
-			break
+			// When the shim is forcefully killed, it's possible we
+			// still have data to write. Ignore errors for that case.
+			vm.infof(1, "io", "error writing I/O data to client:", err)
+			continue
 		}
 	}
 
-	// Having an error on read/write is interpreted as having lost the VM.
+	// Having an error on the IO channel read is interpreted as having lost
+	// the VM.
 	vm.signalVMLost()
 	vm.wg.Done()
 }


### PR DESCRIPTION
That's a bug we have had for the longest time. There is one such
goroutine per VM and we where quitting it whenever we had an error
writing data to a shim.

However, we may have a number of shim per-VM, one for the initial
container and one for each exec. We can't just quite the whole goroutine
if the write to one of the shim is failing.

This bug was discovered because we know signal "VM lost" when this
goroutine exits, which was causing havoc.

Fixes: https://github.com/01org/cc-oci-runtime/issues/638
Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>