### PR TITLE
release: version 2.1.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+2.1.0:
+	Add complete configuration to prepare coverity build
+	Fixed coverity token
+
 2.1.0-rc.6:
     Added additional groups and user related tests
     Added docker attach functional tests

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.0-rc.6])
+AC_INIT([cc-oci-runtime], [2.1.0])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
2.1.0:
	Fixed coverity token
	Add complete configuration to prepare coverity build

Shortlog:

cf0e726 ci: Run complete configuration to prepare coverity build
c82fe5e ci: Fix coverity token

Signed-off-by: Julio Montes <julio.montes@intel.com>