### PR TITLE
fdleak: Don't let Compare() return true when it shouldn't

### DIFF
--- a/proxy/fdleak_test.go
+++ b/proxy/fdleak_test.go
@@ -195,7 +195,7 @@ func (d *FdLeakDetector) Compare(w io.Writer, a, b *FdSnapshot) bool {
 
 		if aInfo.Fd == bInfo.Fd {
 			// File descriptor found in both snapshots
-			equal = aInfo.equal(bInfo)
+			equal = equal && aInfo.equal(bInfo)
 			i++
 			j++
 
@@ -457,6 +457,39 @@ func TestFdDetectorCompare(t *testing.T) {
 					{
 						Fd:    0,
 						Flags: syscall.O_RDWR,
+					},
+				},
+			},
+			new: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDWR,
+					},
+					{
+						Fd:    1,
+						Flags: syscall.O_RDWR,
+						Text:  "/foo",
+					},
+				},
+			},
+			equal: false,
+		},
+
+		// Same number of fds in the two snapshots, different fds at
+		// index 0 but same fds at index 1. We used to have a bug
+		// saying the two snapshots were identical.
+		{
+			old: &FdSnapshot{
+				Fds: []FdInfo{
+					{
+						Fd:    0,
+						Flags: syscall.O_RDONLY,
+					},
+					{
+						Fd:    1,
+						Flags: syscall.O_RDWR,
+						Text:  "/foo",
 					},
 				},
 			},


### PR DESCRIPTION
*Note: This bug was discovered in clearcontainers/proxy when testing against go tip (what will become 1.9). It's a real bug though that could have happened even with earlier go versions.*

When we've already failed the comparison for a previous fd, nothing
should be able to make us return true.

Unfortunately, we were overriding unconditionally the equal boolean
with no regard of the past.

This was found testing the proxy on go tip (what will become 1.9), the
runtime has changed and exposed that bug.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>