### PR TITLE
tests: fix tests that depend of clean_docker_ps

### DIFF
--- a/tests/metrics/density/docker_cpu_usage.sh.in
+++ b/tests/metrics/density/docker_cpu_usage.sh.in
@@ -39,13 +39,15 @@ TIMES="$1"
 WAIT_TIME="$2"
 
 function get_idle_cpu_usage(){
+	containers=()
 	testArgs="rootfs=${IMAGE} idle_mode"
 	testResultFile="${RESULT_DIR}/cpu-usage-idle"
 	backup_old_file "$testResultFile"
 	write_csv_header "$testResultFile"
 	if [ $RUNTIME == 'cor' ]; then
 		for i in $(seq 1 "$TIMES"); do
-			$DOCKER_EXE run -tid $IMAGE bash
+			containers+=($(random_name))
+			$DOCKER_EXE run --name ${containers[-1]} -tid $IMAGE bash
 		done
 		sleep "$WAIT_TIME"
 		qemu_pids=$(pgrep -f @QEMU_PATH@)
@@ -55,19 +57,22 @@ function get_idle_cpu_usage(){
 			write_result_to_file "$TEST_NAME" "$testArgs" "$test_data" "$testResultFile"
 		done
 		get_average "$testResultFile"
+		docker rm -f ${containers[@]}
 	else
 		echo "Runtime: ${RUNTIME} is not valid for this test"
 	fi
 }
 
 function get_working_cpu_usage(){
+	containers=()
 	testArgs="rootfs=${IMAGE} working_mode"
 	testResultFile="${RESULT_DIR}/cpu-usage-working"
 	backup_old_file "$testResultFile"
 	write_csv_header "$testResultFile"
 	if [ $RUNTIME == 'cor' ]; then
 		for i in $(seq 1 "$TIMES"); do
-			$DOCKER_EXE run -tid $IMAGE bash -c "shuf -i 1-10000000 -n 500000"
+			containers+=($(random_name))
+			$DOCKER_EXE run --name ${containers[-1]} -tid $IMAGE bash -c "shuf -i 1-10000000 -n 500000"
 		done
 		sleep "$WAIT_TIME"
 		qemu_pids=$(pgrep -f @QEMU_PATH@)
@@ -77,6 +82,7 @@ function get_working_cpu_usage(){
 			write_result_to_file "$TEST_NAME" "$testArgs" "$test_data" "$testResultFile"
 		done
 		get_average "$testResultFile"
+		docker rm -f ${containers[@]}
 	else
 		echo "Runtime: ${RUNTIME} is not valid for this test"
 	fi
@@ -84,6 +90,4 @@ function get_working_cpu_usage(){
 
 echo "Executing Test: ${TEST_NAME}"
 get_idle_cpu_usage
-clean_docker_ps
 get_working_cpu_usage
-clean_docker_ps

--- a/tests/metrics/density/docker_memory_usage.sh.in
+++ b/tests/metrics/density/docker_memory_usage.sh.in
@@ -42,14 +42,17 @@ SMEM_BIN=$(command -v smem || true)
 QEMU_BIN="@QEMU_PATH@"
 
 function get_docker_memory_usage(){
+	containers=()
 	for i in $(seq 1 "$TIMES"); do
-		${DOCKER_EXE} run -tid $IMAGE $CMD
+		containers+=($(random_name))
+		${DOCKER_EXE} run --name ${containers[-1]} -tid $IMAGE $CMD
 	done
 	sleep "$WAIT_TIME"
 	for i in $("$SMEM_BIN" --no-header -P "^$QEMU_BIN" | awk '{print $6}'); do
 		test_data=$i
 		write_result_to_file "$TEST_NAME" "$TEST_ARGS" "$test_data" "$TEST_RESULT_FILE"
 	done
+	docker rm -f ${containers[@]}
 }
 
 echo "Executing Test: ${TEST_NAME}"
@@ -60,4 +63,3 @@ backup_old_file "$TEST_RESULT_FILE"
 write_csv_header "$TEST_RESULT_FILE"
 get_docker_memory_usage
 get_average "$TEST_RESULT_FILE"
-clean_docker_ps

--- a/tests/metrics/workload_time/cor_create_time.sh.in
+++ b/tests/metrics/workload_time/cor_create_time.sh.in
@@ -54,13 +54,13 @@ function get_time(){
 
 function cor_create_time(){
 	echo "" > ${LOG_FILE}
-	${DOCKER_EXE} run --runtime="$RUNTIME" -ti ${IMAGE} true > /dev/null && get_time
+	${DOCKER_EXE} run --rm --runtime="$RUNTIME" -ti ${IMAGE} true > /dev/null && get_time
 	if [ -z $(echo "$test_data" | grep -o "^-*") ]; then
 		testArgs='Network units=seconds'
 		write_result_to_file "$TEST_NAME" "$testArgs" "$test_data" "$testResultFileNet"
 	fi
 	echo "" > ${LOG_FILE}
-	${DOCKER_EXE} run --runtime="$RUNTIME" -ti --net=none ${IMAGE} true > /dev/null && get_time
+	${DOCKER_EXE} run --rm --runtime="$RUNTIME" -ti --net=none ${IMAGE} true > /dev/null && get_time
 	if [ -z "`echo $test_data | grep -o ^-*`" ]; then
 		testArgs='No-network units=seconds'
 		write_result_to_file "$TEST_NAME" "$testArgs" "$test_data" "$testResultFileNoNet"
@@ -77,4 +77,3 @@ for i in $(seq 1 $TIMES); do
 done
 get_average "$testResultFileNet"
 get_average "$testResultFileNoNet"
-clean_docker_ps

--- a/tests/metrics/workload_time/docker_shutdown.sh
+++ b/tests/metrics/workload_time/docker_shutdown.sh
@@ -42,11 +42,13 @@ function shut_down_container(){
 	if [[ "$RUNTIME" != 'runc' && "$RUNTIME" != 'cor' ]]; then
         die "Runtime ${RUNTIME} is not valid"
 	fi
-	$DOCKER_EXE run -tid --runtime "$RUNTIME" "$IMAGE" "$CMD" > /dev/null && \
-		(time -p ${DOCKER_EXE} stop "$($DOCKER_EXE ps -q)") &> "$TMP_FILE" && \
+	contname=$(random_name)
+	$DOCKER_EXE run --name ${contname} -tid --runtime "$RUNTIME" "$IMAGE" "$CMD" > /dev/null && \
+		(time -p ${DOCKER_EXE} stop ${contname}) &> "$TMP_FILE" && \
 		test_data=$(grep 'real' "$TMP_FILE" | cut -f2 -d' ')
 	write_result_to_file "$TEST_NAME" "$TEST_ARGS" "$test_data" "$TEST_RESULT_FILE"
 	rm -f $TMP_FILE
+	docker rm -f ${contname}
 }
 
 echo "Executing test: ${TEST_NAME} ${TEST_ARGS}"
@@ -56,4 +58,3 @@ for i in $(seq 1 "$TIMES"); do
 	shut_down_container
 done
 get_average "$TEST_RESULT_FILE"
-clean_docker_ps

--- a/tests/metrics/workload_time/docker_workload_time.sh
+++ b/tests/metrics/workload_time/docker_workload_time.sh
@@ -43,7 +43,7 @@ function run_workload(){
 	if [[ "$RUNTIME" != 'runc' && "$RUNTIME" != 'cor' ]]; then
 		die "Runtime ${RUNTIME} is not valid"
 	fi
-	(time -p $DOCKER_EXE run -ti --runtime "$RUNTIME" "$IMAGE" "$CMD") &> "$TMP_FILE"
+	(time -p $DOCKER_EXE run --rm -ti --runtime "$RUNTIME" "$IMAGE" "$CMD") &> "$TMP_FILE"
 	if [ $? -eq 0 ]; then
 		test_data=$(grep ^real "$TMP_FILE" | cut -f2 -d' ')
 		write_result_to_file "$TEST_NAME" "$TEST_ARGS" "$test_data" "$TEST_RESULT_FILE"
@@ -58,4 +58,3 @@ for i in $(seq 1 "$TIMES"); do
 	run_workload
 done
 get_average "$TEST_RESULT_FILE"
-clean_docker_ps

--- a/tests/metrics/workload_time/kernel_boot_time.sh
+++ b/tests/metrics/workload_time/kernel_boot_time.sh
@@ -27,7 +27,7 @@ set -e
 [ $# -ne 1 ] && ( echo >&2 "Usage: $0 <times to run>"; exit 1 )
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
-source "${SCRIPT_PATH}/../common/test.common"
+source "${SCRIPT_PATH}/../../lib/test-common.bash"
 
 TEST_NAME="Kernel Boot Time"
 TIMES="$1"
@@ -46,7 +46,7 @@ function get_kernelspace_time(){
 	write_csv_header "$test_result_file"
 	for i in $(seq 1 "$TIMES")
 	do
-		eval docker run "$run_options" -ti debian dmesg > "$TMP_FILE"
+		eval docker run --rm "$run_options" -ti debian dmesg > "$TMP_FILE"
 		test_data=$(grep "Freeing" "$TMP_FILE" | tail -1 | awk '{print $2}' | cut -d']' -f1)
 		write_result_to_file "$TEST_NAME" "$test_args" "$test_data" "$test_result_file"
 		rm "$TMP_FILE"
@@ -57,5 +57,3 @@ echo "Executing test: ${TEST_NAME}"
 
 get_kernelspace_time
 get_kernelspace_time nonet
-
-clean_docker_ps


### PR DESCRIPTION
With this patch metrics tests will use random names
to run and delete containers

fixes #652

Signed-off-by: Julio Montes <julio.montes@intel.com>