### PR TITLE
runtime: check if cc-shim is running before stop it

### DIFF
--- a/src/oci.c
+++ b/src/oci.c
@@ -378,7 +378,7 @@ cc_oci_kill (struct cc_oci_config *config,
 		 * finished with SIGKILL signal hence cc-shim MUST receive
 		 * this signal too
 		 */
-		if (kill (state->pid, signum) < 0) {
+		if (kill (state->pid, signum) < 0 && errno != ESRCH) {
 			g_critical ("failed to stop cc-shim %u: %s",
 					(unsigned)state->pid,
 					strerror (errno));


### PR DESCRIPTION
This patch is to avoid failures when cor tries to
stop cc-shim when it was already stopped

Signed-off-by: Julio Montes <julio.montes@intel.com>