### PR TITLE
docs: Remove use of lsb_release(1) for docker in Ubuntu install guide.

### DIFF
--- a/documentation/Installing-Clear-Containers-on-Ubuntu.md
+++ b/documentation/Installing-Clear-Containers-on-Ubuntu.md
@@ -11,14 +11,19 @@ used but some issues may exist.
 This step is optional and required only in the case where docker is not installed
 on the system, or the explicitly supported version of docker is required.
 
+The `add-apt-repository` and `apt-get` commands below reference
+`ubuntu-xenial`. Both Ubuntu 16.04 and 16.10 require this reference
+since the version of Docker supported by Clear Containers is not
+available as a Ubuntu 16.10 package.
+
 ```
 sudo groupadd docker
 sudo -E gpasswd -a $USER docker
 sudo apt-get install -y apt-transport-https ca-certificates
 curl -fsSL https://yum.dockerproject.org/gpg | sudo apt-key add -
-sudo add-apt-repository "deb https://apt.dockerproject.org/repo/ ubuntu-$(lsb_release -cs) main"
+sudo add-apt-repository "deb https://apt.dockerproject.org/repo/ ubuntu-xenial main"
 sudo apt-get update
-sudo apt-get install -y --allow-downgrades docker-engine=1.12.1-0~$(lsb_release -cs)
+sudo apt-get install -y --allow-downgrades docker-engine=1.12.1-0~xenial
 sudo sudo apt-mark hold docker-engine
 ```
 


### PR DESCRIPTION
The Ubuntu installation guide was using the lsb_release(1) command to
simplify adding the docker apt repository. However, lsb_release(1) can only
be used for Ubuntu 16.04 (xenial) - the commands will fail when running
on Ubuntu 16.10 (yakkety) since docker does not provide version 1.12.1
for yakkety and we only currently support docker 1.12.1.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>