### PR TITLE
release: version 2.1.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.1])
+AC_INIT([cc-oci-runtime], [2.1.2])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
2.1.2:
	Enabled noexecstack and relro
	Added -D_FORTIFY_SOURCE=2 optimization
	Fixed runtime list for pod containers
	Added a pod container check
	Added script to install clear container in RHEL
	Added CRI-O integration tests
	Fixed mac address for configuring network interface
	Updated image version to get latest hyperstart changes
	Added scalability tests
	Added tool for memory mapping
	Fixed intra pod containers volume support
	Honoured detach option in exec command
	Add version details to log file
	Added --all option to kill command
	Added fedora installation details
	Added RHEL installation details
	Added support to measure RSS and PSS
	Added MTU tests using swarm
	Added ciao-down documentation for clear containers
	Added cgroup file creation test
	Created cgroups for pods and containers

Shortlog:
	bf7c483 exec: Short option for --tty should be -t
	a76a2f5 Makefile: Ensure noexecstack and relro are enabled
	df38461 configure.ac: Add -D_FORTIFY_SOURCE=2 optimization
	7815d4f Makefile: Add build hardening with -fPIE flag
	71a6fec tests: fix setup command that kills running containers
	b1ba8bc oci: Fix runtime list for pod containers
	e95a090 pod: Add a pod container check
	a4e9eb8 networking: Remove misplaced comment which is no longer required.
	ed54a09 oci: Remove definitions no longer used.
	223aa3c networking: Remove the comment as it is no longer relevant.
	04fe801 Installation of cc-oci-runtime in RHEL
	f12e212 mount: Fix mount path for pod sandbox containers
	6a44918 tests: Add CRI-O integration test
	606db38 networking: Drop unused networking functions and definitions
	166c364 networking: Drop pcie bus,slot parameters from qemu interface options
	30c54f4 networking: Pass the mac address for configuring network interface
	97f50c2 networking: If fetching mac address failed, then exit early
	ed66be8 networking: If mac address is not found return NULL
	1a977d5 versions: Update image version to get latest hyperstart changes
	4537319 test/metrics: add scalability tests
	7141ea7 tests/metrics: Add tool for memory mapping
	34957ee proxy: README: Add sudo to journalctl command
	25e7432 Docs: README: Add GO requirements
	9a33b7d runtime: check if cc-shim is running before stop it
	2038e66 mount: Fix intra pod containers volume support
	ba578ee ci: Display unified diff with what gofmt wants us to change
	7bc87e2 docs: Render ciao-down in fixed font.
	fa986b8 docs: Fix GOPATH in ciao-down example.
	98e520c pod: Constify some of the API arguments
	385339e docs: Fedora Install: Fix headings tags
	21f7ef0 runtime: honour detach option in exec command
	59b00c9 update .gitignore
	b444105 logging: Add version details to log file
	7ed5952 docs: Remove use of lsb_release(1) in Ubuntu install guide.
	a06082d runtime: add --all option to kill command
	0558ac3 docs: Use EOF rather than EOL for here-doc consistency.
	4c27864 docs: Remove erroneous here-document syntax from Ubuntu install guide.
	704bb0b documentation: add fedora installation details
	cef4d06 Documentation: cc-oci-runtime on RHEL
	022384d tests/metrics: Add support to measure RSS and PSS
	c8dccc0 Test: Remove all function from docker ps
	903cfd4 docs: add reviewer for documentation on pullapprove
	ed1fb83 Tests: Delete function clean_swarm_status
	dfec83f tests: generate test-common.bash for docker-tests
	d558819 Test: MTU tests using Swarm
	0daa37c mount: Remove bogus parameter check
	0a66266 tests: return exit code diff from zero if a test fail
	c088c3f tests: Fix assertions.
	dcc41f7 mount: Fix parameter checks.
	6c4668a Build: Distribute vendor directory.
	02e17af CI: Stop go static checks considering vendor packages.
	2539d25 Documentation: ciao-down support for clear containers
	5e55673 Test: Add new functions to DNS test
	a92cf63 tests: Add a cgroup file creation test
	beef2bc oci: Handle the pod mount points separately
	0e41e88 pod: Wait and pause the shim when creating a pod container
	e2d9a34 mount: Factorize mount points handling routines
	afeb370 proxy: Do not try to create users/groups for pods
	fb4b0b1 oci: Create cgroups for pods and containers
	f98edd4 doc: Update qemu-lite link
	5264af7 dist: moves genfile.sh to extra dist

Signed-off-by: Julio Montes <julio.montes@intel.com>