### PR TITLE
configure: Move to 2.1.0-rc.6

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,13 @@
-2.1.0.rc.5:
+2.1.0-rc.6:
+    Added additional groups and user related tests
+    Added docker attach functional tests
+    Added back popular containers tests
+    Added memory consumption tool
+    Fixed invalid file descriptor Glib warning
+    Fixed removing stale docker instances after docker rm
+    Fixed distcheck, functional and unit tests
+
+2.1.0-rc.5:
     Added SELinux configuration for proxy
     Added environment and image docker tests
     Added virtualization support check
@@ -9,7 +18,7 @@
     Fixed support for latest Docker streams
     Fixed a proxy fd leak
 
-2.1.0.rc.4:
+2.1.0-rc.4:
     Added mount namespace creation
     Added functional test tap output
     Added remaining exec tests

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.0-rc.5])
+AC_INIT([cc-oci-runtime], [2.1.0-rc.6])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
2.1.0-rc.6:
    Added additional groups and user related tests
    Added docker attach functional tests
    Added back popular containers tests
    Added memory consumption tool
    Fixed invalid file descriptor Glib warning
    Fixed removing stale docker instances after docker rm
    Fixed distcheck, functional and unit tests

Shortlog:

e456fb1 Add memory consumption tool
e6d9e53 Update Clear Containter image version
02ae0b6 tests: fix tests that depend of clean_docker_ps
d953ce6 tests: Swarm - get replicas only from active containers
6fa06df tests - Fix 'attemps' typo and indentation issues in swarm.bats
e29f844 ci: Send Travis notifications to Slack
15f7f18 tests: Tighten the docker info check
a1682cd proxy: Don't quit the hyper->client IO goroutine when a shim dies
5f35b14 Test: Delete function from the setup that is not longer used and add --rm flag
91b96ca tests:Add docker test to verify that additional groups are supported.
4ca22c7 tests: fix unit tests
b4a9cb2 runtime: re-implement run hooks
60c642f tests: Fix functional tests that run in detached mode
935f148 tests: fix minimal config json
7a75afb tests: Add namespaces to config.json
19c4503 make: Add test-program to check -race is supported with go
2f59050 proxy: Remove unused vm.CloseIO() method
3efd128 start: Pass additional groups to startpod hyperstart command.
f531b0b state: Write additional groups to state file.
42596dc tests: Add test to verify user info is converted to json correctly.
7dd2e28 oci: Parse additional groups passed in the oci config.json.
2b585d9 proxy: Fix the VM lost detection site
509b1b3 tests: Unskip tests for images for all issues resolved in 2.1 so far.
c8b933a tests: fix docker functional tests
fffeb1f tests: Fix distcheck errors
ac31610 tests: Add tests to check container is run as specified user.
fee503a start: Send the uid and gid to newcontainer cmd
e7e679c state: Fix writing uid and gid to the state file.
27762a8 Test: Check attach functionality

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>