### PR TITLE
proxy: Restrict the socket and parent directory modes

### DIFF
--- a/proxy/cc-proxy.socket.in
+++ b/proxy/cc-proxy.socket.in
@@ -5,6 +5,8 @@ PartOf=cc-proxy.service
 
 [Socket]
 ListenStream=@localstatedir@/run/cc-oci-runtime/proxy.sock
+DirectoryMode=0770
+SocketMode=0660
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
We don't need those sockets to be read/writable to the whole world. Only
root is enough.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>