### PR TITLE
CRI-O integration tests

### DIFF
--- a/.ci/ci-setup.sh
+++ b/.ci/ci-setup.sh
@@ -111,6 +111,15 @@ pkgs+=" lcov"
 # chronic(1)
 pkgs+=" moreutils"
 
+# CRI-O
+pkgs+=" libseccomp2"
+pkgs+=" libseccomp-dev"
+pkgs+=" seccomp"
+pkgs+=" libdevmapper-dev"
+pkgs+=" libdevmapper1.02.1"
+pkgs+=" libgpgme11"
+pkgs+=" libgpgme11-dev"
+
 # qemu-lite won't be built
 # some unit tests need qemu-system
 if [ "$nested" != "Y" ]

--- a/Makefile.am
+++ b/Makefile.am
@@ -90,6 +90,7 @@ $(GENERATED_FILES): %: %.in Makefile
 		DOCKER_ENGINE_FEDORA_VERSION="$(DOCKER_ENGINE_FEDORA_VERSION)" \
 		DOCKER_UBUNTU_VERSION="$(DOCKER_UBUNTU_VERSION)" \
 		DOCKER_ENGINE_UBUNTU_VERSION="$(DOCKER_ENGINE_UBUNTU_VERSION)" \
+		CRIO_CACHE="$(CRIO_CACHE)" \
 		abs_builddir="$(abs_builddir)" \
 		$(top_srcdir)/data/genfile.sh "$<" "$@"
 
@@ -389,6 +390,13 @@ if DOCKER_TESTS
 CHECK_DEPS += docker-tests
 docker-tests: cc-oci-runtime tests/lib/test-common.bash
 	@$(BATS_PATH) -t $(srcdir)/tests/integration/docker
+endif
+
+if CRIO_TESTS
+CHECK_DEPS += crio-tests
+GENERATED_FILES += tests/lib/test-crio.bats
+crio-tests: cc-oci-runtime cc-proxy cc-shim tests/lib/test-crio.bats
+	@$(BATS_PATH) -t $(srcdir)/tests/integration/cri-o
 endif
 
 #### tests ####

--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,19 @@ AS_IF([test x"$run_docker_tests" = x"yes"],
     [AC_SUBST([DOCKER_TESTS], [0])])
 AM_CONDITIONAL([DOCKER_TESTS], [test x"$run_docker_tests" = x"yes"])
 
+# CRI-O integration tests
+AC_ARG_ENABLE(crio-tests, AS_HELP_STRING([--disable-crio-tests],
+              [disable CRI-O tests @<:@default=no@:>@]))
+
+AS_IF([test x"$enable_crio_tests" = x"yes" -o x"$enable_crio_tests" = x""],
+    [run_crio_tests=yes],
+    [run_crio_tests=no])
+
+AS_IF([test x"$run_crio_tests" = x"yes"],
+    [AC_SUBST([CRIO_TESTS], [1])],
+    [AC_SUBST([CRIO_TESTS], [0])])
+AM_CONDITIONAL([CRIO_TESTS], [test x"$run_crio_tests" = x"yes"])
+
 # Checks for libraries.
 source $srcdir/versions.txt
 
@@ -302,6 +315,21 @@ AC_ARG_WITH([cc-image],
     ]
 )
 
