### PR TITLE
CRI-O fixes for 2.1.2

### DIFF
--- a/src/mount.c
+++ b/src/mount.c
@@ -457,7 +457,7 @@ cc_oci_handle_unmounts (const struct cc_oci_config *config)
 gboolean
 cc_pod_handle_unmounts (const struct cc_oci_config *config)
 {
-	if (! config && ! config->pod) {
+	if (! (config && config->pod)) {
 		return true;
 	}
 

--- a/src/mount.c
+++ b/src/mount.c
@@ -207,14 +207,15 @@ cc_oci_perform_mount (const struct cc_oci_mount *m, gboolean dry_run)
 }
 
 /*!
- * Setup required mounts.
+ * Setup mount points.
  *
  * \param config \ref cc_oci_config.
+ * \param mounts List of \ref cc_oci_mount.
  *
  * \return \c true on success, else \c false.
  */
-gboolean
-cc_oci_handle_mounts (struct cc_oci_config *config)
+static gboolean
+cc_handle_mounts(struct cc_oci_config *config, GSList *mounts)
 {
 	GSList    *l;
 	gboolean   ret;
@@ -233,7 +234,7 @@ cc_oci_handle_mounts (struct cc_oci_config *config)
 		return false;
 	}
 
-	for (l = config->oci.mounts; l && l->data; l = g_slist_next (l)) {
+	for (l = mounts; l && l->data; l = g_slist_next (l)) {
 		struct cc_oci_mount *m = (struct cc_oci_mount *)l->data;
 
 		if (cc_oci_mount_ignore (m)) {
@@ -302,6 +303,39 @@ cc_oci_handle_mounts (struct cc_oci_config *config)
 }
 
 /*!
+ * Setup required OCI mounts.
+ *
+ * \param config \ref cc_oci_config.
+ *
+ * \return \c true on success, else \c false.
+ */
+gboolean
+cc_oci_handle_mounts (struct cc_oci_config *config)
+{
+	if (! (config && config->oci.mounts)) {
+		return false;
+	}
+	return cc_handle_mounts(config, config->oci.mounts);
+}
+
+/*!
+ * Setup pod rootfs mount points.
+ *
+ * \param config \ref cc_oci_config.
+ *
+ * \return \c true on success, else \c false.
+ */
+gboolean
+cc_pod_handle_mounts (struct cc_oci_config *config)
+{
+	if (! (config && config->pod)) {
+		return true;
+	}
+
+	return cc_handle_mounts(config, config->pod->rootfs_mounts);
+}
+
+/*!
  * Unmount the mount specified by \p m.
  *
  * \param m \ref cc_oci_mount.
@@ -321,7 +355,54 @@ cc_oci_perform_unmount (const struct cc_oci_mount *m)
 }
 
 /*!
- * Unmount all mounts.
+ * Unmount a list of mounts.
+ *
+ * \param mounts List of \ref cc_oci_mount.
+ *
+ * \return \c true on success, else \c false.
+ */
+static gboolean
+cc_handle_unmounts (GSList *mounts)
+{
+	GSList  *l;
+
+	/* umount files and directories */
+	for (l = mounts; l && l->data; l = g_slist_next (l)) {
+		struct cc_oci_mount *m = (struct cc_oci_mount *)l->data;
+
+		if (m->ignore_mount) {
+			/* was never mounted */
+			continue;
+		}
+
+		if (! cc_oci_perform_unmount (m)) {
+			g_critical("failed to umount %s", m->dest);
+			return false;
+		}
+	}
+
+	/* delete directories created by cc_oci_handle_mounts */
+	for (l = mounts; l && l->data; l = g_slist_next (l)) {
+		struct cc_oci_mount *m = (struct cc_oci_mount *)l->data;
+
+		if (m->ignore_mount) {
+			/* was never mounted */
+			continue;
+		}
+
+		if (m->directory_created) {
+			if (! cc_oci_rm_rf(m->directory_created)) {
+				g_critical("failed to delete %s", m->directory_created);
+			}
+		}
+	}
+
+	return true;
+}
+
+
+/*!
+ * Unmount all OCI mounts.
  *
  * \param config \ref cc_oci_config.
  *
@@ -363,53 +444,39 @@ cc_oci_handle_unmounts (const struct cc_oci_config *config)
 		return true;
 	}
 
-	/* umount files and directories */
-	for (l = config->oci.mounts; l && l->data; l = g_slist_next (l)) {
-		struct cc_oci_mount *m = (struct cc_oci_mount *)l->data;
-
-		if (m->ignore_mount) {
-			/* was never mounted */
-			continue;
-		}
-
-		if (! cc_oci_perform_unmount (m)) {
-			g_critical("failed to umount %s", m->dest);
-			return false;
-		}
-	}
-
-	/* delete directories created by cc_oci_handle_mounts */
-	for (l = config->oci.mounts; l && l->data; l = g_slist_next (l)) {
-		struct cc_oci_mount *m = (struct cc_oci_mount *)l->data;
-
-		if (m->ignore_mount) {
-			/* was never mounted */
-			continue;
-		}
-
-		if (m->directory_created) {
-			if (! cc_oci_rm_rf(m->directory_created)) {
-				g_critical("failed to delete %s", m->directory_created);
-			}
-		}
-	}
-
-	return true;
+	return cc_handle_unmounts(config->oci.mounts);
 }
 
 /*!
- * Convert the list of mounts to a JSON array.
+ * Unmount all pod mount points.
+ *
+ * \param config \ref cc_oci_config.
+ *
+ * \return \c true on success, else \c false.
+ */
+gboolean
+cc_pod_handle_unmounts (const struct cc_oci_config *config)
+{
+	if (! config && ! config->pod) {
+		return true;
+	}
+
+	return cc_handle_unmounts(config->pod->rootfs_mounts);
+}
+
+/*!
+ * Convert a list of mounts to a JSON array.
  *
  * Note that the returned array will be empty unless any of the list of
  * mounts provided in \ref CC_OCI_CONFIG_FILE were actually mounted
  * (many are ignored as they are unecessary in the hypervisor case).
  *
- * \param config \ref cc_oci_config.
+ * \param mounts List of \ref cc_oci_mount.
  *
  * \return \c JsonArray on success, else \c NULL.
  */
-JsonArray *
-cc_oci_mounts_to_json (const struct cc_oci_config *config)
+static JsonArray *
+cc_mounts_to_json (GSList *mounts)
 {
 	JsonArray *array = NULL;
 	JsonObject *mount = NULL;
@@ -417,7 +484,7 @@ cc_oci_mounts_to_json (const struct cc_oci_config *config)
 
 	array  = json_array_new ();
 
-	for (l = config->oci.mounts; l && l->data; l = g_slist_next (l)) {
+	for (l = mounts; l && l->data; l = g_slist_next (l)) {
 		struct cc_oci_mount *m = (struct cc_oci_mount *)l->data;
 
 		if (m->ignore_mount) {
@@ -438,4 +505,38 @@ cc_oci_mounts_to_json (const struct cc_oci_config *config)
 	}
 
 	return array;
+}
+
+/*!
+ * Convert the list of OCI mounts to a JSON array.
+ *
+ * Note that the returned array will be empty unless any of the list of
+ * mounts provided in \ref CC_OCI_CONFIG_FILE were actually mounted
+ * (many are ignored as they are unecessary in the hypervisor case).
+ *
+ * \param config \ref cc_oci_config.
+ *
+ * \return \c JsonArray on success, else \c NULL.
+ */
+JsonArray *
+cc_oci_mounts_to_json (const struct cc_oci_config *config)
+{
+	return cc_mounts_to_json(config->oci.mounts);
+}
+
+/*!
+ * Convert the list of pod mounts to a JSON array.
+ *
+ * \param config \ref cc_oci_config.
+ *
+ * \return \c JsonArray on success, else \c NULL.
+ */
+JsonArray *
+cc_pod_mounts_to_json (const struct cc_oci_config *config)
+{
+	if (! config && ! config->pod) {
+		return NULL;
+	}
+
+	return cc_mounts_to_json(config->pod->rootfs_mounts);
 }

--- a/src/mount.h
+++ b/src/mount.h
@@ -45,11 +45,14 @@
 	 (! g_strcmp0 ((mntent)->element, (cc_oci_mount)->mnt.element)))
 
 gboolean cc_oci_handle_mounts (struct cc_oci_config *config);
+gboolean cc_pod_handle_mounts (struct cc_oci_config *config);
 gboolean cc_oci_handle_unmounts (const struct cc_oci_config *config);
+gboolean cc_pod_handle_unmounts (const struct cc_oci_config *config);
 
 void cc_oci_mounts_free_all (GSList *mounts);
 void cc_oci_mount_free (struct cc_oci_mount *m);
 
 JsonArray *cc_oci_mounts_to_json (const struct cc_oci_config *config);
+JsonArray *cc_pod_mounts_to_json (const struct cc_oci_config *config);
 
 #endif /* _CC_OCI_MOUNT_H */

--- a/src/oci-config.c
+++ b/src/oci-config.c
@@ -158,6 +158,9 @@ cc_oci_config_free (struct cc_oci_config *config)
 	}
 
 	if (config->pod) {
+		if (config->pod->rootfs_mounts) {
+			cc_oci_mounts_free_all (config->pod->rootfs_mounts);
+		}
 		g_free_if_set (config->pod->sandbox_name);
 		g_free (config->pod);
 	}

--- a/src/oci.c
+++ b/src/oci.c
@@ -649,6 +649,14 @@ cc_oci_create (struct cc_oci_config *config)
 		return false;
 	}
 
+	/**
+	 * Pod mounts should happen on the host mount namespace.
+	 */
+	if (! cc_pod_handle_mounts(config)) {
+		g_critical ("failed to handle pod mounts");
+		return false;
+	}
+
 	/* The namespace setup occurs in the parent to ensure
 	 * the hooks run successfully. The child will automatically
 	 * inherit the namespaces.
@@ -1023,6 +1031,11 @@ cc_oci_stop (struct cc_oci_config *config,
 	 * always return false.
 	 */
 	if (! cc_oci_config_update (config, state)) {
+		return false;
+	}
+
+	if (! cc_pod_handle_unmounts(config)) {
+		g_critical ("failed to handle pod unmounts");
 		return false;
 	}
 

--- a/src/oci.c
+++ b/src/oci.c
@@ -216,6 +216,93 @@ err:
 	return false;
 }
 
