### PR TITLE
docs: Remove erroneous here-document syntax from Ubuntu install guide.

### DIFF
--- a/documentation/Installing-Clear-Containers-on-Ubuntu.md
+++ b/documentation/Installing-Clear-Containers-on-Ubuntu.md
@@ -39,11 +39,11 @@ sudo apt-get install -y cc-oci-runtime
 ## Configure docker to use Clear Containers by default
 ```
 sudo mkdir -p /etc/systemd/system/docker.service.d/
-cat << EOL | sudo tee /etc/systemd/system/docker.service.d/clr-containers.conf
+cat << EOF | sudo tee /etc/systemd/system/docker.service.d/clr-containers.conf
 [Service]
 ExecStart=
 ExecStart=/usr/bin/dockerd -D --add-runtime cor=/usr/bin/cc-oci-runtime --default-runtime=cor
-EOL
+EOF
 ```
 
 ## Restart the docker and Clear Containers systemd services

--- a/documentation/Installing-Clear-Containers-on-Ubuntu.md
+++ b/documentation/Installing-Clear-Containers-on-Ubuntu.md
@@ -43,7 +43,7 @@ cat << EOL | sudo tee /etc/systemd/system/docker.service.d/clr-containers.conf
 [Service]
 ExecStart=
 ExecStart=/usr/bin/dockerd -D --add-runtime cor=/usr/bin/cc-oci-runtime --default-runtime=cor
-EOL>>
+EOL
 ```
 
 ## Restart the docker and Clear Containers systemd services


### PR DESCRIPTION
A here-document is terminated by the token immediately after "<<",
not "token >>".

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>