### PR TITLE
runtime: add --all option to kill command

### DIFF
--- a/src/commands/kill.c
+++ b/src/commands/kill.c
@@ -23,6 +23,19 @@
 
 #include "command.h"
 
+static gboolean allProcesses = false;
+
+static GOptionEntry options_kill[] =
+{
+	{
+		"all", 'a' , G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_NONE, &allProcesses,
+		"send a signal to all processes inside the container",
+		NULL
+	},
+	{ NULL }
+};
+
 static gboolean
 handler_kill (const struct subcommand *sub,
 		struct cc_oci_config *config,
@@ -37,9 +50,8 @@ handler_kill (const struct subcommand *sub,
 	g_assert (sub);
 	g_assert (config);
 
-
 	if (handle_default_usage (argc, argv, sub->name,
-				&ret, 1, "[<signal>]")) {
+				&ret, 1, "[<options>] [<signal>]")) {
 		return ret;
 	}
 
@@ -75,7 +87,7 @@ handler_kill (const struct subcommand *sub,
 		goto out;
 	}
 
-	ret = cc_oci_kill (config, state, signum);
+	ret = cc_oci_kill (config, state, signum, allProcesses);
 
 out:
 	g_free_if_set (config_file);
@@ -87,6 +99,7 @@ out:
 struct subcommand command_kill =
 {
 	.name        = "kill",
+	.options     = options_kill,
 	.handler     = handler_kill,
 	.description = "send a signal to the container "
 		       "(signal may be symbolic (\"SIGKILL\"/\"KILL\") "

--- a/src/oci.c
+++ b/src/oci.c
@@ -222,17 +222,25 @@ err:
  * \param config \ref cc_oci_config.
  * \param state \ref oci_state.
  * \param signum Signal number to send to hypervisor.
+ * \param allProcesses \c true to send a signal to all container's processes,
+ *  \c false to send a signal to container's workload.
  *
  * \return \c true on success, else \c false.
  */
 gboolean
 cc_oci_kill (struct cc_oci_config *config,
 		struct oci_state *state,
-		int signum)
+		int signum,
+		gboolean allProcesses)
 {
 	enum oci_status last_status;
 
 	if (! (config && state)) {
+		return false;
+	}
+
+	if (! cc_oci_get_signame (signum)) {
+		g_critical ("signal %d is not supported", signum);
 		return false;
 	}
 
@@ -261,15 +269,14 @@ cc_oci_kill (struct cc_oci_config *config,
 		goto error;
 	}
 
-	/* send signal to cc-shim because it
-	 * will send killcontainer to hyperstart
+#ifndef UNIT_TESTING
+	/* kill container's processes, cc-shim will catch exit code
+	 * and will end
 	 */
-	if (kill (state->pid, signum) < 0) {
-		g_critical ("failed to stop container %s "
-				"running with pid %u: %s",
-				config->optarg_container_id,
-				(unsigned)state->pid,
-				strerror (errno));
+	if (! cc_proxy_hyper_kill_container (config, signum, allProcesses)) {
+		g_critical ("failed to kill container %s: %s",
+			config->optarg_container_id,
+			strerror (errno));
 		/* revert container status */
 		config->state.status = last_status;
 		if (! cc_oci_state_file_create (config, state->create_time)) {
@@ -277,19 +284,20 @@ cc_oci_kill (struct cc_oci_config *config,
 		}
 		return false;
 	}
+#endif //UNIT_TESTING
 
-#ifndef UNIT_TESTING
-	/* cc-shim is not able to catch SIGKILL and SIGSTOP
-	 * signals for this reason we must kill the container
-	 * using hyperstart's API
-	 */
-	if (signum == SIGKILL || signum == SIGSTOP) {
-		if (! cc_proxy_hyper_kill_container (config, signum)) {
-			g_critical ("failed to kill container");
+	if (signum == SIGKILL) {
+		/* cc-shim is not able to catch the exit code of a process
+		 * finished with SIGKILL signal hence cc-shim MUST receive
+		 * this signal too
+		 */
+		if (kill (state->pid, signum) < 0) {
+			g_critical ("failed to stop cc-shim %u: %s",
+					(unsigned)state->pid,
+					strerror (errno));
 			return false;
 		}
 	}
-#endif //UNIT_TESTING
 
 	last_status = config->state.status;
 

--- a/src/oci.h
+++ b/src/oci.h
@@ -644,7 +644,7 @@ gboolean cc_oci_list (struct cc_oci_config *config,
 gboolean cc_oci_delete (struct cc_oci_config *config,
 		struct oci_state *state);
 gboolean cc_oci_kill (struct cc_oci_config *config,
-		struct oci_state *state, int signum);
+		struct oci_state *state, int signum, gboolean allProcesses);
 
 gboolean cc_oci_config_update (struct cc_oci_config *config,
 		struct oci_state *state);

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1514,7 +1514,8 @@ cc_proxy_hyper_new_container (struct cc_oci_config *config)
  * \return \c true on success, else \c false.
  */
 gboolean
-cc_proxy_hyper_kill_container (struct cc_oci_config *config, int signum)
+cc_proxy_hyper_kill_container (struct cc_oci_config *config,
+				int signum, gboolean allProcesses)
 {
 	JsonObject *killcontainer_payload;
 	char       *signum_str = NULL;
@@ -1545,6 +1546,8 @@ cc_proxy_hyper_kill_container (struct cc_oci_config *config, int signum)
 		config->optarg_container_id);
 	json_object_set_string_member (killcontainer_payload, "signal",
 		signum_str);
+	json_object_set_boolean_member (killcontainer_payload, "allProcesses",
+		allProcesses);
 
 	if (! cc_proxy_run_hyper_cmd (config, "killcontainer", killcontainer_payload)) {
 		g_critical("failed to run cmd killcontainer");

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -52,7 +52,8 @@ gboolean cc_proxy_cmd_bye (struct cc_proxy *proxy, const char *container_id);
 gboolean cc_proxy_cmd_allocate_io (struct cc_proxy *proxy, int *proxy_io_fd,
 		int *ioBase, bool tty);
 gboolean
-cc_proxy_hyper_kill_container (struct cc_oci_config *config, int signum);
+cc_proxy_hyper_kill_container (struct cc_oci_config *config, int signum,
+					gboolean allProcesses);
 gboolean cc_proxy_hyper_destroy_pod (struct cc_oci_config *config);
 gboolean cc_proxy_run_hyper_new_container (struct cc_oci_config *config,
 					const char *container_id,

--- a/src/util.c
+++ b/src/util.c
@@ -119,6 +119,31 @@ cc_oci_get_signum (const gchar *signame)
 }
 
 /*!
+ * Convert the specified signal number into its symbolic name
+ *
+ * \param signum Numer of signal.
+ *
+ * \return static signal name string, or NULL on error.
+ */
+const char*
+cc_oci_get_signame (int signum)
+{
+	struct cc_oci_signal_table  *s;
+
+	if (signum < 0) {
+		return NULL;
+	}
+
+	for (s = signal_table; s && s->name; s++) {
+		if (signum == s->num) {
+			return s->name;
+		}
+	}
+
+	return NULL;
+}
+
+/*!
  * Create an ISO-8601-formatted timestamp.
  *
  * \return Newly-allocated string.

--- a/src/util.h
+++ b/src/util.h
@@ -87,6 +87,7 @@ gboolean cc_oci_file_to_strv (const char *file, gchar ***strv);
 char** node_to_strv(GNode* root);
 gboolean gnode_free(GNode* node, gpointer data);
 int cc_oci_get_signum (const gchar *signame);
+const char* cc_oci_get_signame (int signum);
 gchar *cc_oci_resolve_path (const gchar *path);
 gboolean cc_oci_fd_toggle_cloexec (int fd, gboolean set);
 gboolean cc_oci_enable_networking (void);

--- a/tests/functional/kill.bats
+++ b/tests/functional/kill.bats
@@ -36,7 +36,7 @@ function teardown() {
 @test "kill without container id" {
 	run $COR kill
 	[ "$status" -ne 0 ]
-	[[ "${output}" == "Usage: kill <container-id> [<signal>]" ]]
+	[[ "${output}" == "Usage: kill <container-id> [<options>] [<signal>]" ]]
 }
 
 @test "kill with invalid container id" {
@@ -48,13 +48,7 @@ function teardown() {
 @test "start then kill (implicit signal)" {
 	workload_cmd "sh"
 
-	cmd="$COR create --console --bundle $BUNDLE_DIR $container_id"
-	run_cmd "$cmd" "0" "$COR_TIMEOUT"
-	testcontainer "$container_id" "created"
-
-	# 'start' runs in background since it will
-	# update the state file once shim ends
-	cmd="$COR start $container_id &"
+	cmd="$COR run -d --bundle $BUNDLE_DIR $container_id"
 	run_cmd "$cmd" "0" "$COR_TIMEOUT"
 	testcontainer "$container_id" "running"
 
@@ -70,13 +64,7 @@ function teardown() {
 @test "start then kill (short symbolic signal)" {
 	workload_cmd "sh"
 
-	cmd="$COR create  --console --bundle $BUNDLE_DIR $container_id"
-	run_cmd "$cmd" "0" "$COR_TIMEOUT"
-	testcontainer "$container_id" "created"
-
-	# 'start' runs in background since it will
-	# update the state file once shim ends
-	cmd="$COR start $container_id &"
+	cmd="$COR run -d --bundle $BUNDLE_DIR $container_id"
 	run_cmd "$cmd" "0" "$COR_TIMEOUT"
 	testcontainer "$container_id" "running"
 
@@ -96,13 +84,7 @@ function teardown() {
 @test "start then kill (full symbolic signal)" {
 	workload_cmd "sh"
 
-	cmd="$COR create  --console --bundle $BUNDLE_DIR $container_id"
-	run_cmd "$cmd" "0" "$COR_TIMEOUT"
-	testcontainer "$container_id" "created"
-
-	# 'start' runs in background since it will
-	# update the state file once shim ends
-	cmd="$COR start $container_id &"
+	cmd="$COR run -d --bundle $BUNDLE_DIR $container_id"
 	run_cmd "$cmd" "0" "$COR_TIMEOUT"
 	testcontainer "$container_id" "running"
 
@@ -122,21 +104,37 @@ function teardown() {
 @test "start then kill (numeric signal)" {
 	workload_cmd "sh"
 
-	cmd="$COR create  --console --bundle $BUNDLE_DIR $container_id"
-	run_cmd "$cmd" "0" "$COR_TIMEOUT"
-	testcontainer "$container_id" "created"
-
-	# 'start' runs in background since it will
-	# update the state file once shim ends
-	cmd="$COR start $container_id &"
+	cmd="$COR run -d --bundle $BUNDLE_DIR $container_id"
 	run_cmd "$cmd" "0" "$COR_TIMEOUT"
 	testcontainer "$container_id" "running"
 
 	# specify invalid signal number
 	cmd="$COR kill $container_id 123456"
 	run_cmd "$cmd" "1" "$COR_TIMEOUT"
+	testcontainer "$container_id" "running"
 
 	cmd="$COR kill $container_id 15"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	testcontainer "$container_id" "killed"
+
+	cmd="$COR delete $container_id"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	verify_runtime_dirs "$container_id" "deleted"
+}
+
+@test "start then kill --all (numeric signal)" {
+	workload_cmd "sh"
+
+	cmd="$COR run -d --bundle $BUNDLE_DIR $container_id"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	testcontainer "$container_id" "running"
+
+	# specify invalid signal number
+	cmd="$COR kill --all $container_id 123456"
+	run_cmd "$cmd" "1" "$COR_TIMEOUT"
+	testcontainer "$container_id" "running"
+
+	cmd="$COR kill -a $container_id 15"
 	run_cmd "$cmd" "0" "$COR_TIMEOUT"
 	testcontainer "$container_id" "killed"
 

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -947,7 +947,7 @@ START_TEST(test_cc_oci_kill) {
 	config_new = cc_oci_config_create ();
 	ck_assert (config_new);
 
-	ck_assert (! cc_oci_kill (NULL, NULL, 0));
+	ck_assert (! cc_oci_kill (NULL, NULL, 0, false));
 
 	tmpdir = g_dir_make_tmp (NULL, NULL);
 	ck_assert (tmpdir);
@@ -984,14 +984,14 @@ START_TEST(test_cc_oci_kill) {
 
 	ck_assert (state->pid == config_tmp->state.workload_pid);
 
-	ck_assert (cc_oci_kill (config, state, SIGTERM));
+	ck_assert (cc_oci_kill (config, state, SIGKILL, false));
 	(void)waitpid (state->pid, &status, 0);
 
 	ck_assert (kill (config->state.workload_pid, 0) < 0);
 	ck_assert (errno == ESRCH);
 
 	ck_assert (WIFSIGNALED (status));
-	ck_assert (WTERMSIG (status) == SIGTERM);
+	ck_assert (WTERMSIG (status) == SIGKILL);
 
 	config_new->optarg_container_id = config->optarg_container_id;
 	config_new->root_dir = g_strdup (tmpdir);

--- a/tests/util_test.c
+++ b/tests/util_test.c
@@ -412,6 +412,12 @@ START_TEST(test_cc_oci_get_signum) {
 	ck_assert(cc_oci_get_signum("TERM") != -1);
 } END_TEST
 
+START_TEST(test_cc_oci_get_signame) {
+	ck_assert(cc_oci_get_signame(-1) == NULL);
+	ck_assert(cc_oci_get_signame(0) == NULL);
+	ck_assert_str_eq(cc_oci_get_signame(SIGTERM), "SIGTERM");
+} END_TEST
+
 START_TEST(test_cc_oci_node_dump) {
 	GNode* node;
 	cc_oci_node_dump(NULL);
@@ -561,6 +567,7 @@ Suite* make_util_suite(void) {
 	ADD_TEST(test_cc_oci_json_obj_to_string, s);
 	ADD_TEST(test_cc_oci_json_arr_to_string, s);
 	ADD_TEST(test_cc_oci_get_signum, s);
+	ADD_TEST(test_cc_oci_get_signame, s);
 	ADD_TEST(test_cc_oci_node_dump, s);
 	ADD_TEST(test_cc_oci_resolve_path, s);
 	ADD_TEST(test_cc_oci_enable_networking, s);


### PR DESCRIPTION
With this patch users will can send signal to
all processes running inside the container

fixes #693

Signed-off-by: Julio Montes <julio.montes@intel.com>