### PR TITLE
configure.ac: Add -D_FORTIFY_SOURCE=2 optimization

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,9 @@ AS_IF([test "x$enable_debug" = "xyes"],
        LDFLAGS=`echo "$LDFLAGS" | sed -e "s/ -g\b/ -ggdb3/g"`
       ]])
 
+AS_IF([test "x$enable_debug" = "xno"],
+      [[CFLAGS=`echo "$CFLAGS" | sed -e "s/ -O[1-9s]*\b/& -D_FORTIFY_SOURCE=2/g"`]])
+
 AC_ARG_ENABLE(tests, AS_HELP_STRING([--enable-tests], [build unit tests @<:@default=yes@:>@]),
           [], [enable_tests=yes])
 AS_IF([test x"$enable_tests" = "xyes"],


### PR DESCRIPTION
In order to harden the build and the overall security of the project, this patch enables FORTIFY_SOURCE optimization in case the flag --enable-debug is not detected.

Indeed, when debug is enabled, the -O flag is set to -O0, and the option FORTIFY_SOURCE expect at least -O1 to be properly enabled.