### PR TITLE
release: 2.1.8

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.7])
+AC_INIT([cc-oci-runtime], [2.1.8])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
befe20e docs: Install: Fedora: Fix broken markdown hotlin
53ff98c Metrics: Latency measurement
066568e tests: metrics: Improve robustness of PSS mem footprint test

Fixes #899 

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>