### PR TITLE
release: 2.1.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.6])
+AC_INIT([cc-oci-runtime], [2.1.7])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
- Added shim debug logs when runtime debug option is used #878
- Fixed Kernel panic using swarm #581
- Added Metrics to measure memory running network test #865

9911475 shim: Do not print to stderr as well while logging
95369ca logging: When invoked with debug flag, pass that to the shim
539b082 CI: Add script to perform basic checks on commits.
9c92a15 Metrics: Remove iperf2 tests
001e264 networking: Disable multicast snooping on the bridge we create
ab3d6e4 Metrics: Measure PSS memory while running network

Fixes #881

Signed-off-by: Carlos Venegas <jose.carlos.venegas.munoz@intel.com>