### PR TITLE
install: Fix Clear Containers Docker config generation.

### DIFF
--- a/installation/rhel-setup.sh
+++ b/installation/rhel-setup.sh
@@ -106,8 +106,8 @@ make -j5 && sudo make install
 popd
 
 # Configure CC by default
-mkdir -p /etc/systemd/system/docker.service.d/
-cat > /etc/systemd/system/docker.service.d/clr-containers.conf << EOF
+sudo mkdir -p /etc/systemd/system/docker.service.d/
+cat <<EOF|sudo tee /etc/systemd/system/docker.service.d/clr-containers.conf
 [Service]
 ExecStart=
 ExecStart=/usr/bin/dockerd -D --add-runtime cor=/usr/local/bin/cc-oci-runtime --default-runtime=cor


### PR DESCRIPTION
The last two commands in rhel-setup.sh must be run as root so require
the use of sudo(8) for consistency with the rest of the script.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>