### PR TITLE
tests: Use the number of running tests in info.bats

### DIFF
--- a/tests/integration/docker/info.bats
+++ b/tests/integration/docker/info.bats
@@ -31,6 +31,12 @@ setup() {
 @test "Container info" {
 	container=$(random_name)
 	$DOCKER_EXE run -itd --name $container busybox
-	$DOCKER_EXE info| grep "Containers: 1"
+	# Checks one container is running (relies on having no previous docker
+	# container running).
+	$DOCKER_EXE info| grep "^ Running: 1$"
+	# As an additional measure, make sure $container is indeed running
+	run $DOCKER_EXE inspect --type container --format '{{ .State.Status }}' $container
+	[ "$status" -eq 0 ]
+	[ "$output" = "running" ]
 	$DOCKER_EXE rm -f $container
 }


### PR DESCRIPTION
Since:

  commit c8b933adb193d611fc0998368f866d8028efe99a
  Author: Julio Montes <julio.montes@intel.com>
  Date:   Thu Jan 26 18:16:44 2017 -0600

      tests: fix docker functional tests

We don't run docker rm in setup(), which is a good thing and avoid hiding bugs.

However it's possible the system we are running on still has some
(stopped) containers not yet deleted. It's slightly more robust to use
the number of running containers for the check we do here.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>