### PR TITLE
Metrics: Measure PSS memory while running network

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,6 +68,7 @@ GENERATED_FILES = \
 	tests/metrics/density/docker_memory_usage.sh \
 	tests/metrics/workload_time/cor_create_time.sh \
 	tests/metrics/network/network-metrics-cpu-consumption.sh \
+	tests/metrics/network/network-metrics-memory-pss.sh \
 	tests/lib/test-common.bash
 
 $(GENERATED_FILES): %: %.in Makefile
@@ -372,6 +373,7 @@ EXTRA_DIST = \
 	tests/metrics/density/docker_memory_usage.sh.in \
 	tests/metrics/workload_time/cor_create_time.sh.in \
 	tests/metrics/network/network-metrics-cpu-consumption.sh.in \
+	tests/metrics/network/network-metrics-memory-pss.sh.in \
 	vendor \
 	data/genfile.sh \
 	data/cc-bootchart.conf

--- a/tests/metrics/network/network-metrics-memory-pss.sh.in
+++ b/tests/metrics/network/network-metrics-memory-pss.sh.in
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2017 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Description:
+#  Measures Proportional Set Size memory while running an 
+#  inter (docker<->docker) network bandwidth using iperf2
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+
+source "${SCRIPT_PATH}/../../lib/test-common.bash"
+
+# Port number where the server will run
+port=5001:5001
+# Using this image as iperf is not working
+# see (https://github.com/01org/cc-oci-runtime/issues/152)
+# Image name
+image=gabyct/network
+# Total measurement time (seconds)
+# This is required in order to reduce standard deviation
+total_time=10
+# This time (seconds) is required when
+# server and client are more stable, we need to
+# have server and client running for sometime and we
+# need to avoid to measure at the beginning of the running
+middle_time=5
+
+function setup {
+	runtime_docker
+	kill_processes_before_start
+}
+
+# This script will perform all the measurements using a local setup
+
+# Measures PSS memory while running bandwidth measurements
+# using iperf2
+
+function pss_memory {
+	setup
+	total_memory=$(mktemp)
+	server_name="iperf-server"
+	client_name="iperf-client"
+
+	server_command="iperf -p ${port} -s"
+	$DOCKER_EXE run -d --name=${server_name} ${image} bash -c "${server_command}" > /dev/null
+	server_address=$($DOCKER_EXE inspect --format "{{.NetworkSettings.IPAddress}}" $($DOCKER_EXE ps -ql))
+
+	client_command="iperf -c ${server_address} -t ${total_time}"
+	$DOCKER_EXE run -d --name=${client_name} ${image} bash -c "${client_command}" > /dev/null
+
+	# Measurement after client and server are more stable
+	echo >&2 "WARNING: sleeping for $middle_time seconds in order to have server and client stable"
+	sleep ${middle_time}
+	smem -c "pss" -P @QEMU_PATH@ | tail -n 2 > "$total_memory"
+	total_pss_memory=$(awk '{ total += $1 } END { print total/NR }' "$total_memory")
+
+	$DOCKER_EXE rm -f ${server_name} > /dev/null
+	$DOCKER_EXE rm -f ${client_name} > /dev/null
+	rm -f "$total_memory"
+}
+
+pss_memory
+echo "The PSS memory is : $total_pss_memory Kb"


### PR DESCRIPTION
Measure Proportional Set Size Memory using smem while
running a bandwidth measurement using iperf2

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>