### PR TITLE
release: version 2.1.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.4])
+AC_INIT([cc-oci-runtime], [2.1.5])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
2.1.5:
	Fixed failure when trying to create a pod #815
	Added network test using nginx and ab
	Added support for OCI Runtime Specification 1.0.0-rc5
	Fixed failure obtaining host name of a replica in Swarm #578
	Added installation script for RHEL and CentOS

Shortlog:
	11d81fb networking: Disable udev from assigning predictable interface names
	27284c8 Metrics: Network test using nginx and ab
	4e133fe version: Update kernel to version 4.5-57
	70fc5d4 version: Update container image version to 14700
	32a5f18 tests: add json file to test process without consoleSize
	e8cc984 networking: Skip sending iptable rules to hyperstart while running tests
	047fd21 tests: Unskip test to obtain hostname of a replica in Swarm
	b46f03f networking: Send the iptable rules to hyperstart.
	7b13aaa networking: Save and flush iptable rules in the net namespace
	7aaf895 install: Handle RHEL systems without dev packages.
	c9384e7 metrics - abort metrics tests if generated files are missing
	82bd7a4 metrics doc - update metrics README
	e57b541 metrics - Add Makefile rule to run metrics tests
	bb48780 install: Add description to "rhel-setup.sh" script.
	17240ea install: Use correct repo when installing Clear Containers assets.
	2d24ff2 install: Don't update yum packages twice.
	6760124 CI: only set GOROOT if not already set.
	bed9495 install: Use "$deps_dir" for CentOS/RHEL.
	33369c4 install: Use auto $GOPATH for CentOS/RHEL install.
	4781e78 install: Restart services for CentOS/RHEL.
	7978ef9 install: Install docker for CentOS/RHEL.
	7d38009 install: Install golang using sudo.
	d322b0e install: Set "$prefix_dir" before sourcing scripts.
	6805ae1 CI: Only set "prefix_dir" if running under CI.
	fb06752 install: Don't install "clear-containers-selinux" for CentOS/RHEL.
	b6f9dc5 install: Use $prefix_dir for CentOS/RHEL docker configuration.
	77e8747 install: build gmp before mpfr for CentOS/RHEL.
	6388bc3 install: Don't install old repo dev packages for CentOS/RHEL.
	ac80051 Install: Correct libmnl dev package name.
	6e636db Install: Improve comment.
	3ec6cda install: Create new branch for installation.
	01514f2 install: Install missing packages required for CentOS/RHEL.
	b74af89 install: Set prefix_dir for CentOS and not just RHEL.
	bdb3c79 install: Remove RHEL-specific code to handle missing chronic(1).
	3c335bd install: Fix whitespace

Signed-off-by: Julio Montes <julio.montes@intel.com>