### PR TITLE
Build: Distribute vendor directory.

### DIFF
--- a/.ci/ci-go-static-checks.sh
+++ b/.ci/ci-go-static-checks.sh
@@ -49,7 +49,7 @@ done
 go_packages=$args
 
 [ -z "$go_packages" ] && {
-	go_packages=$(go list ./... | grep -v cc-oci-runtime/vendor |\
+	go_packages=$(go list ./... | grep -v "cc-oci-runtime.*/vendor" |\
 		    sed -e 's#.*/cc-oci-runtime/#./#')
 }
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -356,6 +356,7 @@ EXTRA_DIST = \
 	tests/metrics/density/docker_cpu_usage.sh.in \
 	tests/metrics/density/docker_memory_usage.sh.in \
 	tests/metrics/workload_time/cor_create_time.sh.in \
+	vendor \
 	data/genfile.sh
 
 if CPPCHECK


### PR DESCRIPTION
The vendor/ directory needs to be added to the distribution archive to
allow the package to be built fully from that archive.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>