### PR TITLE
tests: return exit code diff from zero if a test fail

### DIFF
--- a/tests/functional/run-functional-tests.sh.in
+++ b/tests/functional/run-functional-tests.sh.in
@@ -25,6 +25,8 @@ echo 'Running a new instance of cc-proxy'
 p=$!
 sleep 1
 bash @ABS_BUILDDIR@/data/run-bats.sh @ABS_BUILDDIR@/tests/functional/
+functional_tests_exit_code="$?"
 echo 'killing cc-proxy instance'
 kill -9 $p 2> /dev/null
 rm -f ${PROXY_SOCKET_PATH}
+exit "$functional_tests_exit_code"


### PR DESCRIPTION
This commit makes `make functional-tests` return an
exit code different from zero if one or more tests fail.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>