### PR TITLE
ci: Run complete configuration to prepare coverity build

### DIFF
--- a/.ci/ci-configure.sh
+++ b/.ci/ci-configure.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2017 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+set -e -x
+
+source $(dirname "$0")/ci-common.sh
+
+./autogen.sh
+
+# We run the travis script from an exploded `make dist` tarball to ensure
+# `make dist` has the necessary files to compile and run the tests.
+#
+# Note: we don't use `make distcheck` here as we can't run everything we want
+#       for distcheck in travis.
+# Note: chronic is used to limit the travis output while still showing it if
+# the command fails.
+chronic make dist
+tarball=`ls -1 cc-oci-runtime-*.tar.xz`
+chronic tar xvf "$tarball"
+tarball_dir=${tarball%.tar.xz}
+
+configure_opts=""
+configure_opts+=" --sysconfdir=/etc"
+configure_opts+=" --localstatedir=/var"
+configure_opts+=" --prefix=/usr"
+configure_opts+=" --enable-cppcheck"
+configure_opts+=" --enable-valgrind"
+configure_opts+=" --disable-valgrind-helgrind"
+configure_opts+=" --disable-valgrind-drd"
+configure_opts+=" --disable-silent-rules"
+
+if [ "$nested" = "Y" ]
+then
+    configure_opts+=" --enable-docker-tests"
+    configure_opts+=" --enable-functional-tests"
+    configure_opts+=" --with-cc-image=\"${clr_assets_dir}/clear-containers.img\""
+    configure_opts+=" --with-cc-kernel=\"${clr_assets_dir}/vmlinux.container\""
+    configure_opts+=" --with-qemu-path=\"${prefix_dir}/bin/qemu-system-x86_64\""
+else
+    configure_opts+=" --disable-docker-tests"
+    configure_opts+=" --disable-functional-tests"
+fi
+
+(cd "$ci_build_dir" && \
+ eval ../"$tarball_dir"/configure "$configure_opts")

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,7 @@ addons:
     project:
       name: 01org/cc-oci-runtime
       description: Build submitted via Travis CI
-    build_command_prepend: "./autogen.sh --enable-cppcheck --enable-valgrind --disable-valgrind-helgrind
-      --disable-valgrind-drd; make clean"
+    build_command_prepend: "./.ci/ci-configure.sh; make clean"
     build_command: make -j5
     branch_pattern: coverity_scan
     # It should be possible to specify the Coverity notification email


### PR DESCRIPTION
The existing ./autogen.sh call was missing many of the exported
variables from ci-common.sh and was for example not finding our
locally installed glib.

This patch extracts the configuration part from ci-build.sh into
ci-configure.sh and call the latter as the coverity prepend build.

Fixes #533

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>