### PR TITLE
Vhostuser network enabling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.3])
+AC_INIT([cc-oci-runtime], [2.1.4])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -302,7 +302,7 @@ AS_IF([test x"$with_tests_bundle_path" != x""],
       [])
 
 #Kernel path for Clear Containers
-DEFAULT_KERNEL_PATH=$localstatedir/lib/$PACKAGE_NAME/data/kernel/vmlinux.container
+DEFAULT_KERNEL_PATH=$localstatedir/lib/$PACKAGE_NAME/data/kernel/vmlinuz.container
 AC_ARG_WITH([cc-kernel],
     [AS_HELP_STRING([--with-cc-kernel=[[KERNEL-PATH]]],
         [clear container kernel path])

--- a/data/hypervisor.args.in
+++ b/data/hypervisor.args.in
@@ -2,7 +2,7 @@
 -name
 @NAME@
 -machine
-pc-lite,accel=kvm,kernel_irqchip,nvdimm
+pc,accel=kvm,kernel_irqchip,nvdimm
 -device
 nvdimm,memdev=mem0,id=nv0
 -object

--- a/documentation/Using-OVS-DPDK-and-COR.md
+++ b/documentation/Using-OVS-DPDK-and-COR.md
@@ -1,0 +1,225 @@
+# Using OVS-DPDK with Clear Containers
+
+The Data Plane Development Kit, or DPDK, is a set of libraries and drivers for
+fast packet processing. Open vSwitch, or OVS, is an open-source implementation
+of a distributed multilayer switch. Enabling DPDK support within OVS can yield
+significant performance improvements over a linux-bridge and also provides a
+switch with DPDK vhost-user ports.
+
+## Installing DPDK and OVS on the host system
+
+The versions of OVS and DPDK are tightly coupled. Versions available via
+distributions are often very out of date. The following instructions assume you
+are building and configuring from the source repos. Update the packages listed
+regularly to ensure your Intel® Clear Containers benefit from performance
+improvements, new features, and CVE security fixes.
+
+### Prerequisites
+
+The following packages are needed on your host to build OVS and DPDK.
+
+* autoconf
+* automake
+* kernel-common
+* libpcap-dev
+* libtool
+* python
+* python-six
+
+For example, install the packages on an Ubuntu host system with the following
+command:
+
+```
+$ sudo apt-get -y install autoconf automake kernel-common \
+    libpcap-dev libtool python python-six
+```
+
+### Installing the DPDK
+
+1. Download the DPDK source code and move into the folder:
+
+   ```
+   $ git clone http://dpdk.org/git/dpdk -b v16.11 $HOME/dpdk
+   $ cd $HOME/dpdk
+   ```
+
+2. Set the environmental variables needed for building:
+
+   ```
+   $ export RTE_SDK=$(pwd)
+   $ export RTE_TARGET=x86_64-native-linuxapp-gcc
+   ```
+
+3. Build the DPDK and copy the binaries to the appropriate folder:
+
+   ```
+   $ make -j install T=$RTE_TARGET DESTDIR=install EXTRA_CFLAGS='-g'
+   $ sudo cp -f install/lib/lib* /lib64/
+   ```
+
+4. Set the environmental variable to the correct folder for the OVS configuration:
+
+   ```
+   $ export DPDK_BUILD_DIR=x86_64-native-linuxapp-gcc
+   ```
+
+### Installing the OVS
+
+Once the DPDK setup completes with out issue, build and configure the OVS with
+the following steps:
+
+1. Download the OVS source code and move into the folder:
+
+   ```
+   $ git clone https://github.com/openvswitch/ovs -b branch-2.6 $HOME/ovs
+   $ cd $HOME/ovs
+   ```
+
+2. Run the `boot.sh` script:
+
+   ```
+   $ ./boot.sh
+   ```
+
+3. Provide the following configuration values:
+
+   ```
+   $ ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var \
+       --with-dpdk="$RTE_SDK/$DPDK_BUILD_DIR"  --disable-ssl --with-debug  CFLAGS='-g'
+   ```
+
+4. Install the OVS with the following Make command:
+
+   ```
+   $ sudo -E make install -j
+   ```
+
+## Running OVS-DPDK on host system
+
+Once both, the OVS and the DPDK, are installed without error, start 
+`ovsdb-server` and `ovs-vswitchd`. The Open_vSwitch configuration settings vary
+depending on the hardware OVS runs on, for example `lcore-mask` and 
+`socket-mem`. The following is an example configuration which should be 
+adjusted for your setup:
+
+1. Create a clean folder for OVS and remove other configurations:
+
+   ```
+   $ sudo mkdir -p /var/run/openvswitch
+   $ sudo killall ovsdb-server ovs-vswitchd
+   $ rm -f /var/run/openvswitch/vhost-user*
+   $ sudo rm -f /etc/openvswitch/conf.db
+   ```
+
+2. Setup the OVS database components:
+
+   ```
+   $ export DB_SOCK=/var/run/openvswitch/db.sock
+   $ sudo -E ovsdb-tool create /etc/openvswitch/conf.db /usr/share/openvswitch/vswitch.ovsschema
+   $ sudo -E ovsdb-server --remote=punix:$DB_SOCK --remote=db:Open_vSwitch,Open_vSwitch,manager_options --pidfile --detach
+   ```
+
+3. Configure OVS's use of the DPDK:
+
+   ```
+   $ sudo -E ovs-vsctl --no-wait init
+   $ sudo -E ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-lcore-mask=0x3
+   $ sudo -E ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-socket-mem=1024,0
+   $ sudo -E ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-init=true
+   ```
+
+4. Configure and mount the `hugepages`:
+
+   ```
+   $ sudo sysctl -w vm.nr_hugepages=4096
+   $ sudo mount -t hugetlbfs -o pagesize=2048k none /dev/hugepages
+   ```
+
+5. Start OVS with the appropriate options:
+
+   ```
+   $ sudo -E ovs-vswitchd unix:$DB_SOCK --pidfile --detach --log-file=/var/log/openvswitch/ovs-vswitchd.log
+   ```
+
+6. Review the status of the OVS process:
+
+   ```
+   $ ps -ae | grep ovs
+   ```
+
+On step **3** of the example, the following configuration options were set for
+the DPDK:
+
+* **dpdk-lcore-mask**: Specifies the CPU cores where DPDK threads should be
+  spawned. The example assigns 0x3 which identifies cores 0 and 1. The setup of
+  the host system determined this decision. Only after monitoring the lspci
+  output to determine which cores are tied to the same NUMA node, could the
+  decision be made.
+
+* **dpdk-socket-mem**: Specifies a list of comma separated values
+  of memory in MB to preallocate from the hugepages on specific sockets. The
+  example requests 1024 MB from socket 0; since cores 0 and 1 are also located
+  on socket 0.
+
+* **dpdk-init**:  Specifies whether OVS should initialize and support DPDK
+  ports.
+
+On step **4** of the example, the number of hugepages mounted at
+`/dev/hugepages` was determined based on the size of memory allocated to each
+VM and the size allocated to OVS itself. Our example will launch two Clear
+Containers using OVS-DPDK. Each container will preallocate 2GB per container
+from hugepages and the OVS-DPDK requires 1GB. Thus, 5GB was the minimum amount
+of memory required to reserve.
+
+Once the steps were followed and modified as necessary, the host system is
+ready to start creating DPDK enabled OVSes.
+
+## Installing the OVSDPDK Docker\* plug-in
+
+To easily create a network and connect the Clear Containers to it via Docker,
+an OVS-DPDK Docker plug-in must be installed.
+
+Details on installing the plug-in are found at
+https://github.com/clearcontainers/ovsdpdk
+
+## Launching two Clear Containers using OVS-DPDK
+
+1. To use of OVS-DPDK, a network is needed. Use Docker to create a network using the OVS-DPDK switch, for example:
+
+   ```
+   $ sudo docker network create -d=ovsdpdk --ipam-driver=ovsdpdk --subnet=192.168.1.0/24 --gateway=192.168.1.1  --opt "bridge"="ovsbr" ovsdpdk_net
+   ```
+
+2. To verify the OVS switch was created, search for the OVS bridge, `ovsbr`, in the output generated by the following command:
+
+   ```
+   $ sudo ovs-vsctl show
+   ```
+
+3. To test the connectivity, launch two containers. The following commands
+   assume Docker is setup to use this branch's runtime.
+
+   1. Launch the first Clear Container, display its networking details, and set
+      it to sleep providing a window for it to be pinged:
+
+      ```
+      $ sudo docker run --net=ovsdpdk_net --ip=192.168.1.2 --mac-address=CA:FE:CA:FE:01:02 -it debian bash -c "ip a; ip route; sleep 300"
+      ```
+
+   2. Launch the second Clear Container, display its networking details, and
+      ping the first container.
+
+      ```
+      $ sudo docker run --net=ovsdpdk_net --ip=192.168.1.3 --mac-address=CA:FE:CA:FE:01:03 -it debian bash -c "ip a; ip route; ping 192.168.1.2"
+      ```
+
+   Once the ping is successful, connectivity between the containers is verified.
+
+4. After verification, cleanup with the following commands:
+
+   ```
+   $ sudo docker kill $(sudo docker ps --no-trunc -aq)
+   $ sudo docker rm $(sudo docker ps --no-trunc -aq)
+   $ sudo docker network rm ovsdpdk_net
+   ```
+

--- a/documentation/Using-VPP-and-COR.md
+++ b/documentation/Using-VPP-and-COR.md
@@ -1,0 +1,62 @@
+# Setup to run VPP
+
+The Data Plane Development Kit (DPDK) is a set of libraries and drivers for
+fast packet processing. The Vector Packet Processing (VPP) is a platform
+extensible framework which provides out-of-the-box production quality
+switch and router functionality. VPP is a high performance packet-processing
+stack which can run on commodity CPUs. Enabling VPP with DPDK support can
+yield significant performance improvements over a Linux\*-bridge providing a
+switch with DPDK vhost-user ports.
+
+For more information about VPP visit their [wiki](https://wiki.fd.io/view/VPP).
+
+## Install VPP
+
+Follow the [VPP installation instructions](https://wiki.fd.io/view/VPP/Installing_VPP_binaries_from_packages).
+
+After a successful installation, your host system is ready to start
+connecting Intel® Clear Containers with VPP bridges.
+
+### Install the VPP Docker\* plugin
+
+To create a network and connect Clear Containers easily to that network via
+Docker, install a VPP Docker plugin.
+
+To install the plugin, you can follow the [plugin installation instructions](https://github.com/clearcontainers/vpp).
+
+This VPP plugin allows the creation of a VPP network. Every container added
+to this network will be connected via an L2 bridge-domain provided by VPP.
+
+## Example: Launch two Clear Containers using VPP
+
+To use VPP, use Docker to create a network which uses the OVS-DPDK switch.
+For example:
+
+```
+$ sudo docker network create -d=vpp --ipam-driver=vpp --subnet=192.168.1.0/24 --gateway=192.168.1.1  vpp_net
+```
+
+Test connectivity by launching two containers, assuming Docker is setup to
+use this branch's runtime:
+
+```
+$ sudo docker run --net=vpp_net --ip=192.168.1.2 --mac-address=CA:FE:CA:FE:01:02 -it debian bash -c "ip a; ip route; sleep 300"
+
+$ sudo docker run --net=vpp_net --ip=192.168.1.3 --mac-address=CA:FE:CA:FE:01:03 -it debian bash -c "ip a; ip route; ping 192.168.1.2"
+```
+
+These commands setup two Clear Containers connected via a VPP L2 bridge
+domain. The first of the the VMs displays the networking details and then
+sleeps providing a period of time for it to be pinged. The second
+VM displays its networking details and then pings the first VM, verifying
+connectivity between them.
+
+After verifying connectivity, cleanup with the following commands:
+
+```
+$ sudo docker kill $(sudo docker ps --no-trunc -aq)
+$ sudo docker rm $(sudo docker ps --no-trunc -aq)
+$ sudo docker network rm vpp_net
+$ sudo service vpp stop
+$ sudo service vpp start
+```

--- a/src/networking.h
+++ b/src/networking.h
@@ -23,6 +23,12 @@
 
 #include "netlink.h"
 
+/* Both openvswitch and VPP will place the vhost-user socket in a particular location,
+ * and we chose to name the interface v_<ip address> during endpoint creation
+ * in the respective Docker plugins.  VHOSTUSER_PORT_PATH is used to identify this file.
+ */
+#define VHOSTUSER_PORT_PATH "/tmp/v_%s"
+
 void cc_oci_net_interface_free (struct cc_oci_net_if_cfg *if_cfg);
 
 void cc_oci_net_ipv4_route_free(struct cc_oci_net_ipv4_route *route);
@@ -35,5 +41,7 @@ gchar * cc_net_get_ip_address(const gint family, const void *const sin_addr);
 
 gboolean cc_oci_network_discover(struct cc_oci_config *const config,
 			struct netlink_handle *hndl);
+
+gboolean is_interface_ovs(struct cc_oci_net_if_cfg* if_cfg);
 
 #endif /* _CC_OCI_NETWORKING_H */

--- a/src/oci.h
+++ b/src/oci.h
@@ -353,6 +353,9 @@ struct cc_oci_net_if_cfg {
 	/** Name of the QEMU tap device */
 	gchar  *tap_device;
 
+	/** Path of vhost-user socket */
+	gchar	*vhostuser_socket_path;
+
 	/** mtu of interface **/
 	unsigned int mtu;
 


### PR DESCRIPTION
PR to enable VPP for POC work on 01org/cc-oci-runtime's network/vhost-user-poc branch.

OVS plugin should be updated to make use of this branch instead of OVS-DPDK POC going forward.

Verified with latest cc-oci-runtime released, 2.1.4.