### PR TITLE
CRI-O fixes for 2.1.2

### DIFF
--- a/src/oci.c
+++ b/src/oci.c
@@ -530,6 +530,11 @@ cc_oci_cleanup (struct cc_oci_config *config)
 		return false;
 	}
 
+	/* Pod unmounts should happen after the volume unmounts */
+	if (! cc_pod_handle_unmounts(config)) {
+		return false;
+	}
+
 	if (! cc_oci_state_file_delete (config)) {
 		return false;
 	}
@@ -1039,11 +1044,6 @@ cc_oci_stop (struct cc_oci_config *config,
 	 * always return false.
 	 */
 	if (! cc_oci_config_update (config, state)) {
-		return false;
-	}
-
-	if (! cc_pod_handle_unmounts(config)) {
-		g_critical ("failed to handle pod unmounts");
 		return false;
 	}
 

--- a/src/pod.c
+++ b/src/pod.c
@@ -428,7 +428,7 @@ cc_pod_container_start (struct cc_oci_config *config)
  * \return the pod container ID on success, else \c NULL.
  */
 const gchar *
-cc_pod_container_id(struct cc_oci_config *config)
+cc_pod_container_id(const struct cc_oci_config *config)
 {
 	if (! config) {
 		return NULL;
@@ -451,7 +451,7 @@ cc_pod_container_id(struct cc_oci_config *config)
  * \return \c true if the container is a pod sanbox, \c false otherwise
  */
 gboolean
-cc_pod_is_sandbox(struct cc_oci_config *config)
+cc_pod_is_sandbox(const struct cc_oci_config *config)
 {
 	if (config && config->pod && config->pod->sandbox) {
 		return true;
@@ -471,7 +471,7 @@ cc_pod_is_sandbox(struct cc_oci_config *config)
  * \return \c true if the container is a virtual machine, \c false otherwise
  */
 gboolean
-cc_pod_is_vm(struct cc_oci_config *config)
+cc_pod_is_vm(const struct cc_oci_config *config)
 {
 	if (config && config->pod && ! config->pod->sandbox) {
 		return false;

--- a/src/pod.h
+++ b/src/pod.h
@@ -33,8 +33,8 @@ struct cc_oci_mount *cc_pod_mount_point(struct cc_oci_config *config);
 void cc_pod_free (struct cc_pod *pod);
 gboolean cc_pod_container_create (struct cc_oci_config *config);
 gboolean cc_pod_container_start (struct cc_oci_config *config);
-const gchar *cc_pod_container_id(struct cc_oci_config *config);
-gboolean cc_pod_is_sandbox(struct cc_oci_config *config);
-gboolean cc_pod_is_vm(struct cc_oci_config *config);
+const gchar *cc_pod_container_id(const struct cc_oci_config *config);
+gboolean cc_pod_is_sandbox(const struct cc_oci_config *config);
+gboolean cc_pod_is_vm(const struct cc_oci_config *config);
 
 #endif /* _CC_POD_H */

--- a/tests/pod_test.c
+++ b/tests/pod_test.c
@@ -31,9 +31,9 @@
 #include "oci.h"
 #include "oci-config.h"
 
-const gchar *cc_pod_container_id(struct cc_oci_config *config);
-gboolean cc_pod_is_sandbox(struct cc_oci_config *config);
-gboolean cc_pod_is_vm(struct cc_oci_config *config);
+const gchar *cc_pod_container_id(const struct cc_oci_config *config);
+gboolean cc_pod_is_sandbox(const struct cc_oci_config *config);
+gboolean cc_pod_is_vm(const struct cc_oci_config *config);
 
 START_TEST(test_cc_pod_container_id) {
 	struct cc_oci_config *config = NULL;


### PR DESCRIPTION
This PR fixes the way we mount volumes for intra pod containers.
We were mounting them in the pod rootfs instead of the container rootfs, making them unreachable from the container workload.