### PR TITLE
Revert "runtime: add --all option to kill command"

### DIFF
--- a/src/commands/kill.c
+++ b/src/commands/kill.c
@@ -23,19 +23,6 @@
 
 #include "command.h"
 
-static gboolean allProcesses = false;
-
-static GOptionEntry options_kill[] =
-{
-	{
-		"all", 'a' , G_OPTION_FLAG_NONE,
-		G_OPTION_ARG_NONE, &allProcesses,
-		"send a signal to all processes inside the container",
-		NULL
-	},
-	{ NULL }
-};
-
 static gboolean
 handler_kill (const struct subcommand *sub,
 		struct cc_oci_config *config,
@@ -50,8 +37,9 @@ handler_kill (const struct subcommand *sub,
 	g_assert (sub);
 	g_assert (config);
 
+
 	if (handle_default_usage (argc, argv, sub->name,
-				&ret, 1, "[<options>] [<signal>]")) {
+				&ret, 1, "[<signal>]")) {
 		return ret;
 	}
 
@@ -87,7 +75,7 @@ handler_kill (const struct subcommand *sub,
 		goto out;
 	}
 
-	ret = cc_oci_kill (config, state, signum, allProcesses);
+	ret = cc_oci_kill (config, state, signum);
 
 out:
 	g_free_if_set (config_file);
@@ -99,7 +87,6 @@ out:
 struct subcommand command_kill =
 {
 	.name        = "kill",
-	.options     = options_kill,
 	.handler     = handler_kill,
 	.description = "send a signal to the container "
 		       "(signal may be symbolic (\"SIGKILL\"/\"KILL\") "

--- a/src/oci.h
+++ b/src/oci.h
@@ -647,7 +647,7 @@ gboolean cc_oci_list (struct cc_oci_config *config,
 gboolean cc_oci_delete (struct cc_oci_config *config,
 		struct oci_state *state);
 gboolean cc_oci_kill (struct cc_oci_config *config,
-		struct oci_state *state, int signum, gboolean allProcesses);
+		struct oci_state *state, int signum);
 
 gboolean cc_oci_config_update (struct cc_oci_config *config,
 		struct oci_state *state);

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1516,8 +1516,7 @@ cc_proxy_hyper_new_container (struct cc_oci_config *config)
  * \return \c true on success, else \c false.
  */
 gboolean
-cc_proxy_hyper_kill_container (struct cc_oci_config *config,
-				int signum, gboolean allProcesses)
+cc_proxy_hyper_kill_container (struct cc_oci_config *config, int signum)
 {
 	JsonObject *killcontainer_payload;
 	char       *signum_str = NULL;
@@ -1548,8 +1547,6 @@ cc_proxy_hyper_kill_container (struct cc_oci_config *config,
 		config->optarg_container_id);
 	json_object_set_string_member (killcontainer_payload, "signal",
 		signum_str);
-	json_object_set_boolean_member (killcontainer_payload, "allProcesses",
-		allProcesses);
 
 	if (! cc_proxy_run_hyper_cmd (config, "killcontainer", killcontainer_payload)) {
 		g_critical("failed to run cmd killcontainer");

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -52,8 +52,7 @@ gboolean cc_proxy_cmd_bye (struct cc_proxy *proxy, const char *container_id);
 gboolean cc_proxy_cmd_allocate_io (struct cc_proxy *proxy, int *proxy_io_fd,
 		int *ioBase, bool tty);
 gboolean
-cc_proxy_hyper_kill_container (struct cc_oci_config *config, int signum,
-					gboolean allProcesses);
+cc_proxy_hyper_kill_container (struct cc_oci_config *config, int signum);
 gboolean cc_proxy_hyper_destroy_pod (struct cc_oci_config *config);
 gboolean cc_proxy_run_hyper_new_container (struct cc_oci_config *config,
 					const char *container_id,

--- a/src/util.c
+++ b/src/util.c
@@ -119,31 +119,6 @@ cc_oci_get_signum (const gchar *signame)
 }
 
 /*!
- * Convert the specified signal number into its symbolic name
- *
- * \param signum Numer of signal.
- *
- * \return static signal name string, or NULL on error.
- */
-const char*
-cc_oci_get_signame (int signum)
-{
-	struct cc_oci_signal_table  *s;
-
-	if (signum < 0) {
-		return NULL;
-	}
-
-	for (s = signal_table; s && s->name; s++) {
-		if (signum == s->num) {
-			return s->name;
-		}
-	}
-
-	return NULL;
-}
-
-/*!
  * Create an ISO-8601-formatted timestamp.
  *
  * \return Newly-allocated string.

--- a/src/util.h
+++ b/src/util.h
@@ -87,7 +87,6 @@ gboolean cc_oci_file_to_strv (const char *file, gchar ***strv);
 char** node_to_strv(GNode* root);
 gboolean gnode_free(GNode* node, gpointer data);
 int cc_oci_get_signum (const gchar *signame);
-const char* cc_oci_get_signame (int signum);
 gchar *cc_oci_resolve_path (const gchar *path);
 gboolean cc_oci_fd_toggle_cloexec (int fd, gboolean set);
 gboolean cc_oci_enable_networking (void);

--- a/tests/functional/kill.bats
+++ b/tests/functional/kill.bats
@@ -36,7 +36,7 @@ function teardown() {
 @test "kill without container id" {
 	run $COR kill
 	[ "$status" -ne 0 ]
-	[[ "${output}" == "Usage: kill <container-id> [<options>] [<signal>]" ]]
+	[[ "${output}" == "Usage: kill <container-id> [<signal>]" ]]
 }
 
 @test "kill with invalid container id" {
@@ -48,7 +48,13 @@ function teardown() {
 @test "start then kill (implicit signal)" {
 	workload_cmd "sh"
 
-	cmd="$COR run -d --bundle $BUNDLE_DIR $container_id"
+	cmd="$COR create --console --bundle $BUNDLE_DIR $container_id"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	testcontainer "$container_id" "created"
+
+	# 'start' runs in background since it will
+	# update the state file once shim ends
+	cmd="$COR start $container_id &"
 	run_cmd "$cmd" "0" "$COR_TIMEOUT"
 	testcontainer "$container_id" "running"
 
@@ -64,7 +70,13 @@ function teardown() {
 @test "start then kill (short symbolic signal)" {
 	workload_cmd "sh"
 
-	cmd="$COR run -d --bundle $BUNDLE_DIR $container_id"
+	cmd="$COR create  --console --bundle $BUNDLE_DIR $container_id"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	testcontainer "$container_id" "created"
+
+	# 'start' runs in background since it will
+	# update the state file once shim ends
+	cmd="$COR start $container_id &"
 	run_cmd "$cmd" "0" "$COR_TIMEOUT"
 	testcontainer "$container_id" "running"
 
@@ -84,7 +96,13 @@ function teardown() {
 @test "start then kill (full symbolic signal)" {
 	workload_cmd "sh"
 
-	cmd="$COR run -d --bundle $BUNDLE_DIR $container_id"
+	cmd="$COR create  --console --bundle $BUNDLE_DIR $container_id"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	testcontainer "$container_id" "created"
+
+	# 'start' runs in background since it will
+	# update the state file once shim ends
+	cmd="$COR start $container_id &"
 	run_cmd "$cmd" "0" "$COR_TIMEOUT"
 	testcontainer "$container_id" "running"
 
@@ -104,37 +122,21 @@ function teardown() {
 @test "start then kill (numeric signal)" {
 	workload_cmd "sh"
 
-	cmd="$COR run -d --bundle $BUNDLE_DIR $container_id"
+	cmd="$COR create  --console --bundle $BUNDLE_DIR $container_id"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	testcontainer "$container_id" "created"
+
+	# 'start' runs in background since it will
+	# update the state file once shim ends
+	cmd="$COR start $container_id &"
 	run_cmd "$cmd" "0" "$COR_TIMEOUT"
 	testcontainer "$container_id" "running"
 
 	# specify invalid signal number
 	cmd="$COR kill $container_id 123456"
 	run_cmd "$cmd" "1" "$COR_TIMEOUT"
-	testcontainer "$container_id" "running"
 
 	cmd="$COR kill $container_id 15"
-	run_cmd "$cmd" "0" "$COR_TIMEOUT"
-	testcontainer "$container_id" "killed"
-
-	cmd="$COR delete $container_id"
-	run_cmd "$cmd" "0" "$COR_TIMEOUT"
-	verify_runtime_dirs "$container_id" "deleted"
-}
-
-@test "start then kill --all (numeric signal)" {
-	workload_cmd "sh"
-
-	cmd="$COR run -d --bundle $BUNDLE_DIR $container_id"
-	run_cmd "$cmd" "0" "$COR_TIMEOUT"
-	testcontainer "$container_id" "running"
-
-	# specify invalid signal number
-	cmd="$COR kill --all $container_id 123456"
-	run_cmd "$cmd" "1" "$COR_TIMEOUT"
-	testcontainer "$container_id" "running"
-
-	cmd="$COR kill -a $container_id 15"
 	run_cmd "$cmd" "0" "$COR_TIMEOUT"
 	testcontainer "$container_id" "killed"
 

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -947,7 +947,7 @@ START_TEST(test_cc_oci_kill) {
 	config_new = cc_oci_config_create ();
 	ck_assert (config_new);
 
-	ck_assert (! cc_oci_kill (NULL, NULL, 0, false));
+	ck_assert (! cc_oci_kill (NULL, NULL, 0));
 
 	tmpdir = g_dir_make_tmp (NULL, NULL);
 	ck_assert (tmpdir);
@@ -984,14 +984,14 @@ START_TEST(test_cc_oci_kill) {
 
 	ck_assert (state->pid == config_tmp->state.workload_pid);
 
-	ck_assert (cc_oci_kill (config, state, SIGKILL, false));
+	ck_assert (cc_oci_kill (config, state, SIGTERM));
 	(void)waitpid (state->pid, &status, 0);
 
 	ck_assert (kill (config->state.workload_pid, 0) < 0);
 	ck_assert (errno == ESRCH);
 
 	ck_assert (WIFSIGNALED (status));
-	ck_assert (WTERMSIG (status) == SIGKILL);
+	ck_assert (WTERMSIG (status) == SIGTERM);
 
 	config_new->optarg_container_id = config->optarg_container_id;
 	config_new->root_dir = g_strdup (tmpdir);

--- a/tests/util_test.c
+++ b/tests/util_test.c
@@ -412,12 +412,6 @@ START_TEST(test_cc_oci_get_signum) {
 	ck_assert(cc_oci_get_signum("TERM") != -1);
 } END_TEST
 
-START_TEST(test_cc_oci_get_signame) {
-	ck_assert(cc_oci_get_signame(-1) == NULL);
-	ck_assert(cc_oci_get_signame(0) == NULL);
-	ck_assert_str_eq(cc_oci_get_signame(SIGTERM), "SIGTERM");
-} END_TEST
-
 START_TEST(test_cc_oci_node_dump) {
 	GNode* node;
 	cc_oci_node_dump(NULL);
@@ -567,7 +561,6 @@ Suite* make_util_suite(void) {
 	ADD_TEST(test_cc_oci_json_obj_to_string, s);
 	ADD_TEST(test_cc_oci_json_arr_to_string, s);
 	ADD_TEST(test_cc_oci_get_signum, s);
-	ADD_TEST(test_cc_oci_get_signame, s);
 	ADD_TEST(test_cc_oci_node_dump, s);
 	ADD_TEST(test_cc_oci_resolve_path, s);
 	ADD_TEST(test_cc_oci_enable_networking, s);


### PR DESCRIPTION
hyperstart 0.7.0 has not support to kill all processes inside
the container so 61e511eaee17caec904372aebfb7dc87aa3d6840 is
causing issues killing containers.

This reverts commit 61e511eaee17caec904372aebfb7dc87aa3d6840.

Signed-off-by: Julio Montes <julio.montes@intel.com>