### PR TITLE
build: Run apt-get update before installing packages

### DIFF
--- a/.ci/ci-setup.sh
+++ b/.ci/ci-setup.sh
@@ -118,6 +118,7 @@ then
 	pkgs+=" qemu-system-x86"
 fi
 
+sudo apt-get -qq update
 eval sudo apt-get -qq install "$pkgs"
 
 function compile {


### PR DESCRIPTION
The travis builds started failing with errors when installing packages.
Turns out we need to do an apt-get update before install when using the
standard infrastructure:

  https://docs.travis-ci.com/user/installing-dependencies/#Installing-Packages-on-Standard-Infrastructure

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>