### PR TITLE
Swarm tests fixes 

### DIFF
--- a/tests/integration/docker/swarm.bats
+++ b/tests/integration/docker/swarm.bats
@@ -119,7 +119,7 @@ setup() {
 }
 
 @test "check that replicas has two interfaces" {
-	REPLICAS_UP=(`$DOCKER_EXE ps -a -q`)
+	REPLICAS_UP=(`$DOCKER_EXE ps -q`)
 	for i in ${REPLICAS_UP[@]}; do
 		# here we are checking that each replica has two interfaces
 		# and they should be always eth0 and eth1
@@ -130,7 +130,7 @@ setup() {
 @test "check service ip among the replicas" {
 	service_name=`$DOCKER_EXE service ls --filter name=testswarm -q`
 	ip_service=`$DOCKER_EXE service inspect $service_name --format='{{range .Endpoint.VirtualIPs}}{{.Addr}}{{end}}' | cut -d'/' -f1`
-	REPLICAS_UP=(`$DOCKER_EXE ps -a -q`)
+	REPLICAS_UP=(`$DOCKER_EXE ps -q`)
 	for i in ${REPLICAS_UP[@]}; do
 		# here we are checking that all the
 		# replicas have the service ip
@@ -139,7 +139,7 @@ setup() {
 }
 
 @test "ping among replicas on their gateway ip" {
-	REPLICAS_UP=(`$DOCKER_EXE ps -a | tail -n +2 | awk '{ print $1 }'`)
+	REPLICAS_UP=(`$DOCKER_EXE ps | tail -n +2 | awk '{ print $1 }'`)
 	IPS_REPLICAS=(`$DOCKER_EXE network inspect docker_gwbridge --format='{{range .Containers}} {{ println .IPv4Address}}{{end}}' | head -n -2 | cut -d'/' -f1`)
 	for i in ${REPLICAS_UP[@]}; do
 		for j in ${IPS_REPLICAS[@]}; do

--- a/tests/integration/docker/swarm.bats
+++ b/tests/integration/docker/swarm.bats
@@ -25,9 +25,9 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 # maximum number of replicas that will be launch
 number_of_replicas=4
 url=http://127.0.0.1:8080/hostname
-# number of attemps to obtain the hostname
+# number of attempts to obtain the hostname
 # of the replicas using curl
-number_of_attemps=5
+number_of_attempts=5
 # saves the hostname of the replicas
 declare -a REPLICAS
 # saves the process id of the replicas
@@ -39,7 +39,7 @@ declare -a IPS_REPLICAS
 
 #This function will verify that swarm is not running or it finishes
 function clean_swarm_status() {
-	for j in `seq 0 $number_of_attemps`; do
+	for j in `seq 0 $number_of_attempts`; do
 		if $DOCKER_EXE node ls; then
 			$DOCKER_EXE swarm leave --force
 			# docker swarm leave is not inmediately so it requires time to finish
@@ -47,7 +47,7 @@ function clean_swarm_status() {
 		else
 			break
 		fi
-        done
+	done
 }
 
 
@@ -80,48 +80,48 @@ setup() {
 			if [ "$i" != "$j" ] && [ -n "${NAMES_REPLICAS[$i]}" ]; then
 				# here we are performing a ping with the list
 				# of the overlay ips obtained from the replicas
-				$DOCKER_EXE exec ${NAMES_REPLICAS[$i]} bash -c "ping -c $number_of_attemps ${IPS_REPLICAS[$j]}"
+				$DOCKER_EXE exec ${NAMES_REPLICAS[$i]} bash -c "ping -c $number_of_attempts ${IPS_REPLICAS[$j]}"
 			fi
 		done
 	done
 }
 
 @test "check that the replicas' names are different" {
-	skip "this test is not working properly (see https://github.com/01org/cc-oci-runtime/issues/578)" 
-	# this will help to obtain the hostname of 
+	skip "this test is not working properly (see https://github.com/01org/cc-oci-runtime/issues/578)"
+	# this will help to obtain the hostname of
 	# the replicas from the curl
-        unset http_proxy
-        for j in `seq 0 $number_of_attemps`; do
-	        for i in `seq 0 $((number_of_replicas-1))`; do
-		        # this will help that bat does not exit incorrectly 
-			# when curl fails in one of the attemps
+	unset http_proxy
+	for j in `seq 0 $number_of_attempts`; do
+		for i in `seq 0 $((number_of_replicas-1))`; do
+			# this will help that bat does not exit incorrectly
+			# when curl fails in one of the attempts
 			set +e
-		        REPLICAS[$i]="$(curl $url 2> /dev/null)"
-	                set -e
-               done
+			REPLICAS[$i]="$(curl $url 2> /dev/null)"
+			set -e
+		done
 		non_empty_elements="$(echo ${REPLICAS[@]} | egrep -o "[[:space:]]+" | wc -l)"
-               if [ "$non_empty_elements" == "$((number_of_replicas-1))" ]; then
-                	break
-                fi
-		# this will give enough time between attemps
-                sleep 5
-        done
+		if [ "$non_empty_elements" == "$((number_of_replicas-1))" ]; then
+		break
+		fi
+		# this will give enough time between attempts
+		sleep 5
+	done
 	for i in `seq 0 $((number_of_replicas-1))`; do
-                if [ -z "${REPLICAS[$i]}" ]; then
-                    false
-                fi
+		if [ -z "${REPLICAS[$i]}" ]; then
+			false
+		fi
 		for j in `seq $((i+1)) $((number_of_replicas-1))`; do
 			if [ "${REPLICAS[$i]}" == "${REPLICAS[$j]}" ]; then
 				false
 			fi
 		done
-	done 
+	done
 }
 
 @test "check that replicas has two interfaces" {
 	REPLICAS_UP=(`$DOCKER_EXE ps -a -q`)
 	for i in ${REPLICAS_UP[@]}; do
-		# here we are checking that each replica has two interfaces 
+		# here we are checking that each replica has two interfaces
 		# and they should be always eth0 and eth1
 		$DOCKER_EXE exec $i bash -c "ip route show | grep -E eth0 && ip route show | grep -E eth1"
 	done
@@ -132,7 +132,7 @@ setup() {
 	ip_service=`$DOCKER_EXE service inspect $service_name --format='{{range .Endpoint.VirtualIPs}}{{.Addr}}{{end}}' | cut -d'/' -f1`
 	REPLICAS_UP=(`$DOCKER_EXE ps -a -q`)
 	for i in ${REPLICAS_UP[@]}; do
-		# here we are checking that all the 
+		# here we are checking that all the
 		# replicas have the service ip
 		$DOCKER_EXE exec $i bash -c "ip a | grep $ip_service"
 	done
@@ -145,7 +145,7 @@ setup() {
 		for j in ${IPS_REPLICAS[@]}; do
 			# here we are checking that the replica can not perform
 			# a ping among the gateway ips
-			run $DOCKER_EXE exec $i bash -c "ip a | grep $j; if [ $? -ne 0 ]; then ping -c $number_of_attemps $j; else exit 1; fi"
+			run $DOCKER_EXE exec $i bash -c "ip a | grep $j; if [ $? -ne 0 ]; then ping -c $number_of_attempts $j; else exit 1; fi"
 			[ $status -ne 0 ]
 		done
 	done
@@ -161,7 +161,7 @@ setup() {
 			if [ "$i" != "$j" ] && [ -n "${NAMES_REPLICAS[$i]}" ]; then
 				# here we are performing a ping with the list
 				# of the overlay ips obtained from the replicas
-				$DOCKER_EXE exec ${NAMES_REPLICAS[$i]} bash -c "ping -c $number_of_attemps ${IPS_REPLICAS[$j]}"
+				$DOCKER_EXE exec ${NAMES_REPLICAS[$i]} bash -c "ping -c $number_of_attempts ${IPS_REPLICAS[$j]}"
 				break
 			fi
 		done


### PR DESCRIPTION
This PR fixes:
- replicas obtained from non-running containers:
    The swarm tests are verifying the interfaces and IP addresses
    from the containers listed with 'docker ps -a -q', but this fails
    if there is a container that is not running (which maybe was created
    before running the tests).
    This commit changes the command to 'docker ps -q' so that we only
    get the list of containers that are running.

- a typo in swarm.bats
- indentation issues.
