### PR TITLE
docs: Install: Fedora: Fix broken markdown hotlink

### DIFF
--- a/documentation/Installing-Clear-Containers-on-Fedora-25.md
+++ b/documentation/Installing-Clear-Containers-on-Fedora-25.md
@@ -59,7 +59,9 @@ Note: this should not be necessary if you update `--default-runtime` setting in 
 ## Increase limits (optional)
 If you are running a recent enough kernel (4.3+), you should consider
 increasing the `TasksMax=` systemd setting. Without this, the number of
-Clear Containers you are able to run will be limited.  A sample of the error which may manifest can be seen at [issue 154] (https://github.com/01org/cc-oci-runtime/issues/154).
+Clear Containers you are able to run will be limited.  A example of the error
+which may occur can be seen at:
+[issue 154](https://github.com/01org/cc-oci-runtime/issues/154).
 
 
 Run the commands below and if they display `OK`, proceed, else skip this


### PR DESCRIPTION
A hotlink was using '[] ()', where the inter-bracket space breaks
markdown rendering of the hotlink on github at least. Fix it (remove
the space).

Fixes #857 (issue is referenced in that ticket)

Signed-off-by: Graham Whaley <graham.whaley@intel.com>