### PR TITLE
release: version 2.1.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.3])
+AC_INIT([cc-oci-runtime], [2.1.4])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
2.1.4
	Fixed cc-proxy socket and parent directory modes

Shortlog:
	841d8e7 docs: update clear containers image version
	00f182b fdleak: Handle nil snapshots in Compare
	80426a5 Metrics: Improve readability for iperf2 metrics
	3338dc8 proxy: Restrict the socket and parent directory modes
	138c09f Metrics: Improve readability
	899bb76 tests: kill a container with a no termination signal

Signed-off-by: Julio Montes <julio.montes@intel.com>