### PR TITLE
Fix cc-oci-runtime list for pod containers

### DIFF
--- a/src/mount.c
+++ b/src/mount.c
@@ -243,7 +243,7 @@ cc_handle_mounts(struct cc_oci_config *config, GSList *mounts, gboolean volume)
 			continue;
 		}
 
-		if ((! cc_pod_is_vm(config) || cc_pod_is_sandbox(config)) && volume) {
+		if ((! cc_pod_is_vm(config) || cc_pod_is_pod_sandbox(config)) && volume) {
 			g_snprintf (m->dest, sizeof (m->dest),
 				    "%s/%s/rootfs/%s", workload_dir, config->optarg_container_id, m->mnt.mnt_dir);
 		} else {
@@ -447,7 +447,7 @@ cc_oci_handle_unmounts (const struct cc_oci_config *config)
 	 * since namespace created by unshare in \ref cc_oci_ns_setup
 	 * is destroyed when qemu ends
 	 */
-	if (! mountns && (cc_pod_is_vm(config) && !cc_pod_is_sandbox(config))) {
+	if (! mountns && (cc_pod_is_vm(config) && !cc_pod_is_pod_sandbox(config))) {
 		return true;
 	}
 

--- a/src/oci.c
+++ b/src/oci.c
@@ -155,6 +155,31 @@ cc_oci_get_workload_dir (struct cc_oci_config *config)
 }
 
 /*!
+ * Get the container PID.
+ *
+ * \param state Container state.
+ *
+ * \return Container PID on success, else \c -1.
+ */
+static GPid
+cc_oci_container_pid (const struct oci_state *state)
+{
+	if (! state) {
+		return -1;
+	}
+
+	if (state->vm && state->vm->pid) {
+		return state->vm->pid;
+	}
+
+	if (state->pod && ! state->pod->sandbox) {
+		return state->pid;
+	}
+
+	return -1;
+}
+
+/*!
  * Determine the containers config file, its configuration
  * and state.
  *
@@ -406,20 +431,27 @@ error:
 }
 
 /*!
- * Determine if the VM is running.
+ * Determine if the container is running.
  *
  * \param  state \ref oci_state.
  *
  * \return \c true on success, else \c false.
  */
 private gboolean
-cc_oci_vm_running (const struct oci_state *state)
+cc_oci_container_running (const struct oci_state *state)
 {
-	if (! (state && state->vm && state->vm->pid)) {
+	GPid container_pid;
+
+	if (! state) {
 		return false;
 	}
 
-	return kill (state->vm->pid, 0) == 0;
+	container_pid = cc_oci_container_pid(state);
+	if (container_pid < 0) {
+		return false;
+	}
+
+	return kill (container_pid, 0) == 0;
 }
 
 /*!
@@ -771,7 +803,7 @@ cc_oci_start (struct cc_oci_config *config,
 	}
 
 	if (state->status == OCI_STATUS_RUNNING) {
-		if (cc_oci_vm_running (state)) {
+		if (cc_oci_container_running (state)) {
 			g_critical ("container %s is already running",
 					config->optarg_container_id);
 		} else {
@@ -1017,12 +1049,15 @@ cc_oci_stop (struct cc_oci_config *config,
 		return false;
 	}
 
-	if (cc_oci_vm_running (state)) {
+	if (cc_oci_container_running (state) && ! cc_pod_is_pod_container(config)) {
 		gboolean ret;
 		ret = cc_proxy_hyper_destroy_pod(config);
 		if (! ret) {
 			return false;
 		}
+	} else if (cc_pod_is_pod_container(config)) {
+		g_debug("Cannot delete container %s (pid %u) - "
+			"it is a pod container", state->id, state->pid);
 	} else {
 		/* This isn't a fatal condition since:
 		 *
@@ -1039,8 +1074,8 @@ cc_oci_stop (struct cc_oci_config *config,
 	 * We need to update our config so that both
 	 * the pod and mount pointers are accurate.
 	 * OTOH we can't update our config before calling
-	 * cc_oci_vm_running() as config_update() clears
-	 * the state pointer and cc_oci_vm_running would
+	 * cc_oci_container_running() as config_update() clears
+	 * the state pointer and cc_oci_container_running would
 	 * always return false.
 	 */
 	if (! cc_oci_config_update (config, state)) {
@@ -1225,7 +1260,7 @@ cc_oci_list_vm (const struct oci_state *state,
 	g_assert (state);
 	g_assert (options);
 
-	if (! cc_oci_vm_running (state)) {
+	if (! cc_oci_container_running (state)) {
 		status = cc_oci_status_to_str (OCI_STATUS_STOPPED);
 	} else {
 		status = cc_oci_status_to_str (state->status);

--- a/src/oci.c
+++ b/src/oci.c
@@ -334,8 +334,8 @@ cc_oci_kill (struct cc_oci_config *config,
 	/* save current status */
 	last_status = config->state.status;
 
-	/* A sandbox is not a running container, nothing to kill here */
-	if (cc_pod_is_sandbox(config)) {
+	/* A pod sandbox is not a running container, nothing to kill here */
+	if (cc_pod_is_pod_sandbox(config)) {
 		config->state.status = OCI_STATUS_STOPPED;
 
 		/* update state file */
@@ -849,12 +849,12 @@ cc_oci_start (struct cc_oci_config *config,
 			ret = false;
 			goto out;
 		}
-	} else if (cc_pod_is_sandbox(config)) {
+	} else if (cc_pod_is_pod_sandbox(config)) {
 		cc_proxy_hyper_new_pod_container(config,
 						config->optarg_container_id,
 						config->optarg_container_id,
 						"rootfs", config->optarg_container_id);
-	} else if (! cc_pod_is_sandbox(config)) {
+	} else if (! cc_pod_is_pod_sandbox(config)) {
 		if (! cc_pod_container_start (config)) {
 			ret = false;
 			goto out;

--- a/src/pod.c
+++ b/src/pod.c
@@ -443,7 +443,7 @@ cc_pod_container_id(const struct cc_oci_config *config)
 }
 
 /**
- * cc_pod_sandbox tells if a container is a pod
+ * cc_pod_is_pod_sandbox tells if a container is a pod
  * sandbox or not.
  *
  * \param config \ref cc_oci_config.
@@ -451,9 +451,28 @@ cc_pod_container_id(const struct cc_oci_config *config)
  * \return \c true if the container is a pod sanbox, \c false otherwise
  */
 gboolean
-cc_pod_is_sandbox(const struct cc_oci_config *config)
+cc_pod_is_pod_sandbox(const struct cc_oci_config *config)
 {
 	if (config && config->pod && config->pod->sandbox) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * cc_pod_is_pod_container tells if a container is a pod
+ * container or not. A pod container is a container
+ * running inside a pod VM. It's not a VM itself.
+ *
+ * \param config \ref cc_oci_config.
+ *
+ * \return \c true if the container is a pod container, \c false otherwise
+ */
+gboolean
+cc_pod_is_pod_container(const struct cc_oci_config *config)
+{
+	if (config && config->pod && !config->pod->sandbox) {
 		return true;
 	}
 

--- a/src/pod.h
+++ b/src/pod.h
@@ -34,7 +34,8 @@ void cc_pod_free (struct cc_pod *pod);
 gboolean cc_pod_container_create (struct cc_oci_config *config);
 gboolean cc_pod_container_start (struct cc_oci_config *config);
 const gchar *cc_pod_container_id(const struct cc_oci_config *config);
-gboolean cc_pod_is_sandbox(const struct cc_oci_config *config);
+gboolean cc_pod_is_pod_sandbox(const struct cc_oci_config *config);
+gboolean cc_pod_is_pod_container(const struct cc_oci_config *config);
 gboolean cc_pod_is_vm(const struct cc_oci_config *config);
 
 #endif /* _CC_POD_H */

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1379,7 +1379,7 @@ cc_proxy_run_hyper_new_container (struct cc_oci_config *config,
 			config->oci.process.cwd);
 
 	/* Only set user for a container as sandboxes may not have users defined */
-	if (! cc_pod_is_sandbox(config)) {
+	if (! cc_pod_is_pod_sandbox(config)) {
 		/* Hyperstart is not able to handle uid 0. This is a bug. */
 		if ((int)config->oci.process.user.uid == 0) {
 			json_object_set_string_member (process, "user", "root");

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -40,7 +40,7 @@
 #include "../src/oci.h"
 #include "../src/util.h"
 
-gboolean cc_oci_vm_running (const struct oci_state *state);
+gboolean cc_oci_container_running (const struct oci_state *state);
 gboolean cc_oci_create_container_workload (struct cc_oci_config *config);
 gchar* get_user_home_dir(struct cc_oci_config *config, gchar *password_path);
 void set_env_home(struct cc_oci_config *config);
@@ -795,25 +795,25 @@ START_TEST(test_cc_oci_get_config_and_state) {
 START_TEST(test_cc_oci_vm_running) {
 	struct oci_state state = {0};
 
-	ck_assert (! cc_oci_vm_running (NULL));
+	ck_assert (! cc_oci_container_running (NULL));
 
 	/* no vm */
-	ck_assert (! cc_oci_vm_running (&state));
+	ck_assert (! cc_oci_container_running (&state));
 
 	state.vm = g_malloc0(sizeof(struct cc_oci_vm_cfg));
 	ck_assert(state.vm);
 
 	/* no pid for vm */
-	ck_assert (! cc_oci_vm_running (&state));
+	ck_assert (! cc_oci_container_running (&state));
 
 	/* our pid provided as hypervisor pid*/
 	state.vm->pid = getpid ();
-	ck_assert (cc_oci_vm_running (&state));
+	ck_assert (cc_oci_container_running (&state));
 
 	/* invalid pid (we hope: this is potential an unreliable test).
 	 */
 	state.vm->pid = (pid_t)INT_MAX;
-	ck_assert (! cc_oci_vm_running (&state));
+	ck_assert (! cc_oci_container_running (&state));
 
 	g_free(state.vm);
 

--- a/tests/pod_test.c
+++ b/tests/pod_test.c
@@ -61,23 +61,45 @@ START_TEST(test_cc_pod_container_id) {
 	cc_oci_config_free (config);
 } END_TEST
 
-START_TEST(test_cc_pod_is_sandbox) {
+START_TEST(test_cc_pod_is_pod_sandbox) {
 	struct cc_oci_config *config = NULL;
 
-	ck_assert(!cc_pod_is_sandbox(config));
+	ck_assert(!cc_pod_is_pod_sandbox(config));
 
 	config = cc_oci_config_create ();
 	ck_assert(config);
-	ck_assert(!cc_pod_is_sandbox(config));
+	ck_assert(!cc_pod_is_pod_sandbox(config));
 
 	config->pod = g_malloc0 (sizeof (struct cc_pod));
 	ck_assert(config->pod);
 
 	config->pod->sandbox = false;
-	ck_assert(!cc_pod_is_sandbox(config));
+	ck_assert(!cc_pod_is_pod_sandbox(config));
 
 	config->pod->sandbox = true;
-	ck_assert(cc_pod_is_sandbox(config));
+	ck_assert(cc_pod_is_pod_sandbox(config));
+
+	/* clean up */
+	cc_oci_config_free (config);
+} END_TEST
+
+START_TEST(test_cc_pod_is_pod_container) {
+	struct cc_oci_config *config = NULL;
+
+	ck_assert(!cc_pod_is_pod_container(config));
+
+	config = cc_oci_config_create ();
+	ck_assert(config);
+	ck_assert(!cc_pod_is_pod_container(config));
+
+	config->pod = g_malloc0 (sizeof (struct cc_pod));
+	ck_assert(config->pod);
+
+	config->pod->sandbox = false;
+	ck_assert(cc_pod_is_pod_container(config));
+
+	config->pod->sandbox = true;
+	ck_assert(!cc_pod_is_pod_container(config));
 
 	/* clean up */
 	cc_oci_config_free (config);
@@ -109,7 +131,8 @@ Suite* make_pod_suite(void) {
 	Suite* s = suite_create(__FILE__);
 
 	ADD_TEST (test_cc_pod_container_id, s);
-	ADD_TEST (test_cc_pod_is_sandbox, s);
+	ADD_TEST (test_cc_pod_is_pod_sandbox, s);
+	ADD_TEST (test_cc_pod_is_pod_container, s);
 	ADD_TEST (test_cc_pod_is_vm, s);
 
 	return s;


### PR DESCRIPTION
cc-oci-runtime list would always return `stopped` for pod containers.
Pod containers are shim controlled containers, but they're not associated to a VM, so `cc_oci_vm_running` would always return false on them.

This PR generalizes `cc_oci_vm_running` to `cc_oci_container_running` and consider both VM linked containers (Docker containers and pod sandbox containers) as well as pod containers.