### PR TITLE
build: Update versions.txt to include cc-oci-runtime version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,8 +20,9 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
+
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.8])
+AC_INIT([cc-oci-runtime], m4_esyscmd_s([cat versions.txt  | grep cc_oci_runtime_version | cut -d'=' -f2]))
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])

--- a/versions.txt
+++ b/versions.txt
@@ -15,3 +15,4 @@ mpfr_version=3.1.4
 gmp_version=6.1.0
 mpc_version=1.0.3
 autoconf_archive_version=2017.03.21
+cc_oci_runtime_version=2.1.8


### PR DESCRIPTION
versions.txt should add cc-oci-runtime version.

Automation needs an easy way to access the cc-oci-runtime version
when building packages for diferent distros.

This will require that in future releases versions.txt must be
updated along with configure.ac.

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>