### PR TITLE
Makefile: Ensure noexecstack and relro are enabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -140,7 +140,7 @@ AM_CFLAGS = -std=gnu99 -fstack-protector -Wall -pedantic \
 	-Wconversion -Wunreachable-code \
 	-fPIE
 
-AM_LDFLAGS = -pie
+AM_LDFLAGS = -pie -z noexecstack -z relro -z now
 
 # We set --with-systemdunitdir here so make distcheck can run make install as a
 # normal user and not fail.


### PR DESCRIPTION
As we want to increase the security of the project, we want to make sure we have both noexecstack and relro flags enabled. By default on several distributions, gcc will enable those flags, but we don't want to end up with a case where those flags are not enabled.

About the details of these flags, noexecstack protects the stack from being executed, while relro protects against data relocation.