+
+/*!
+ * Create OCI cgroup files under a given directory.
+ * The actual cgroup creation routine (\ref cc_oci_create_cgroups)
+ * is a wrapper around that function with \ref CGROUP_MEM_DIR as
+ * the directory argument.
+ *
+ * \param config \ref cc_oci_config.
+ * \param directory The directory where cgroup files will be created.
+ *
+ * \return \c true on success, else \c false.
+ */
+gboolean
+cc_oci_create_cgroup_files (struct cc_oci_config *config, const gchar *directory)
+{
+	g_autofree gchar *cgroup_dir = NULL;
+	g_autofree gchar *cgroup_tasks = NULL;
+	g_autofree gchar *cgroup_procs = NULL;
+	g_autofree gchar *pid_str = NULL;
+	int      fd_tasks = -1;
+	int      fd_procs = -1;
+	gboolean ret = false;
+
+	if (! (config && directory)) {
+		return false;
+	}
+
+	if (!config->oci.oci_linux.cgroupsPath) {
+		return true;
+	}
+
+	cgroup_dir = g_strdup_printf ("%s/%s", directory,
+				      config->oci.oci_linux.cgroupsPath);
+	if (g_mkdir_with_parents (cgroup_dir, CC_OCI_CGROUP_MODE) < 0) {
+		g_critical("Failed to create cgroup directory: %s", strerror(errno));
+		goto out;
+	}
+
+	pid_str = g_strdup_printf ("%d", config->state.workload_pid);
+
+	cgroup_tasks = g_strdup_printf ("%s/tasks", cgroup_dir);
+	fd_tasks = open (cgroup_tasks, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+	if (fd_tasks < 0) {
+		g_critical("Failed to create cgroup tasks file: %s", strerror(errno));
+		goto out;
+	}
+
+	if (write (fd_tasks, pid_str, strlen(pid_str)) <= 0) {
+		g_critical ("failed to copy workload pid to cgroup tasks: %s",
+			    strerror(errno));
+		goto out;
+	}
+
+	cgroup_procs = g_strdup_printf ("%s/cgroup.procs", cgroup_dir);
+	fd_procs = open (cgroup_procs, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+	if (fd_procs < 0) {
+		g_critical("Failed to create cgroup procs file: %s", strerror(errno));
+		goto out;
+	}
+
+	if (write (fd_procs, pid_str, strlen(pid_str)) <= 0) {
+		g_critical ("failed to copy workload pid to cgroup procs: %s",
+			    strerror(errno));
+		goto out;
+	}
+
+	ret = true;
+out:
+	if (fd_procs != -1) close (fd_procs);
+	if (fd_tasks != -1) close (fd_tasks);
+
+	return ret;
+}
+
+/*!
+ * Create OCI cgroup files for a given container.
+ *
+ * \param config \ref cc_oci_config.
+ *
+ * \return \c true on success, else \c false.
+ */
+gboolean
+cc_oci_create_cgroups (struct cc_oci_config *config)
+{
+	return cc_oci_create_cgroup_files(config, CGROUP_MEM_DIR);
+}
+
 /*!
  * Forcibly stop the Hypervisor.
  *

--- a/src/oci.h
+++ b/src/oci.h
@@ -657,5 +657,9 @@ cc_oci_create_container_networking_workload (struct cc_oci_config *config);
 JsonObject *
 cc_oci_process_to_json(const struct oci_cfg_process *process);
 
+gboolean
+cc_oci_create_cgroup_files (struct cc_oci_config *config, const gchar *directory);
+gboolean cc_oci_create_cgroups (struct cc_oci_config *config);
+
 void set_env_home(struct cc_oci_config *config);
 #endif /* _CC_OCI_H */

--- a/src/oci.h
+++ b/src/oci.h
@@ -569,6 +569,14 @@ struct cc_pod {
 	 * /sandbox_workloads/<container_id>/rootfs.
 	 */
 	gchar    sandbox_workloads[PATH_MAX];
+
+	/**
+	 * List of \ref cc_oci_mount mounts.
+	 *
+	 * This is a list of rootfs mount points for each container
+	 * within the pod.
+	 */
+	GSList   *rootfs_mounts;
 };
 
 /** The main object holding all configuration data.

--- a/src/pod.c
+++ b/src/pod.c
@@ -34,6 +34,8 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/mount.h>
+#include <sys/ptrace.h>
+#include <sys/wait.h>
 
 #include <glib.h>
 #include <gio/gunixconnection.h>
@@ -216,6 +218,7 @@ cc_pod_container_create (struct cc_oci_config *config)
 	int                ioBase = -1;
 	GSocketConnection *shim_socket_connection = NULL;
 	GError            *error = NULL;
+	int                status = 1;
 
 	if (! (config && config->pod && config->proxy)) {
 		return false;
@@ -335,6 +338,39 @@ cc_pod_container_create (struct cc_oci_config *config)
 	ret = cc_oci_state_file_create (config, timestamp);
 	if (! ret) {
 		g_critical ("failed to create state file");
+		goto out;
+	}
+
+	/* wait for child to receive the expected SIGTRAP caused
+	 * by it calling exec() whilst under PTRACE control.
+	 */
+	if (waitpid (config->state.workload_pid,
+			&status, 0) != config->state.workload_pid) {
+		g_critical ("failed to wait for shim %d: %s",
+				config->state.workload_pid,
+				strerror (errno));
+		goto out;
+	}
+
+	if (! WIFSTOPPED (status)) {
+		g_critical ("shim %d not stopped by signal",
+				config->state.workload_pid);
+		goto out;
+	}
+
+	if (! (WSTOPSIG (status) == SIGTRAP)) {
+		g_critical ("shim %d not stopped by expected signal",
+				config->state.workload_pid);
+		goto out;
+	}
+
+	/* Stop tracing, but send a stop signal to the shim so that it
+	 * remains in a paused state.
+	 */
+	if (ptrace (PTRACE_DETACH, config->state.workload_pid, NULL, SIGSTOP) < 0) {
+		g_critical ("failed to ptrace detach in child %d: %s",
+				(int)config->state.workload_pid,
+				strerror (errno));
 		goto out;
 	}
 

--- a/src/pod.c
+++ b/src/pod.c
@@ -248,6 +248,10 @@ cc_pod_container_create (struct cc_oci_config *config)
 		goto out;
 	}
 
+	if (! cc_oci_create_cgroups(config)) {
+		goto out;
+	}
+
 	/* Create the pid file. */
 	if (config->pid_file) {
 		ret = cc_oci_create_pidfile (config->pid_file,

--- a/src/pod.c
+++ b/src/pod.c
@@ -89,8 +89,8 @@ add_container_mount(struct cc_oci_config *config) {
 		goto error;
 	}
 
-	/* Add our pod container mount to the list of all mount points */
-	config->oci.mounts = g_slist_append(config->oci.mounts, m);
+	/* Add our pod container rootfs mount to the pod mount points */
+	config->pod->rootfs_mounts = g_slist_append(config->pod->rootfs_mounts, m);
 
 	return true;
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1386,20 +1386,21 @@ cc_proxy_run_hyper_new_container (struct cc_oci_config *config,
 	json_object_set_string_member (process, "workdir",
 			config->oci.process.cwd);
 
-	/* Hyperstart is not able to handle uid 0. This is a bug.
-	 * Fix pending: https://github.com/clearcontainers/hyperstart/pull/2
-	 */
-	if ((int)config->oci.process.user.uid == 0) {
-		json_object_set_string_member (process, "user", "root");
-	} else {
-		uid_str = g_strdup_printf("%d", config->oci.process.user.uid);
-		gid_str = g_strdup_printf("%d", config->oci.process.user.gid);
+	/* Only set user for a container as sandboxes may not have users defined */
+	if (! cc_pod_is_sandbox(config)) {
+		/* Hyperstart is not able to handle uid 0. This is a bug. */
+		if ((int)config->oci.process.user.uid == 0) {
+			json_object_set_string_member (process, "user", "root");
+		} else {
+			uid_str = g_strdup_printf("%d", config->oci.process.user.uid);
+			gid_str = g_strdup_printf("%d", config->oci.process.user.gid);
 
-		json_object_set_string_member (process, "user", uid_str);
-		json_object_set_string_member (process, "group", gid_str);
+			json_object_set_string_member (process, "user", uid_str);
+			json_object_set_string_member (process, "group", gid_str);
 
-		g_free(uid_str);
-		g_free(gid_str);
+			g_free(uid_str);
+			g_free(gid_str);
+		}
 	}
 
 	if (config->oci.process.user.additionalGids) {


### PR DESCRIPTION
This PR carries a couple of CRI-O/k8s related fixes for 2.1.1:

1. Do not force hyperstart into creating users for a pod (This is preventing CRI-O pods to be created at all).
2. Create pod and pod containers cgroups.
