### PR TITLE
install: Extract autoconf-archive install to separate script

### DIFF
--- a/installation/curl-autoconf-archive.sh
+++ b/installation/curl-autoconf-archive.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2017 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+# Description: This script downloads and installs the autoconf-archive macros
+#   necessary to configure this project. This is invoked for distro builds where
+#   the necessary package is not available to install, and is also useful to
+#   hand run under certain circumstances.
+#   Should be run from the top level directory
+#
+
+# autoconf-archive url
+autoconf_archive_url="http://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=blob_plain;f=m4"
+mkdir -p m4/
+# curl the required autoconf archive files into the correct place
+curl -L "${autoconf_archive_url}/ax_code_coverage.m4" -o m4/ax_code_coverage.m4
+curl -L "${autoconf_archive_url}/ax_valgrind_check.m4" -o m4/ax_valgrind_check.m4

--- a/installation/rhel-setup.sh
+++ b/installation/rhel-setup.sh
@@ -152,15 +152,12 @@ cor=github.com/01org/cc-oci-runtime
 # Currently it is the latest version for cc-oci-runtime
 commit=tags/2.1.9
 release=${commit##*/}
-# autoconf-archive url
-autoconf_archive_url="http://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=blob_plain;f=m4"
 go get "$cor"
 pushd "$GOPATH/src/$cor"
 git checkout -b "$release" "$commit"
-mkdir -p m4/
-# autoconf-archive package does not exist in RHEL we need to download all m4 files required
-curl -L "${autoconf_archive_url}/ax_code_coverage.m4" -o m4/ax_code_coverage.m4
-curl -L "${autoconf_archive_url}/ax_valgrind_check.m4" -o m4/ax_valgrind_check.m4
+# autoconf-archive package does not exist in RHEL we need to download all m4
+# files required
+source "${SCRIPT_PATH}/curl-autoconf-archive.sh"
 ./autogen.sh \
     --prefix="${prefix_dir}" \
     --disable-tests \


### PR DESCRIPTION
Under some circumstances it is needed to 'hand install' the m4
scripts. This was done in the rhel install script, but sometimes
it is really useful to be able to do that by hand, so extract the
relevant commands into their own script (to allow hand running),
and get the rhel script to invoke that new script at the appropriate
time.

Fixes: #875

Signed-off-by: Graham Whaley <graham.whaley@intel.com>