### PR TITLE
tests - add timeout for cri-o tests

### DIFF
--- a/.ci/ci-configure.sh
+++ b/.ci/ci-configure.sh
@@ -55,6 +55,7 @@ then
 else
     configure_opts+=" --disable-docker-tests"
     configure_opts+=" --disable-functional-tests"
+    configure_opts+=" --disable-crio-tests"
 fi
 
 (cd "$ci_build_dir" && \

--- a/Makefile.am
+++ b/Makefile.am
@@ -402,7 +402,7 @@ if CRIO_TESTS
 CHECK_DEPS += crio-tests
 GENERATED_FILES += tests/lib/test-crio.bats
 crio-tests: cc-oci-runtime cc-proxy cc-shim tests/lib/test-crio.bats
-	@$(BATS_PATH) -t $(srcdir)/tests/integration/cri-o
+	@timeout 4m $(BATS_PATH) -t $(srcdir)/tests/integration/cri-o
 endif
 
 #### tests ####


### PR DESCRIPTION
When there is something wrong running the cri-o tests, some cri-o
processes get hanged and the test does not finish, this affects the
CI.
Normally, the test takes around 2 minutes to be executed succesfully,
so this commit adds a timeout of 4 minutes to complete the cri-o test.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>