### PR TITLE
Add 'make metrics-tests' rule to execute all metrics

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -411,6 +411,15 @@ crio-tests: cc-oci-runtime cc-proxy cc-shim tests/lib/test-crio.bats
 	@timeout 4m $(BATS_PATH) -t $(srcdir)/tests/integration/cri-o
 endif
 
+if METRICS_TESTS
+METRICS_PATH := "$(abs_top_srcdir)/tests/metrics"
+metrics-tests: cc-oci-runtime cc-proxy cc-shim $(GENERATED_FILES)
+	@pushd $(METRICS_PATH); \
+	./run_docker_metrics; \
+	popd ; \
+	echo "Metrics results can be found on $(METRICS_PATH)/results"
+endif
+
 #### tests ####
 if BUILD_TESTS
 

--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,19 @@ AS_IF([test x"$run_docker_tests" = x"yes"],
     [AC_SUBST([DOCKER_TESTS], [0])])
 AM_CONDITIONAL([DOCKER_TESTS], [test x"$run_docker_tests" = x"yes"])
 
+# Metrics tests
+AC_ARG_ENABLE(metrics-tests, AS_HELP_STRING([--disable-metrics-tests],
+              [disable metrics tests @<:@default=no@:>@]))
+
+AS_IF([test x"$enable_metrics_tests" = x"yes" -o x"$enable_metrics_tests" = x""],
+    [run_metrics_tests=yes],
+    [run_metrics_tests=no])
+
+AS_IF([test x"$run_metrics_tests" = x"yes"],
+    [AC_SUBST([METRICS_TESTS], [1])],
+    [AC_SUBST([METRICS_TESTS], [0])])
+AM_CONDITIONAL([METRICS_TESTS], [test x"$run_metrics_tests" = x"yes"])
+
 # CRI-O integration tests
 AC_ARG_ENABLE(crio-tests, AS_HELP_STRING([--disable-crio-tests],
               [disable CRI-O tests @<:@default=no@:>@]))

--- a/tests/metrics/README.md
+++ b/tests/metrics/README.md
@@ -4,19 +4,21 @@
 Some tests require you to enable the debug mode of cc-oci-runtime. To enable it, please take a look at:
 https://github.com/01org/cc-oci-runtime#18running-under-docker
 
-To run the metrics, just run:
+
+### Run all metrics tests
+To run the metrics, please use the Makefile rule `metrics-tests` on the top level of this repository:
 
 ```bash
-$ cd tests/metrics
-$ ./run_docker_metrics
+$ sudo -E PATH=$PATH make metrics-tests
 ```
 
 This will run all metrics tests and generete a `results` directory.
 
-Each file in the `result` directory contains the result for a test and has the format of a CSV.
+Each file in the `results` directory contains the result for a test as a comma separated values or CSV.
 At the end of each file you will find the result average of all the data collected by the test.
 
-You can also run each tests script separately. e.g.
+Execute `sudo -E PATH=$PATH make metrics tests` to generate the necessary files to run individual tests.
+For example:
 
 ```bash
 $ cd tests/metrics

--- a/tests/metrics/run_docker_metrics
+++ b/tests/metrics/run_docker_metrics
@@ -1,23 +1,19 @@
 #!/bin/bash
 
 source ./run_docker_metrics.dat
+
+# Verify that test-common.bash is generated.
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+[ -f "${SCRIPT_PATH}/../lib/test-common.bash" ] || \
+	{ echo "Required files are not generated, please run 'sudo make metrics-tests' from top level of this repo" \
+	&& exit 1; }
+
+
 RESULT_DIR="./results"
 
 if [ ! -d "$RESULT_DIR" ]; then
 	mkdir "$RESULT_DIR"
 fi
-
-IN_FILES=(workload_time/cor_create_time.sh.in)
-
-#generate files if they do not exist
-for inf in ${IN_FILES[@]}; do
-	outf="`dirname \"${inf}\"`/`basename -s '.in' \"${inf}\"`"
-	if [ ! -f "${outf}" ]; then
-		PACKAGE_NAME=cc-oci-runtime \
-		../../data/genfile.sh "${inf}" "${outf}"
-		chmod +x "${outf}"
-	fi
-done
 
 # complete workload : docker run --runtime $runtime -tid $image $cmd
 bash workload_time/docker_workload_time.sh true ubuntu runc "$TIMES"
@@ -37,5 +33,5 @@ bash density/docker_cpu_usage.sh "$TIMES" "$CPU_WAIT_TIME"
 bash density/docker_memory_usage.sh "$MEM_CONTAINERS" "$MEM_WAIT_TIME"
 
 # kernel boot time
-bash workload_time/kernel_boot_time.sh $TIMES
+bash workload_time/kernel_boot_time.sh "$TIMES"
 bash workload_time/kernel_boot_time_stress.sh


### PR DESCRIPTION
This PR contains 3 commits:

- metrics - Add Makefile rule to run metrics tests
This new Makefile rule will run all metrics tests in
tests/metrics/run_docker_metrics and will generate the files
needed to execute them

- metrics doc - update metrics README
This change documents how to execute the new rule to
execute the metrics tests.

- metrics - abort metrcis tests if generated files are missing
This commit will verify if the test/lib/test-common.bash is
already generated before running the metrics tests. It will
also tell you to use the Makefile rule 'make metrics-test' so
the missing files are generated.