### PR TITLE
CI: Disallow approval of 'on-hold' PRs

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -9,6 +9,7 @@ always_pending:
   title_regex: 'WIP'
   labels:
     - do-not-merge
+    - on-hold
     - wip
   explanation: 'Work in progress - do not merge'
 


### PR DESCRIPTION
There is now a new 'on-hold' tag which is similar to 'do-not-merge' and
'wip'. Unlike the latter two tags (which are generally added by the author),
the intent is for 'on-hold' to be added to a PR by a reviewer to
signify that the author needs to either make further changes or respond
to review feedback. This new tag makes it easier to identify such
"in progress" PRs when reviewing the PR backlog and since they are not
complete PRs with this tag should not be approvable.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>