### PR TITLE
Add Dockerfile and README for network images

### DIFF
--- a/tests/metrics/network/dockerfile_image/Dockerfile
+++ b/tests/metrics/network/dockerfile_image/Dockerfile
@@ -1,0 +1,40 @@
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2017 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+# Usage: FROM [image name]
+FROM ubuntu
+
+# Ensure packages are current, then install:
+#
+# - a basic development environment
+# - and additional general tooling
+#
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    smem \
+    iperf3 \
+    iperf
+
+# Install nuttcp (Network performance measurement tool)
+RUN cd $HOME && \
+    curl -OkL "http://nuttcp.net/nuttcp/beta/nuttcp-7.3.2.c" && \
+    gcc nuttcp-7.3.2.c -o nuttcp
+
+CMD ["/bin/bash"]

--- a/tests/metrics/network/dockerfile_image/README.md
+++ b/tests/metrics/network/dockerfile_image/README.md
@@ -1,0 +1,18 @@
+# Networking image for Intel® Clear Containers performance metrics
+
+In order to build the network image with the general tooling
+and system dependencies which are used in our networking tests,
+follow these steps:
+
+1. Building the network image with the following command:
+
+```
+$ docker build -t cc-network .
+```
+
+2. Verify the network image with the following command:
+
+```
+$ docker run -ti cc-network bash
+
+```


### PR DESCRIPTION
Add Dockerfile to create the network image currently used in all our networking testing. This Dockerfile will install all the dependencies that are required.
Add a README where it has the basic steps of building the image and verifying the image.