### PR TITLE
exec: Short option for --tty should be -t

### DIFF
--- a/src/commands/exec.c
+++ b/src/commands/exec.c
@@ -117,7 +117,7 @@ static GOptionEntry options_exec[] =
 		NULL
 	},
 	{
-		"tty", '0' , G_OPTION_FLAG_NONE,
+		"tty", 't' , G_OPTION_FLAG_NONE,
 		G_OPTION_ARG_NONE, &start_data.allocate_tty,
 		"allocate a pseudo-TTY for the new exec process",
 		NULL


### PR DESCRIPTION
Probably just a copy/paste effect in action. runc abbreviates --tty
with -t as well.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>