### PR TITLE
docs: Fix distribution of documentation.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -310,7 +310,7 @@ bats_test_sources = \
 	tests/functional/version.bats
 
 documentation_extra_dist =	\
-	documentation/
+	documentation
 
 EXTRA_DIST = \
 	.ci \


### PR DESCRIPTION
Previously, the documentation was distributed in
"documentation/documentation/", rather than just "documentation/".

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>