### PR TITLE
release: version 2.1.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.0])
+AC_INIT([cc-oci-runtime], [2.1.1])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
2.1.1:
	Added installation instructions for Ubuntu
	Added small history section covering V2.0 and V1.0
	Added DAX appendix to architecture documentation
	Added MTU support for network interface
	Fixed docker file descriptor leaks
	Fixed additionalGids array assignment
	Added Clear Linux and Centos 7 installation instructions
	Added Clear Containers architecture

Shortlog:
	c228baa Documentation: Add installation instructions for Ubuntu
	5b179b0 tests: fix run_docker_metrics script
	ebff893 CI: Disallow approval of 'on-hold' PRs
	4bae2a9 packaging: Adds --enable-autogopath, default=false
	ed6c49c docs: Fix distribution of documentation.
	d7552f3 docs: Add small history section covering V2.0 and V1.0
	74aab81 docs: Add DAX appendix to architecture documentation
	5e741b0 tests: fail tests if a process is left behind
	1b20133 networking: Send the MTU discovered to hyperstart.
	c455b7d networking: Get the MTU set by docker and apply it to the tap interface.
	fe91945 runtime: Fix docker file descriptor leaks
	e26bd86 create: Kill the VM along with shim on create error.
	42d8da6 fdleak: Don't let Compare() return true when it shouldn't
	b5970b4 networking: Set return value to false on network error condition.
	65feab3 networking: Fix incorrect goto on error condition in networking setup.
	3ff861a tests: Perform JSON checks on additionalGids.
	eba21a6 Tests: Remove spurious backslash.
	3b9423e tests: Fix additionalGids array assignment.
	eb3e5a9 tests: Cast away write(2) return value.
	babb379 shim: Always close console tty if it was opened.
	80cb71f docs: Add Clear Linux and Centos 7 installation instructions
	fc12475 documentation: Clarify the QEMU diagram
	b014471 Build: Fix -race pre-test to test cc-proxy
	93edd43 documentation: Fix all links
	f19fdcb docs: Distribute all documentation.
	7055d94 documentation: Clear Containers architecture
	fdef472 build: Run apt-get update before installing packages

Signed-off-by: Julio Montes <julio.montes@intel.com>