### PR TITLE
Metrics/bootchart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ tags
 test-driver
 tests/functional/common.bash
 tests/functional/data/config-minimal-cc-oci.json
+tests/metrics/workload_time/bootchart/insert_bootchart_service.sh.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,8 @@ STORED_COMMIT = $(shell cat $(builddir)/commit_id 2>/dev/null || cat $(srcdir)/c
 SYSCONFDIR = $(sysconfdir)/$(PACKAGE_NAME)
 DEFAULTSDIR = $(datadir)/defaults/$(PACKAGE_NAME)
 
+INSERT_BOOTCHART_SH = tests/metrics/workload_time/bootchart/insert_bootchart_service.sh
+
 src/commands/cc_oci_runtime-version.$(OBJEXT): \
 	 commit_id
 
@@ -65,6 +67,7 @@ GENERATED_FILES = \
 	tests/functional/data/config-minimal-cc-oci.json \
 	tests/metrics/density/docker_cpu_usage.sh \
 	tests/metrics/density/docker_memory_usage.sh \
+	$(INSERT_BOOTCHART_SH) \
 	tests/metrics/workload_time/cor_create_time.sh
 
 $(GENERATED_FILES): %: %.in Makefile
@@ -89,6 +92,7 @@ $(GENERATED_FILES): %: %.in Makefile
 		-e 's|[@]DOCKER_UBUNTU_VERSION[@]|$(DOCKER_UBUNTU_VERSION)|g' \
 		-e 's|[@]DOCKER_ENGINE_UBUNTU_VERSION[@]|$(DOCKER_ENGINE_UBUNTU_VERSION)|g' \
 		-e 's|[@]ABS_BUILDDIR[@]|$(abs_builddir)|g' \
+		-e 's|[@]CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH[@]|$(ccimage_systemdfilesdir)|g' \
 		"$<" > "$@"
 
 if FUNCTIONAL_TESTS
@@ -129,7 +133,13 @@ cc_image_systemd_files = \
 if CC_IMAGE_SYSTEMDSYSTEMUNIT
 ccimage_systemdfilesdir= @CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH@
 ccimage_systemdfiles_DATA = $(cc_image_systemd_files)
+else
+#default container image services path
+ccimage_systemdfilesdir= "/usr/lib/systemd/system"
 endif
+
+insert-bootchart: $(INSERT_BOOTCHART_SH) $(CONTAINERS_IMG)
+	bash $(abs_builddir)/$(INSERT_BOOTCHART_SH) $(CONTAINERS_IMG)
 
 AM_CFLAGS = -std=gnu99 -fstack-protector -Wall -pedantic \
 	-Wstrict-prototypes -Wundef -fno-common \
@@ -340,6 +350,7 @@ EXTRA_DIST = \
 	tests/lib \
 	tests/metrics/density/docker_cpu_usage.sh.in \
 	tests/metrics/density/docker_memory_usage.sh.in \
+	$(INSERT_BOOTCHART_SH).in \
 	tests/metrics/workload_time/cor_create_time.sh.in
 
 if CPPCHECK

--- a/data/cc-agent.target
+++ b/data/cc-agent.target
@@ -2,6 +2,8 @@
 Description=Clear Containers Agent Target
 Requires=basic.target
 Requires=cc-agent.service
+Wants=cc-debug-console.service
+Wants=cc-bootchart.service
 Conflicts=rescue.service rescue.target
 After=basic.target rescue.service rescue.target
 AllowIsolate=yes

--- a/data/cc-bootchart.service
+++ b/data/cc-bootchart.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Copy systemd-bootchart to container rootfs
+
+[Service]
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Type=simple
+#wait some time before copy the bootchart svg
+ExecStart=/usr/bin/bash -c 'sleep 2; cp /run/log/*.svg /tmp/hyper/shared/run'

--- a/tests/metrics/workload_time/bootchart/insert_bootchart_service.sh.in
+++ b/tests/metrics/workload_time/bootchart/insert_bootchart_service.sh.in
@@ -1,0 +1,112 @@
+#!/bin/bash
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#This script can be used to insert debug services to a clear containers image.
+
+
+set -e
+
+script_name=${0##*/}
+bootchart_service="@ABS_BUILDDIR@/data/cc-bootchart.service"
+cc_agent_service="@ABS_BUILDDIR@/data/cc-agent.service"
+cc_agent_target="@ABS_BUILDDIR@/data/cc-agent.target"
+
+services="${bootchart_service} ${cc_agent_service} ${cc_agent_target}"
+
+image=$1
+
+die()
+{
+	msg="$*"
+	echo "ERROR: ${msg}" >&2
+	exit 1
+}
+info()
+{
+	msg="$*"
+	echo "INFO: ${msg}" >&2
+}
+
+usage()
+{
+	cat <<EOT
+Usage: ${script_name} CONTAINER_IMAGE MOUNT_DIRECTORY"
+
+CONTAINER_IMAGE: Clear Container image to modify
+
+EOT
+	exit 0
+} 
+
+
+
+mount_image()
+{
+	image=$1
+	mount_dir=$2
+
+	[ -f "${image}" ] || die "image does not exist: ${image}"
+	[ -d "${mount_dir}" ] || die "mount directory not exist: ${mount_dir}"
+
+	device=$(losetup -fP --show "${image}")
+
+	#In clear containers image the root partition is always the first
+	root_partition="${device}p1"
+
+	mount "${root_partition}" "${mount_dir}"
+	info "${image}(${device}) mounted in ${mount_dir}"
+}
+
+
+umount_image(){
+	image=$1
+	mount_dir=$2
+
+	[ -f "${image}" ] || die "image does not exist: ${image}"
+	[ -d "$mount_dir" ] || die "mount directory does not exist: $image"
+
+	device=$(losetup -j "${image}" --list -O NAME -n)
+	
+	umount "${mount_dir}"
+	losetup -d "${device}"
+}
+
+
+[ -n "${image}" ] || usage
+[ -f "${image}" ] || die "image does not exist: ${image}"
+
+if [ $EUID -ne 0 ]; then
+	die "need to run as root"
+fi
+
+mount_dir=$(mktemp -d cc-image-XXXXXXX)
+mount_image "${image}" "${mount_dir}"
+
+[ -n "${mount_dir}/@CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH@" ] || \
+	die "CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH not found"
+
+info "copying ${services} to ${mount_dir}/@CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH@/"
+
+cp ${services} ${mount_dir}/@CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH@/
+
+umount_image "${image}" "${mount_dir}"
+
+#clean up
+info "remove mount directory ${mount_dir}"
+rm -r "$mount_dir"


### PR DESCRIPTION
This PR adds a new service called cc-bootchart for systemd based images.  If a bootchart was created at boot time ( by systemd-bootchart)  it will copy  the svg to the container /run directory. 

This service should be used just for measures and would not be installed by default in a clear container image. A target is added to insert the service in the container image called insert-bootchart. 