### PR TITLE
release: version 2.1.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.5])
+AC_INIT([cc-oci-runtime], [2.1.6])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
- Fixed: docker: Error response from daemon: shim error: open pid: no such file
  or directory on Centos #850
- Fixed: hyperstart failures when running cc-oci-runtime on Ubuntu #837
- Metrics: CPU % consumption for network
- Updated kernel version to 4.9.24-60

Short log:

11bedb3 docs: Require every PR to include a "Fixes #XXX" comment.
aa3f234 docs: contrib: Fix hotlinks in contributing document
a210cc4 versions: Specifies a version of autoconf-archive
b67f0f7 Metrics: CPU % consumption for network
06a5340 version: Update versions of linux kernel and qemu-lite
d1fd072 tests: Adds new target to run valgrind tests
4c8cb61 ci: Download code coverage and valgrind m4 files
ae8ac0a autogen: create m4 directory before autoreconf
b8691c5 installation: Download m4 files archives in RHEL
3be9a9c dist: Adds missing extra dist files
6f5b91d license: rename COPYING to LICENSE
63d6a2b Metrics: UDP Network Bandwidth
0b3c401 data: remove 2.0 systemd files
9134862 gitignore: Adds m4/ directory to ignore list
17332c1 docs: Adds autoconf-archive to dependencies list
510f7e2 m4: Removes valgrind and code coverage m4 files
3ff51f7 configure: Adds macro to check if all required macros are installed
9b9eb99 docs: Remove duplicate call to sudo(8).
f77e259 Documentation: Install cc-oci-runtime on RHEL 7.3

Fixes #863

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>