### PR TITLE
Test: Add new functions to DNS test

### DIFF
--- a/tests/integration/docker/dns.bats
+++ b/tests/integration/docker/dns.bats
@@ -45,6 +45,7 @@ function clean_swarm_status() {
 setup() {
         source $SRC/test-common.bash
 	runtime_docker
+	kill_processes_before_start
 	clean_swarm_status
 	interfaces=($(readlink /sys/class/net/* | grep -i pci | xargs basename -a))
 	swarm_interface_arg=""
@@ -108,4 +109,5 @@ setup() {
 teardown () {
 	$DOCKER_EXE service remove testswarm1 testswarm2 testdns
 	clean_swarm_status
+	check_no_processes_up
 }


### PR DESCRIPTION
Addition of the functions check_no_processes_up and
kill_processes_before_start to the DNS test

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>