### PR TITLE
mount: Remove bogus parameter check

### DIFF
--- a/src/mount.c
+++ b/src/mount.c
@@ -312,9 +312,10 @@ cc_handle_mounts(struct cc_oci_config *config, GSList *mounts)
 gboolean
 cc_oci_handle_mounts (struct cc_oci_config *config)
 {
-	if (! (config && config->oci.mounts)) {
+	if (! config) {
 		return false;
 	}
+
 	return cc_handle_mounts(config, config->oci.mounts);
 }
 


### PR DESCRIPTION
We only want to fail if our config is NULL. The list of OCI mounts being
empty is a perfectly valid use case.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>