### PR TITLE
Tests: Delete function clean_swarm_status

### DIFF
--- a/tests/integration/docker/dns.bats
+++ b/tests/integration/docker/dns.bats
@@ -29,19 +29,6 @@ total_number_of_tests=3
 # number of attempts
 number_of_attempts=5
 
-#This function will verify that swarm is not running or it finishes
-function clean_swarm_status() {
-        for j in `seq 0 $number_of_attempts`; do
-                if $DOCKER_EXE node ls; then
-                    $DOCKER_EXE swarm leave --force
-                    # "docker swarm leave" is not immediate so it requires some time to finish
-                    sleep 5
-                else
-                        break
-                fi
-        done
-}
-
 setup() {
         source $SRC/test-common.bash
 	runtime_docker

--- a/tests/integration/docker/swarm.bats
+++ b/tests/integration/docker/swarm.bats
@@ -37,20 +37,6 @@ declare -a NAMES_IPS_REPLICAS
 # saves the ip of the replicas
 declare -a IPS_REPLICAS
 
-#This function will verify that swarm is not running or it finishes
-function clean_swarm_status() {
-	for j in `seq 0 $number_of_attempts`; do
-		if $DOCKER_EXE node ls; then
-			$DOCKER_EXE swarm leave --force
-			# docker swarm leave is not inmediately so it requires time to finish
-			sleep 5
-		else
-			break
-		fi
-	done
-}
-
-
 setup() {
 	source $SRC/test-common.bash
 	runtime_docker


### PR DESCRIPTION
Deleting function clean_swarm_status from the script as this
is already part of the test-common.bash

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>