### PR TITLE
versions: Specifies a version of autoconf-archive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,7 +198,7 @@ installed on your system:
 - json-glib
 - libmnl
 - uuid
-- autoconf-archive
+- autoconf-archive - version 2017.03.21 or above
 
 Configure Stage
 ~~~~~~~~~~~~~~~

--- a/configure.ac
+++ b/configure.ac
@@ -32,10 +32,12 @@ AC_LANG(C)
 
 LT_INIT
 
+source $srcdir/versions.txt
+
 # Check for macros
 AC_DEFUN_ONCE([MACRO_CHECK],
 [
-	ifdef([$1], true, [AC_FATAL([Please install autoconf-archive],)])
+	ifdef([$1], true, [AC_FATAL([Please install autoconf-archive version ${autoconf_archive_version}],)])
 ])
 
 MACRO_CHECK([AX_VALGRIND_DFLT])
@@ -154,8 +156,6 @@ AS_IF([test x"$run_crio_tests" = x"yes"],
 AM_CONDITIONAL([CRIO_TESTS], [test x"$run_crio_tests" = x"yes"])
 
 # Checks for libraries.
-source $srcdir/versions.txt
-
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= "$glib_version"], have_required_glib=yes, have_required_glib=no)
 AS_IF([test "$have_required_glib" != "yes"], AC_MSG_ERROR([ERROR: need glib ${glib_version}+ for the `G_FILE_MONITOR_WATCH_MOVES' flag]))
 

--- a/versions.txt
+++ b/versions.txt
@@ -14,3 +14,4 @@ qemu_lite_version=741f430a960b5b67745670e8270db91aeb083c5f
 mpfr_version=3.1.4
 gmp_version=6.1.0
 mpc_version=1.0.3
+autoconf_archive_version=2017.03.21


### PR DESCRIPTION
version 2017.03.21 of autoconf-archive is required
because this version contains a macro (AX_VALGRIND_DFLT)
to enable or disable valgrind tests

Signed-off-by: Julio Montes <julio.montes@intel.com>