### PR TITLE
tests: fail tests if a process is left behind

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,7 +65,8 @@ GENERATED_FILES = \
 	tests/functional/data/config-minimal-cc-oci.json \
 	tests/metrics/density/docker_cpu_usage.sh \
 	tests/metrics/density/docker_memory_usage.sh \
-	tests/metrics/workload_time/cor_create_time.sh
+	tests/metrics/workload_time/cor_create_time.sh \
+	tests/lib/test-common.bash
 
 $(GENERATED_FILES): %: %.in Makefile
 	@mkdir -p `dirname $@`
@@ -369,7 +370,7 @@ endif
 if DOCKER_TESTS
 CHECK_DEPS += docker-tests
 docker-tests: cc-oci-runtime
-	@$(BATS_PATH) $(srcdir)/tests/integration/docker
+	@$(BATS_PATH) -t $(srcdir)/tests/integration/docker
 endif
 
 #### tests ####

--- a/tests/integration/docker/attach.bats
+++ b/tests/integration/docker/attach.bats
@@ -26,6 +26,7 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
 }
 
 @test "Check attach functionality" {
@@ -38,4 +39,5 @@ setup() {
 
 teardown() {
 	rm result_file
+	check_no_processes_up
 }

--- a/tests/integration/docker/build.bats
+++ b/tests/integration/docker/build.bats
@@ -26,11 +26,13 @@ IMG_NAME="ccbuildtests"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
 }
 
 teardown () {
 	echo "teardown:"
 	$DOCKER_EXE rmi $IMG_NAME
+	check_no_processes_up
 }
 
 @test "docker build env vars" {

--- a/tests/integration/docker/commit.bats
+++ b/tests/integration/docker/commit.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Commit a container" {

--- a/tests/integration/docker/cp.bats
+++ b/tests/integration/docker/cp.bats
@@ -26,6 +26,7 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
 }
 
 @test "Check mounted files at /etc after a docker cp" {
@@ -39,4 +40,8 @@ setup() {
 	$DOCKER_EXE exec -i $container bash -c "[ -s /etc/resolv.conf ]"
 	rm -f $testfile
 	$DOCKER_EXE rm -f $container
+}
+
+teardown() {
+	check_no_processes_up
 }

--- a/tests/integration/docker/create.bats
+++ b/tests/integration/docker/create.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Create a container" {

--- a/tests/integration/docker/env.bats
+++ b/tests/integration/docker/env.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Verify LANG is not set in env" {

--- a/tests/integration/docker/exec.bats
+++ b/tests/integration/docker/exec.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "modifying a container with exec" {

--- a/tests/integration/docker/exit-code.bats
+++ b/tests/integration/docker/exit-code.bats
@@ -27,6 +27,11 @@ exit_status=55
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Exit Code from container process when running non-interactive" {

--- a/tests/integration/docker/export.bats
+++ b/tests/integration/docker/export.bats
@@ -26,6 +26,7 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
 }
 
 @test "Export a container" {
@@ -40,4 +41,5 @@ setup() {
 
 teardown () {
 	rm -rf latest.tar
+	check_no_processes_up
 }

--- a/tests/integration/docker/info.bats
+++ b/tests/integration/docker/info.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Container info" {

--- a/tests/integration/docker/inspect.bats
+++ b/tests/integration/docker/inspect.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Inspect a container ip address" {

--- a/tests/integration/docker/kill.bats
+++ b/tests/integration/docker/kill.bats
@@ -22,15 +22,21 @@
 #Based on docker commands
 
 SRC="${BATS_TEST_DIRNAME}/../../lib/"
+cc_shim="/usr/libexec/cc-shim"
 
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
 }
 
 @test "Kill a container" {
 	container=$(random_name)
 	$DOCKER_EXE run -d -ti --name $container busybox sh
 	$DOCKER_EXE kill $container
-	$DOCKER_EXE rm -f $container
+	$DOCKER_EXE rm $container
+}
+
+teardown() {
+	check_no_processes_up
 }

--- a/tests/integration/docker/load.bats
+++ b/tests/integration/docker/load.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Load container" {

--- a/tests/integration/docker/logs.bats
+++ b/tests/integration/docker/logs.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Retrieve logs from container" {

--- a/tests/integration/docker/network.bats
+++ b/tests/integration/docker/network.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "HostName is passed to the container" {

--- a/tests/integration/docker/port.bats
+++ b/tests/integration/docker/port.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Port a container" {

--- a/tests/integration/docker/restart.bats
+++ b/tests/integration/docker/restart.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Restart a container" {

--- a/tests/integration/docker/run.bats
+++ b/tests/integration/docker/run.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Run shell echo" {

--- a/tests/integration/docker/swarm.bats
+++ b/tests/integration/docker/swarm.bats
@@ -54,6 +54,7 @@ function clean_swarm_status() {
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
 	clean_swarm_status
 	interfaces=($(readlink /sys/class/net/* | grep -i pci | xargs basename -a))
 	swarm_interface_arg=""
@@ -171,4 +172,5 @@ setup() {
 teardown () {
 	$DOCKER_EXE service remove testswarm
 	clean_swarm_status
+	check_no_processes_up
 }

--- a/tests/integration/docker/tag.bats
+++ b/tests/integration/docker/tag.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Tag a container" {

--- a/tests/integration/docker/terminal.bats
+++ b/tests/integration/docker/terminal.bats
@@ -28,6 +28,11 @@ tty_dev="/dev/pts/.*"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "TERM env variable is set when allocating a tty" {

--- a/tests/integration/docker/user.bats
+++ b/tests/integration/docker/user.bats
@@ -26,6 +26,11 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Run as non-root user" {

--- a/tests/integration/docker/volume.bats
+++ b/tests/integration/docker/volume.bats
@@ -26,7 +26,12 @@ SRC="${BATS_TEST_DIRNAME}/../../lib/"
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
 	volName='volume1'
+}
+
+teardown() {
+	check_no_processes_up
 }
 
 @test "Volume - create" {

--- a/tests/lib/test-common.bash.in
+++ b/tests/lib/test-common.bash.in
@@ -22,28 +22,14 @@ DOCKER_EXE="docker"
 DOCKER_SERVICE="docker-cor"
 SCRIPT_PATH=$(dirname $(readlink -f $0))
 RESULT_DIR="${SCRIPT_PATH}/../results"
-
-# Restarting test environment
-function start_docker_service(){
-	systemctl status "$DOCKER_SERVICE" | grep 'running'
-	if [ "$?" -eq 0 ]; then
-		systemctl restart "$DOCKER_SERVICE"
-	fi
-}
+HYPERVISOR_PATH="@QEMU_PATH@"
+CC_SHIM_PATH="/usr/libexec/cc-shim"
 
 # Checking that default runtime is cor
 function runtime_docker(){
 	default_runtime=`$DOCKER_EXE info 2>/dev/null | grep "^Default Runtime" | cut -d: -f2 | tr -d '[[:space:]]'`
 	if [ "$default_runtime" != "cor" ]; then
 		die "Tests need to run with COR runtime"
-	fi
-}
-
-function pull_image(){
-	docker images | grep -q "$1"
-	if [ $? == 1 ]; then
-		echo "Pull $1 image"
-		docker pull "$1"
 	fi
 }
 
@@ -91,4 +77,44 @@ function get_average(){
 
 function random_name() {
 	echo $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+}
+
+function check_active_process() {
+	process=$1
+	if pgrep -f "$process" > /dev/null; then
+		return 1
+	else
+		return 0
+	fi
+}
+
+# This function checks if there are containers or
+# cc-shim and qemu-lite processes up, if found, they are
+# killed to start test with clean environment.
+# The function is intended to be used in the setup() of
+# the docker integration tests for cc-oci-runtime.
+function kill_processes_before_start() {
+	[ "$($DOCKER_EXE ps -q)" ] && $DOCKER_EXE kill $("$DOCKER_EXE ps -q")
+	check_active_process "$HYPERVISOR_PATH" || killall "$HYPERVISOR_PATH"
+	check_active_process "$CC_SHIM_PATH" || killall "$CC_SHIM_PATH"
+}
+
+# This function checks for active processes that were
+# left behind by cc-oci-runtime.
+# The function is intended to be used in the teardown() of
+# the docker integration tests for cc-oci-runtime.
+function check_no_processes_up() {
+	wait_time=5
+	while [ "$wait_time" -gt 0 ]; do
+		if [ ! -z "$($DOCKER_EXE ps -q)" ] && \
+		[ ! "$(check_active_process qemu)" ] && \
+		[ ! "$(check_active_process cc-shim)" ]
+		then
+			wait_time=$((wait_time-1))
+			sleep 1
+		else
+			return 0
+		fi
+	done
+	return 1
 }


### PR DESCRIPTION
This commit enhances the tests to verify that the
containers and all subprocesses (cc-shim and qemu)
are killed properly.

Fixes #647

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>