### PR TITLE
runtime: Fix docker file descriptor leaks

### DIFF
--- a/src/oci-config.c
+++ b/src/oci-config.c
@@ -196,6 +196,9 @@ cc_oci_config_free (struct cc_oci_config *config)
 		g_slist_free_full(config->oci.oci_linux.namespaces,
                 (GDestroyNotify)cc_oci_ns_free);
 	}
+	if (config->oci.oci_linux.cgroupsPath) {
+		g_free (config->oci.oci_linux.cgroupsPath);
+	}
 
 	g_free_if_set (config->net.hostname);
 	g_free_if_set (config->net.dns_ip1);

--- a/src/oci.h
+++ b/src/oci.h
@@ -109,6 +109,11 @@
 /** Mode for \ref CC_OCI_WORKLOAD_FILE. */
 #define CC_OCI_SCRIPT_MODE		0755
 
+/** Mode for cgroup directory.
+ * 0755 is the mode used to create directories in /sys/fs/cgroup/memory/
+ */
+#define CC_OCI_CGROUP_MODE		0755
+
 /** Mode for all created directories. */
 #define CC_OCI_DIR_MODE                0750
 
@@ -136,6 +141,9 @@
 
 /* Path to the stateless passwd file. */ 
 #define STATELESS_PASSWD_PATH "/usr/share/defaults/etc/passwd"
+
+/* Path to memory cgroup directory */
+#define CGROUP_MEM_DIR "/sys/fs/cgroup/memory"
 
 /* Offset to add to the interface index for assigning the pci slot.
  * First 3 slots are in use for pc-lite machine type
@@ -254,6 +262,9 @@ struct oci_cfg_process {
 struct oci_cfg_linux {
 	/** List of \ref oci_cfg_namespace namespaces */
 	GSList          *namespaces;
+
+	/** cgroup path */
+	gchar           *cgroupsPath;
 };
 
 /** Representation of the OCI runtime schema embodied by

--- a/src/process.c
+++ b/src/process.c
@@ -788,6 +788,12 @@ cc_oci_vm_launch (struct cc_oci_config *config)
 	GSocketConnection *shim_socket_connection = NULL;
 	GError            *error = NULL;
 	int                status = 0;
+	char              *pid_str = NULL;
+	int                fd_tasks = -1;
+	int                fd_procs = -1;
+	gchar             *cgroup_dir = NULL;
+	gchar             *cgroup_tasks = NULL;
+	gchar             *cgroup_procs = NULL;
 
 	if (! config) {
 		return false;
@@ -1186,6 +1192,38 @@ child_failed:
 	 */
 	ret = cc_proxy_disconnect (config->proxy);
 
+	/* Before create pid file!
+	 *
+	 * Docker provides a cgroup path that MUST be created before pid file
+	 * workload pid MUST be copied to task and cgroup.procs notifying to docker
+	 * that the workload is part of a cgroup.
+	 * With this change docker WILL NOT create a new cgroup and WILL NOT copy
+	 * the workload pid to this new cgroup avoiding file descriptor leaks
+	 */
+	if (config->oci.oci_linux.cgroupsPath) {
+		cgroup_dir = g_strdup_printf ("%s/%s", CGROUP_MEM_DIR,
+			config->oci.oci_linux.cgroupsPath);
+		g_mkdir_with_parents (cgroup_dir, CC_OCI_CGROUP_MODE);
+
+		pid_str = g_strdup_printf ("%d", config->state.workload_pid);
+
+		cgroup_tasks = g_strdup_printf ("%s/tasks", cgroup_dir);
+		fd_tasks = open (cgroup_tasks, O_WRONLY);
+		if (write (fd_tasks, pid_str, strlen(pid_str)) <= 0) {
+			g_critical ("failed to copy workload pid to cgroup tasks: %s",
+				strerror(errno));
+			goto out;
+		}
+
+		cgroup_procs = g_strdup_printf ("%s/cgroup.procs", cgroup_dir);
+		fd_procs = open (cgroup_procs, O_WRONLY);
+		if (write (fd_procs, pid_str, strlen(pid_str)) <= 0) {
+			g_critical ("failed to copy workload pid to cgroup procs: %s",
+				strerror(errno));
+			goto out;
+		}
+	}
+
 	/* Finally, create the pid file.
 	 *
 	 * This MUST be done after all setup since containerd
@@ -1207,6 +1245,14 @@ out:
 	if (shim_err_fd != -1) close (shim_err_fd);
 	if (shim_args_fd != -1) close (shim_args_fd);
 	if (shim_socket_fd != -1) close (shim_socket_fd);
+
+	close_if_set (fd_procs);
+	close_if_set (fd_tasks);
+
+	g_free_if_set (cgroup_dir);
+	g_free_if_set (cgroup_tasks);
+	g_free_if_set (cgroup_procs);
+	g_free_if_set (pid_str);
 
 	if (setup_networking) {
 		netlink_close (hndl);

--- a/src/spec_handlers/linux.c
+++ b/src/spec_handlers/linux.c
@@ -102,6 +102,8 @@ handle_linux_section (GNode *root, struct cc_oci_config *config)
 		g_node_children_foreach(root, G_TRAVERSE_ALL,
 			(GNodeForeachFunc)handle_namespaces_section,
 			config);
+	} else if (! g_strcmp0 (root->data, "cgroupsPath")) {
+		config->oci.oci_linux.cgroupsPath = g_strdup (root->children->data);
 	}
 }
 

--- a/tests/data/linux-no-cgroupsPath.json
+++ b/tests/data/linux-no-cgroupsPath.json
@@ -1,0 +1,5 @@
+{
+	"linux" : {
+		"namespaces": []
+	}
+}

--- a/tests/data/linux.json
+++ b/tests/data/linux.json
@@ -1,4 +1,6 @@
 {
 	"linux" : {
+		"namespaces": [],
+		"cgroupsPath": "/mycontainer/"
 	}
 }

--- a/tests/spec_handlers/linux_test.c
+++ b/tests/spec_handlers/linux_test.c
@@ -34,6 +34,7 @@ static struct spec_handler_test tests[] = {
 	{ TEST_DATA_DIR "/linux-namespaces-no-path.json"     , true  },
 	{ TEST_DATA_DIR "/linux-namespaces-with-paths.json"  , true  },
 	{ TEST_DATA_DIR "/linux-invalid-namespace-type.json" , false },
+	{ TEST_DATA_DIR "/linux-no-cgroupsPath.json"         , true  },
 	{ TEST_DATA_DIR "/linux.json"                        , true  },
 	{ NULL, false },
 };


### PR DESCRIPTION
Docker provides a cgroup path where the workload MUST be
added before create pid file otherwise docker will create a new
cgroup and add the workload to it.
When workload process ends the runtime MUST delete the cgroup path
notifying docker to free its open event file descriptors otherwise
docker won't close them causing file descriptors leaks.

fixes #616

Signed-off-by: Julio Montes <julio.montes@intel.com>