### PR TITLE
oci: add support for OCI 1.0.0-rc5

### DIFF
--- a/src/oci.h
+++ b/src/oci.h
@@ -227,6 +227,12 @@ struct oci_cfg_process {
 
 	struct oci_cfg_user  user;
 
+	/** terminal rows */
+	int rows;
+
+	/** terminal columns */
+	int columns;
+
 	/** Stream IO ids allocated by \c cc_proxy_allocate_io */
 	gint                 stdio_stream;
 	gint                 stderr_stream;

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1417,6 +1417,14 @@ cc_proxy_run_hyper_new_container (struct cc_oci_config *config,
 	json_object_set_boolean_member (newcontainer_payload,
 			"initialize", false);
 
+	if (config->oci.process.columns > 0) {
+		json_object_set_int_member (process, "columns", config->oci.process.columns);
+	}
+
+	if (config->oci.process.rows > 0) {
+		json_object_set_int_member (process, "rows", config->oci.process.rows);
+	}
+
 	json_object_set_array_member (process, "args", args);
 	json_object_set_array_member (process, "envs", envs);
 	json_object_set_object_member (newcontainer_payload,

--- a/src/spec_handlers/process.c
+++ b/src/spec_handlers/process.c
@@ -42,6 +42,25 @@ handle_user_section (GNode *root, struct cc_oci_config *config)
 	}
 }
 
+/*!
+ * function to handle consoleSize section
+ *
+ * \param root contains mount section.
+ * \param config \ref cc_oci_config..
+ */
+static void
+handle_console_size_section (GNode *root, struct cc_oci_config *config) {
+	if (! (root && config)) {
+		return;
+	}
+
+	if (g_strcmp0(root->data, "height") == 0) {
+		config->oci.process.rows = (int)atoi (root->children->data);
+	} else if (g_strcmp0(root->data, "width") == 0) {
+		config->oci.process.columns = (int)atoi (root->children->data);
+	}
+}
+
 static void
 handle_process_section(GNode* root, struct cc_oci_config* config) {
 	if (! (root && root->children)) {
@@ -64,6 +83,9 @@ handle_process_section(GNode* root, struct cc_oci_config* config) {
 	} else if(g_strcmp0(root->data, "user") == 0) {
 		g_node_children_foreach (root, G_TRAVERSE_ALL,
 				(GNodeForeachFunc)handle_user_section, config);
+	} else if(g_strcmp0(root->data, "consoleSize") == 0) {
+		g_node_children_foreach (root, G_TRAVERSE_ALL,
+				(GNodeForeachFunc)handle_console_size_section, config);
 	} else if(g_strcmp0(root->data, "stdio_stream") == 0) {
 		config->oci.process.stdio_stream = atoi (root->children->data);
 	} else if(g_strcmp0(root->data, "stderr_stream") == 0) {
@@ -86,6 +108,8 @@ process_handle_section(GNode* root, struct cc_oci_config* config)
 
 	config->oci.process.stdio_stream = -1;
 	config->oci.process.stderr_stream = -1;
+	config->oci.process.rows = -1;
+	config->oci.process.columns = -1;
 
 	g_node_children_foreach(root, G_TRAVERSE_ALL,
 		(GNodeForeachFunc)handle_process_section, config);

--- a/tests/data/process-invalid-relative-cwd.json
+++ b/tests/data/process-invalid-relative-cwd.json
@@ -1,5 +1,9 @@
 {
 	"process": {
+		"consoleSize": {
+			"height": 15,
+			"width": 15
+		},
 		"terminal": true,
 		"user": {
 			"uid": 0,

--- a/tests/data/process-no-args-cwd.json
+++ b/tests/data/process-no-args-cwd.json
@@ -1,5 +1,9 @@
 {
 	"process": {
+		"consoleSize": {
+			"height": 15,
+			"width": 15
+		},
 		"terminal": true,
 		"user": {
 			"uid": 0,

--- a/tests/data/process-no-consolesize.json
+++ b/tests/data/process-no-consolesize.json
@@ -1,0 +1,17 @@
+{
+	"process": {
+		"terminal": true,
+		"user": {
+			"uid": 0,
+			"gid": 0
+		},
+		"args": [
+			"sh"
+		],
+		"env": [
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"TERM=xterm"
+		],
+		"cwd": "/"
+	}
+}

--- a/tests/data/process-no-cwd.json
+++ b/tests/data/process-no-cwd.json
@@ -1,5 +1,9 @@
 {
 	"process": {
+		"consoleSize": {
+			"height": 15,
+			"width": 15
+		},
 		"terminal": true,
 		"user": {
 			"uid": 0,

--- a/tests/data/process.json
+++ b/tests/data/process.json
@@ -1,5 +1,9 @@
 {
 	"process": {
+		"consoleSize": {
+			"height": 15,
+			"width": 15
+		},
 		"terminal": true,
 		"user": {
 			"uid": 0,

--- a/tests/functional/data/config-minimal-cc-oci.json.in
+++ b/tests/functional/data/config-minimal-cc-oci.json.in
@@ -5,6 +5,10 @@
 		"arch": "amd64"
 	},
 	"process": {
+		"consoleSize": {
+			"height": 15,
+			"width": 15
+		},
 		"terminal": false,
 		"user": {
 			"uid": 0,

--- a/tests/spec_handlers/process_test.c
+++ b/tests/spec_handlers/process_test.c
@@ -34,6 +34,7 @@ static struct spec_handler_test tests[] = {
 	{ TEST_DATA_DIR "/process-invalid-relative-cwd.json" , false },
 	{ TEST_DATA_DIR "/process-no-cwd.json"               , false },
 	{ TEST_DATA_DIR "/process-no-args-cwd.json"          , false },
+	{ TEST_DATA_DIR "/process-no-consolesize.json"       , true  },
 	{ TEST_DATA_DIR "/process.json"                      , true  },
 	{ NULL                                               , false },
 };


### PR DESCRIPTION
console size can be specified in config.json this patch
add support to handle this case and change console size
when container is launched

Fixes #690

Signed-off-by: Julio Montes <julio.montes@intel.com>