### PR TITLE
docs: add reviewer for documentation on pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -39,3 +39,18 @@ groups:
       enabled: true
       approve_regex: '^qa-passed'
       reject_regex: '^qa-failed'
+
+  docs-team:
+    conditions:
+      files:
+        - "documentation/*"
+        - "*.md"
+        - "*.rst"
+    required: 1
+    users:
+      - rcaballeromx
+      - mltullis
+    approve_by_comment:
+      enabled: true
+      approve_regex: '^docs-passed'
+      reject_regex: '^docs-failed'


### PR DESCRIPTION
Now that we have rcaballeromx as documentation owner,
I am adding him as a reviewer for changes in the files
inside docs directory and for any md and rst file.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>