+# CRI-O artifacts
+DEFAULT_CRIO_CACHE=$localstatedir/lib/$PACKAGE_NAME/cri-o/cache
+AC_ARG_WITH([crio-cache],
+    [AS_HELP_STRING([--with-crio-cache=[[CACHE-PATH]]],
+        [CRIO cache directory])
+    ],
+    [
+        CONTAINERS_IMG=$with_crio_cache
+        AC_SUBST([CRIO_CACHE])
+    ],
+    [
+        AC_SUBST([CRIO_CACHE],[$DEFAULT_CRIO_CACHE])
+    ]
+)
+
 AC_ARG_ENABLE([autogopath],
 	AS_HELP_STRING([--enable-autogopath], [Set GOPATH variable for you, used when packaging @<:@default=false@:>@]),
 	[case "${enableval}" in
@@ -319,6 +347,9 @@ dnl === Summary ===============================================================
 
 AS_IF([test x"$disable_docker_tests" = xno],
       [enable_docker_tests=yes], [enable_docker_tests=no])
+
+AS_IF([test x"$disable_crio_tests" = xno],
+      [enable_crio_tests=yes], [enable_crio_tests=no])
 
 AC_MSG_RESULT([
 cc-oci-runtime - $VERSION
@@ -341,6 +372,7 @@ cc-oci-runtime - $VERSION
        Unit tests               : $enable_tests
        Functional tests         : $run_functional_tests
        Docker tests             : $run_docker_tests
+       CRI-O tests              : $run_crio_tests
        Cppcheck                 : $enable_cppcheck
        Valgrind                 : $VALGRIND_ENABLED
        Code coverage            : $CODE_COVERAGE_ENABLED

--- a/data/genfile.sh
+++ b/data/genfile.sh
@@ -26,5 +26,6 @@ ${SED} \
 	-e 's|@DOCKER_ENGINE_FEDORA_VERSION@|'"${DOCKER_ENGINE_FEDORA_VERSION}"'|g' \
 	-e 's|@DOCKER_UBUNTU_VERSION@|'"${DOCKER_UBUNTU_VERSION}"'|g' \
 	-e 's|@DOCKER_ENGINE_UBUNTU_VERSION@|'"${DOCKER_ENGINE_UBUNTU_VERSION}"'|g' \
+	-e 's|@CRIO_CACHE@|'"${CRIO_CACHE}"'|g' \
 	-e 's|@ABS_BUILDDIR@|'"${abs_builddir}"'|g' \
 	"${in_file}" > "${out_file}"

--- a/tests/data/container_redis.json
+++ b/tests/data/container_redis.json
@@ -1,0 +1,64 @@
+{
+	"metadata": {
+		"name": "podsandbox1-redis"
+	},
+	"image": {
+		"image": "docker://redis:3.2.3"
+	},
+	"args": [
+                "docker-entrypoint.sh",
+                "redis-server"
+	],
+	"working_dir": "/data",
+	"envs": [
+		{
+			"key": "PATH",
+			"value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+		},
+		{
+			"key": "TERM",
+			"value": "xterm"
+		},
+		{
+			"key": "REDIS_VERSION",
+			"value": "3.2.3"
+		},
+		{
+			"key": "REDIS_DOWNLOAD_URL",
+			"value": "http://download.redis.io/releases/redis-3.2.3.tar.gz"
+		},
+		{
+			"key": "REDIS_DOWNLOAD_SHA1",
+			"value": "92d6d93ef2efc91e595c8bf578bf72baff397507"
+		}
+	],
+	"labels": {
+		"tier": "backend"
+	},
+	"annotations": {
+		"pod": "podsandbox1"
+	},
+	"readonly_rootfs": false,
+	"log_path": "container.log",
+	"stdin": false,
+	"stdin_once": false,
+	"tty": false,
+	"linux": {
+		"resources": {
+			"cpu_period": 10000,
+			"cpu_quota": 20000,
+			"cpu_shares": 512,
+			"memory_limit_in_bytes": 88000000,
+			"oom_score_adj": 30
+		},
+		"capabilities": {
+			"add_capabilities": [
+				"sys_admin"
+			]
+		},
+		"user": {
+			"uid": 0,
+			"gid": 0
+		}
+	}
+}

--- a/tests/data/policy.json
+++ b/tests/data/policy.json
@@ -1,0 +1,7 @@
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ]
+}

--- a/tests/data/sandbox_config.json
+++ b/tests/data/sandbox_config.json
@@ -1,0 +1,64 @@
+{
+	"metadata": {
+		"name": "podsandbox1",
+		"uid": "redhat-test-ocid",
+		"namespace": "redhat.test.ocid",
+		"attempt": 1
+	},
+	"hostname": "ocic_host",
+	"log_directory": ".",
+	"dns_options": {
+		"servers": [
+			"server1.redhat.com",
+			"server2.redhat.com"
+		],
+		"searches": [
+			"8.8.8.8"
+		]
+	},
+	"port_mappings": [
+		{
+			"name": "port_map1",
+			"protocol": 1,
+			"container_port": 80,
+			"host_port": 4888,
+			"host_ip": "192.168.0.33"
+		},
+		{
+			"name": "port_map2",
+			"protocol": 2,
+			"container_port": 81,
+			"host_port": 4889,
+			"host_ip": "192.168.0.33"
+		}
+	],
+	"resources": {
+		"cpu": {
+			"limits": 3,
+			"requests": 2
+		},
+		"memory": {
+			"limits": 50000000,
+			"requests": 2000000
+		}
+	},
+	"labels": {
+		"group": "test"
+	},
+	"annotations": {
+		"owner": "hmeng",
+		"security.alpha.kubernetes.io/sysctls": "kernel.shm_rmid_forced=1,net.ipv4.ip_local_port_range=1024 65000",
+		"security.alpha.kubernetes.io/unsafe-sysctls": "kernel.msgmax=8192" ,
+		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
+	},
+	"linux": {
+		"cgroup_parent": "/ocid-podsandbox1",
+		"security_context": {
+			"namespace_options": {
+				"host_network": false,
+				"host_pid": false,
+				"host_ipc": false
+			}
+		}
+	}
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,29 @@
+## cc-oci-runtime integration tests
+
+### Docker
+
+1. Enable the Docker integration tests:
+
+```
+./autogen.sh --enable-docker-tests
+```
+
+2. Run the Docker integration tests:
+
+```
+sudo -E make docker-tests
+```
+
+### CRI-O
+
+1. Enable the CRI-O integration tests:
+
+```
+./autogen.sh --enable-crio-tests
+```
+
+2. Run the CRI-O integration tests:
+
+```
+sudo -E make crio-tests
+```

--- a/tests/integration/cri-o/container.bats
+++ b/tests/integration/cri-o/container.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+# *-*- Mode: sh; sh-basic-offset: 8; indent-tabs-mode: nil -*-*
+
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2017 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+SRC="${BATS_TEST_DIRNAME}/../../lib/"
+TESTDATA="${BATS_TEST_DIRNAME}/../../data/"
+
+setup() {
+	source $SRC/test-crio.bats
+}
+
+function teardown() {
+	cleanup_test
+}
+
+@test "CRI-O redis container start and remove" {
+	start_ocid
+	run ocic pod run --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	run ocic ctr create --config "$TESTDATA"/container_redis.json --pod "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run ocic ctr start --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run ocic ctr remove --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run ocic pod stop --id "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run ocic pod remove --id "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_ocid
+}

--- a/tests/lib/test-crio.bats.in
+++ b/tests/lib/test-crio.bats.in
@@ -1,0 +1,214 @@
+#!/usr/bin/env bats
+
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2017 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+# CC tests data
+TEST_DATA="${BATS_TEST_DIRNAME}/../../data/"
+
+# CRI-O URL and version
+CRIO_GITHUB="github.com/kubernetes-incubator/cri-o"
+CRIO_VERSION="3195f459"
+
+# CRI-O root directory
+OCID_ROOT="$GOPATH/src/$CRIO_GITHUB"
+
+# Path of the ocid binary.
+OCID_BINARY=${OCID_BINARY:-${OCID_ROOT}/ocid}
+# Path of the ocic binary.
+OCIC_BINARY=${OCIC_BINARY:-${OCID_ROOT}/ocic}
+# Path of the conmon binary.
+CONMON_BINARY=${CONMON_BINARY:-${OCID_ROOT}/conmon/conmon}
+# Path of the pause binary.
+PAUSE_BINARY=${PAUSE_BINARY:-${OCID_ROOT}/pause/pause}
+# Path of the default seccomp profile.
+SECCOMP_PROFILE=${SECCOMP_PROFILE:-${OCID_ROOT}/seccomp.json}
+# Name of the default apparmor profile.
+APPARMOR_PROFILE=${APPARMOR_PROFILE:-ocid-default}
+# Path of the bin2img binary.
+BIN2IMG_BINARY=${BIN2IMG_BINARY:-${OCID_ROOT}/test/bin2img/bin2img}
+# Path of the copyimg binary.
+COPYIMG_BINARY=${COPYIMG_BINARY:-${OCID_ROOT}/test/copyimg/copyimg}
+# Path of tests artifacts.
+ARTIFACTS_PATH="@CRIO_CACHE@"
+# Path of the checkseccomp binary.
+CHECKSECCOMP_BINARY=${CHECKSECCOMP_BINARY:-${OCID_ROOT}/test/checkseccomp/checkseccomp}
+
+# CRI-O Runtime
+RUNTIME=${RUNTIME:-cc-oci-runtime}
+RUNTIME_PATH=$(command -v $RUNTIME || true)
+RUNTIME_BINARY=${RUNTIME_PATH:-/usr/bin/cc-oci-runtime}
+
+TESTDIR=$(mktemp -d)
+if [ -e /usr/sbin/selinuxenabled ] && /usr/sbin/selinuxenabled; then
+    . /etc/selinux/config
+    filelabel=$(awk -F'"' '/^file.*=.*/ {print $2}' /etc/selinux/${SELINUXTYPE}/contexts/lxc_contexts)
+    chcon -R ${filelabel} $TESTDIR
+fi
+OCID_SOCKET="$TESTDIR/ocid.sock"
+OCID_CONFIG="$TESTDIR/ocid.conf"
+OCID_CNI_CONFIG="$TESTDIR/cni/net.d/"
+OCID_CNI_PLUGIN="/opt/cni/bin/"
+POD_CIDR="10.88.0.0/16"
+POD_CIDR_MASK="10.88.*.*"
+mkdir -p $OCID_CNI_CONFIG
+
+PATH=$PATH:$TESTDIR
+
+# Make sure we have a copy of the CRI-O code.
+if ! [ -d "$OCID_ROOT" ]; then
+    #    mkdir -p "$OCID_ROOT"
+    echo "Cloning CRI-O repo..."
+    go get $CRIO_GITHUB || true
+    pushd $OCID_ROOT && git reset --hard $CRIO_VERSION && popd
+fi
+
+# Build the CRI-O binaries
+echo "Building CRI-O...($GOPATH)"
+make -C ${OCID_ROOT} binaries
+
+cp "$CONMON_BINARY" "$TESTDIR/conmon"
+
+# Make sure we have a copy of the redis:latest image.
+if ! [ -d "$ARTIFACTS_PATH"/redis-image ]; then
+    mkdir -p "$ARTIFACTS_PATH"/redis-image
+    echo "Copying redis image (Only needed during the first run)..."
+    if ! "$COPYIMG_BINARY" --import-from=docker://redis --export-to=dir:"$ARTIFACTS_PATH"/redis-image --signature-policy="$TEST_DATA"/policy.json ; then
+        echo "Error pulling docker://redis"
+        rm -fr "$ARTIFACTS_PATH"/redis-image
+        exit 1
+    fi
+fi
+
+# Retry a command $1 times until it succeeds. Wait $2 seconds between retries.
+function retry() {
+	local attempts=$1
+	shift
+	local delay=$1
+	shift
+	local i
+
+	for ((i=0; i < attempts; i++)); do
+		run "$@"
+		if [[ "$status" -eq 0 ]] ; then
+			return 0
+		fi
+		sleep $delay
+	done
+
+	echo "Command \"$@\" failed $attempts times. Output: $output"
+	false
+}
+
+# Waits until the given ocid becomes reachable.
+function wait_until_reachable() {
+	retry 15 1 ocic runtimeversion
+}
+
+# Start ocid.
+function start_ocid() {
+	# Don't forget: bin2img, copyimg, and ocid have their own default drivers, so if you override any, you probably need to override them all
+	if ! [ "$3" = "--no-pause-image" ] ; then
+		"$BIN2IMG_BINARY" --root "$TESTDIR/ocid" --runroot "$TESTDIR/ocid-run" --source-binary "$PAUSE_BINARY"
+	fi
+	"$COPYIMG_BINARY" --root "$TESTDIR/ocid" --runroot "$TESTDIR/ocid-run" --image-name=redis --import-from=dir:"$ARTIFACTS_PATH"/redis-image --add-name=docker://docker.io/library/redis:latest --signature-policy="$TEST_DATA"/policy.json
+	"$OCID_BINARY" --conmon "$CONMON_BINARY" --listen "$OCID_SOCKET" --runtime "$RUNTIME_BINARY" --root "$TESTDIR/ocid" --runroot "$TESTDIR/ocid-run" --seccomp-profile "$SECCOMP_PROFILE" --apparmor-profile "$APPARMOR_PROFILE" --cni-config-dir "$OCID_CNI_CONFIG" --signature-policy "$TEST_DATA"/policy.json --config /dev/null config >$OCID_CONFIG
+	"$OCID_BINARY" --debug --config "$OCID_CONFIG" & OCID_PID=$!
+	wait_until_reachable
+
+	run ocic image status --id=redis
+	if [ "$status" -ne 0 ] ; then
+	        echo "Pulling redis image..."
+		ocic image pull redis:latest
+	fi
+	REDIS_IMAGEID=$(ocic image status --id=redis | head -1 | sed -e "s/ID: //g")
+}
+
+# Run ocid using the binary specified by $OCID_BINARY.
+# This must ONLY be run on engines created with `start_ocid`.
+function ocid() {
+	"$OCID_BINARY" --listen "$OCID_SOCKET" "$@"
+}
+
+# Run ocic using the binary specified by $OCIC_BINARY.
+function ocic() {
+	"$OCIC_BINARY" --connect "$OCID_SOCKET" "$@"
+}
+
+function cleanup_ctrs() {
+	run ocic ctr list --quiet
+	if [ "$status" -eq 0 ]; then
+		if [ "$output" != "" ]; then
+			printf '%s\n' "$output" | while IFS= read -r line
+			do
+			   ocic ctr stop --id "$line" || true
+			   ocic ctr remove --id "$line"
+			done
+		fi
+	fi
+}
+
+function cleanup_pods() {
+	run ocic pod list --quiet
+	if [ "$status" -eq 0 ]; then
+		if [ "$output" != "" ]; then
+			printf '%s\n' "$output" | while IFS= read -r line
+			do
+			   ocic pod stop --id "$line" || true
+			   ocic pod remove --id "$line"
+			done
+		fi
+	fi
+}
+
+# Stop ocid.
+function stop_ocid() {
+	if [ "$OCID_PID" != "" ]; then
+		kill "$OCID_PID" >/dev/null 2>&1
+		wait "$OCID_PID"
+		rm -f "$OCID_CONFIG"
+	fi
+}
+
+function cleanup_test() {
+	for i in `ls /var/lib/ocid/sandboxes/ 2> /dev/null`; do
+		umount /var/lib/ocid/sandboxes/$i/shm 2> /dev/null;
+	done
+
+	for i in `find /tmp -name "shm" `; do
+		umount $i 2> /dev/null;
+		rm -rf $i
+	done
+
+	for i in `find /tmp -name "*.conf" `; do
+		umount $i 2> /dev/null;
+		rm -rf $i
+	done
+
+	for i in `find /tmp -name "tmp.*" `; do
+		for j in `ls $i/ocid/devicemapper/mnt/`; do
+			umount $i/ocid/devicemapper/mnt/$j
+		done
+
+		umount $i/ocid/devicemapper 2> /dev/null;
+		rm -rf $i
+	done
+
+	rm -rf /var/lib/ocid 2> /dev/null
+	rm -rf "$TESTDIR"
+}


### PR DESCRIPTION
Through `make crio-tests`, we add CRI-O integration tests. This needs to be configured in with a new `--enable-crio-tests` configure option.

For now, we only have one test that starts a pod and a redis container within that pod and verifies that they're both running fine. Then it stops both container and pod.
This will give us a quick BAT for CRI-O support.

Fixes #723 