### PR TITLE
release: version 2.1.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.2])
+AC_INIT([cc-oci-runtime], [2.1.3])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
2.1.3:
	Fixed compatibility with docker v17.03.1-ce
	Added iperf tests to measure network

Shortlog:
	a68d318 metrics: Add cc-bootchart.conf
	eb1dfd0 tests/metrics: networking. fixup double space in iperf3 script
	6cf02dc tests/metrics: networking, iperf3 tests - describe functions
	f2bfa1a tests/metrics: networking. iperf3. Combine identical client/server test
	d1b5f13 runtime: remove unused state
	3972250 runtime: delete command must terminate the VM
	09e48fc runtime: Add validation to avoid any possibility of an overrun
	bfe3196 tests: do not fail if pid file does not exist
	af1d8e2 tests: fix test according to new kill workflow
	0e69d1f runtime: add -w option to cc-shim
	635b545 runtime: redesign kill command workflow
	f303930 shim: Add new option to kill the VM when shim is the initial workload
	08902ca runtime: do not show message error if cgroup dir doesn't exist
	127e8fc tests: add docker test to check exit code
	cf31941 Metrics: Network Measurements using Iperf3
	b34adc0 Fix CC memory footprint calculation
	5b955b4 install: Fix Clear Containers Docker config generation.
	dccd1d8 Metrics: Network Measurement using Iperf
	ec9b875 hooks: If the exec call to hooks fails, exit with failure.

Signed-off-by: Julio Montes <julio.montes@intel.com>