### PR TITLE
metrics: Add cc-bootchart.conf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -133,6 +133,11 @@ ccimage_systemdfilesdir= @CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH@
 ccimage_systemdfiles_DATA = $(cc_image_systemd_files)
 endif
 
+if CC_IMAGE_BOOTCHART_CONFIG
+ccimage_bootchart_filesdir = @CC_IMAGE_BOOTCHART_CONFIG_DIR@
+ccimage_bootchart_files_DATA = data/cc-bootchart.conf
+endif
+
 AM_CFLAGS = -std=gnu99 -fstack-protector -Wall -pedantic \
 	-Wstrict-prototypes -Wundef -fno-common \
 	-Werror-implicit-function-declaration \
@@ -357,7 +362,8 @@ EXTRA_DIST = \
 	tests/metrics/density/docker_memory_usage.sh.in \
 	tests/metrics/workload_time/cor_create_time.sh.in \
 	vendor \
-	data/genfile.sh
+	data/genfile.sh \
+	data/cc-bootchart.conf
 
 if CPPCHECK
 CHECK_DEPS += cppcheck

--- a/configure.ac
+++ b/configure.ac
@@ -162,6 +162,19 @@ AC_ARG_WITH([cc-image-systemdsystemunitdir],
 AM_CONDITIONAL([CC_IMAGE_SYSTEMDSYSTEMUNIT],[test x"$CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH" != xno])
 
 		AC_SUBST([CC_IMAGE_SYSTEMDSYSTEMUNIT], [1])
+
+AC_ARG_WITH([cc-image-bootchart-config-dir],
+	AS_HELP_STRING([--with-cc-image-bootchart-config-dir=DIR],
+				   [path to bootchart config directory for cc-image]),
+	[
+		CC_IMAGE_BOOTCHART_CONFIG_DIR=${withval}
+		AC_SUBST(CC_IMAGE_BOOTCHART_CONFIG_DIR)
+	],
+	[WITH_CC_IMAGE_BOOTCHART_CONFIG=no]
+)
+
+AM_CONDITIONAL([CC_IMAGE_BOOTCHART_CONFIG],[test x"$WITH_CC_IMAGE_BOOTCHART_CONFIG" != xno])
+
 #Check for qemu
 DEFAULT_QEMU_PATH=/usr/bin/qemu-system-x86_64
 

--- a/data/cc-bootchart.conf
+++ b/data/cc-bootchart.conf
@@ -1,0 +1,8 @@
+[Bootchart]
+Samples=120
+Frequency=200
+ScaleX=2600
+ControlGroup=yes
+Filter=no
+PerCPU=yes
+Output=/tmp/hyper/shared/run

--- a/documentation/Get-Bootchart-metrics.md
+++ b/documentation/Get-Bootchart-metrics.md
@@ -1,0 +1,88 @@
+# Get Bootchart from a Clear Container #
+
+The following steps describe how to get a bootchart from a Clear Containers
+container. Currently `systemd` is the default init process in the Clear Containers mini-os
+system. The systemd project provides a tool called `systemd-bootchart` that
+collects the CPU load, disk load, memory usage, as well as per-process information
+about the os boot process.
+
+## Configure Clear Containers to get a bootchart ##
+
+To get a bootchart from a Clear Container, follow the steps below.
+
+1. Prepare your Clear Container image:
+
+Use the file data/cc-bootchart.conf to get a bootchart graph.
+
+To install the configuration file in a Clear Container image with systemd and
+systemd-bootchart, use the configure option `--with-cc-image-bootchart-config-dir`.
+
+```
+#Change ROOTFS value to rootfs container image
+ROOTFS="dir/to/cc_rootfs"
+BOOTCHART_CONFIG_DIR="${ROOTFS}/usr/lib/systemd/bootchart.conf.d/"
+
+./autogen.sh --with-cc-image-bootchart-config-dir="${BOOTCHART_CONFIG_DIR}"
+```
+
+2. Configure Clear Containers to boot with bootchart:
+
+Make sure your kernel uses `systemd-bootchart` as the init process (PID 1).
+
+* Option 1: Using a packaged version of `cc-oci-runtime`
+
+    1. Copy the file `/usr/share/defaults/cc-oci-runtime/vm.json` to
+       `/etc/cc-oci-runtime/vm.json` (only if it does not exist).
+
+    2. Replace in `/etc/cc-oci-runtime/vm.json` `init=/usr/lib/systemd/systemd` to
+       `init=/usr/lib/systemd/systemd-bootchart`.
+
+  Example:
+
+  ```
+  sudo mkdir -p /etc/cc-oci-runtime/
+  [ -f /etc/cc-oci-runtime/vm.json ] || \
+      sudo cp /usr/share/defaults/cc-oci-runtime/vm.json /etc/cc-oci-runtime/vm.json
+  sudo sed -i 's,init=/usr/lib/systemd/systemd,init=/usr/lib/systemd/systemd-bootchart,g'\
+      /etc/cc-oci-runtime/vm.json
+  ```
+
+* Option 2: Installing `cc-oci-runtime` from source code
+
+  1. Replace `init=/usr/lib/systemd/systemd` to `init=PATH TO SYSTEMD-BOOTCHART BINARY`
+     in the file `data/kernel-cmdline`. 
+
+  2. Install `cc-oci-runtime` using `make install`.
+
+     Example:
+
+     ```
+     sed -i 's,init=/usr/lib/systemd/systemd,init=/usr/lib/systemd/systemd-bootchart,g' \
+     data/kernel-cmdline
+     ./autogen.sh
+     make
+     make install
+     ```
+
+3. Extract bootchart from a container:
+
+The Clear Containers system is now configured to use systemd-bootchart and
+all newly created containers will create a bootchart on boot at this location:
+
+`/run/bootchart-*.svg`
+
+Example:
+
+```
+# wait some time if svg does not exist.
+docker run -ti debian bash -c \
+        't=0 ;
+        set -x;
+        while [ ! -f /run/*.svg ] && [ "$t" -lt 10 ];
+        do
+                sleep 1;
+                echo  "wait for bootchart" ;
+                t=$((t+1));
+        done;
+        cat /run/*.svg' > bootchart.svg
+```


### PR DESCRIPTION
This patch add a new config file for systemd-bootchart in the clear container image.

The config file can be installed in the clear container image rootfs
using the  configure option:

--with-cc-image-bootchart-config-dir=DIR

The config will tell systemd-bootchart to generate the
svg image in the container rootfs.

This will allow get a boot chart from a container when the systemd-bootchart is used as init (init can
be changed in the kernel cmdline in the vm.json file )

docker run --rm -ti debian bash -c 'sleep 10s; cat /run/*.svg' > ./bootchart.svg

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>