### PR TITLE
RFC: srio-v enabling on 2.1.11

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -162,7 +162,7 @@ DISTCHECK_CONFIGURE_FLAGS = \
 	--with-systemdsystemunitdir=/tmp/cc-distcheck/systemdunitdir/
 
 bin_PROGRAMS = cc-oci-runtime
-dist_bin_SCRIPTS = data/cc-oci-runtime.sh
+dist_bin_SCRIPTS = data/cc-oci-runtime.sh data/cc-sriovdownscript.sh
 
 common_sources = \
 	src/util.c src/util.h \

--- a/data/cc-sriovdownscript.sh
+++ b/data/cc-sriovdownscript.sh
@@ -1,0 +1,5 @@
+mkdir -p /var/run/netns
+ln -s /proc/$1/ns/net /var/run/netns/$1
+ip link set $2 netns $1
+ip netns exec $1 ip link set $2 down
+ip netns exec $1 ip link set dev $2 name eth0

--- a/src/hypervisor.h
+++ b/src/hypervisor.h
@@ -30,5 +30,7 @@ gboolean cc_oci_expand_cmdline (struct cc_oci_config *config,
 		gchar **args);
 void cc_oci_populate_extra_args(struct cc_oci_config *config,
                 GPtrArray *additional_args);
-
+gboolean cc_oci_bind_host(struct cc_oci_device* d_info);
+gboolean cc_oci_switch_iface_to_container(struct cc_oci_device* d_info,
+		GPid pid);
 #endif /* _CC_OCI_HYPERVISOR_H */

--- a/src/networking.h
+++ b/src/networking.h
@@ -29,6 +29,14 @@
  */
 #define VHOSTUSER_PORT_PATH "/tmp/v_%s"
 
+#define SRIOV_TEARDOWN_SCRIPT	"/usr/bin/cc-sriovdownscript.sh"
+
+/* bind/unbind paths to aid in SRIOV VF bring-up/restore */
+#define PCI_DRIVER_UNBIND_PATH	"/sys/bus/pci/devices/%s/driver/unbind"
+#define PCI_DRIVER_BIND_PATH	"/sys/bus/pci/drivers/%s/bind"
+#define VFIO_RMID_PATH		"/sys/bus/pci/drivers/vfio-pci/remove_id"
+#define VFIO_NEWID_PATH		"/sys/bus/pci/drivers/vfio-pci/new_id"
+
 void cc_oci_net_interface_free (struct cc_oci_net_if_cfg *if_cfg);
 
 void cc_oci_net_ipv4_route_free(struct cc_oci_net_ipv4_route *route);
@@ -44,4 +52,5 @@ gboolean cc_oci_network_discover(struct cc_oci_config *const config,
 
 gboolean is_interface_ovs(struct cc_oci_net_if_cfg* if_cfg);
 
+JsonObject * cc_oci_network_devices_to_json (const struct cc_oci_config *config);
 #endif /* _CC_OCI_NETWORKING_H */

--- a/src/oci.c
+++ b/src/oci.c
@@ -213,7 +213,7 @@ cc_oci_get_config_and_state (gchar **config_file,
 	*state = cc_oci_state_file_read (config->state.state_file_path);
 	if (! (*state)) {
 		g_critical("failed to read state file for container %s",
-		           config->optarg_container_id);
+			config->optarg_container_id);
 		goto err;
 	}
 
@@ -1055,7 +1055,7 @@ cc_oci_stop (struct cc_oci_config *config,
 				return false;
 			}
 		}
-    } else {
+	} else {
 		/* This isn't a fatal condition since:
 		 *
 		 * - containerd calls "delete" twice (unclear why).
@@ -1626,6 +1626,11 @@ cc_oci_config_update (struct cc_oci_config *config,
 	if(state->process && ! config->oci.process.args) {
 		config->oci.process = *state->process;
 		g_free_if_set (state->process);
+	}
+
+	if (state->devices) {
+		config->devices = state->devices;
+		state->devices = NULL;
 	}
 
 	if (state->console) {

--- a/src/oci.h
+++ b/src/oci.h
@@ -371,11 +371,24 @@ struct cc_oci_net_if_cfg {
 	/** mtu of interface **/
 	unsigned int mtu;
 
+	/** Flag indicated interface is a virtual function */
+	gboolean vf_based;
+
+	/** BDF associated with this VF device */
+	gchar *bdf;
+
+	/** device driver associated with this VF device */
+	gchar *device_driver;
+
+	/** vendor and device ID associated with this VF */
+	gchar *vd_id;
+
 	/** List of IPv4 addresses on the interface */
 	GSList  *ipv4_addrs;
 
 	/** List of IPv6 addresses on the interface */
 	GSList  *ipv6_addrs;
+
 };
 
 /** cc-specific IPv4 configuration data. */
@@ -435,10 +448,12 @@ struct oci_state {
 	 */
 	GSList          *mounts;
 
-        /** List of \ref oci_cfg_annotation annotations.
-         *
-         */
-        GSList          *annotations;
+	GSList          *devices;
+
+	/** List of \ref oci_cfg_annotation annotations.
+	 *
+	 */
+	GSList          *annotations;
 
 	/** List of \ref oci_cfg_namespace namespaces */
 	GSList          *namespaces;
@@ -573,6 +588,17 @@ struct cc_pod {
 	GSList   *rootfs_mounts;
 };
 
+struct cc_oci_device {
+	/* bdf of device */
+	gchar *bdf;
+
+	/* original driver associated with device */
+	gchar *driver;
+
+	/* vendor and device ID associated with device */
+	gchar *vd_id;
+};
+
 /** The main object holding all configuration data.
  *
  * \note The main user of this object is "start" - other commands
@@ -591,6 +617,8 @@ struct cc_oci_config {
 
 	/** Network configuration. */
 	struct cc_oci_net_cfg           net;
+
+	GSList *devices;
 
 	/** Container-specific state. */
 	struct cc_oci_container_state  state;
@@ -638,7 +666,7 @@ gboolean cc_oci_get_config_and_state (gchar **config_file,
 		struct oci_state **state);
 void cc_oci_state_free (struct oci_state *state);
 gboolean cc_oci_stop (struct cc_oci_config *config,
-        struct oci_state *state);
+		struct oci_state *state);
 gboolean cc_oci_toggle (struct cc_oci_config *config,
 		struct oci_state *state, gboolean pause);
 gboolean cc_oci_exec (struct cc_oci_config *config,

--- a/src/process.h
+++ b/src/process.h
@@ -24,7 +24,7 @@
 gboolean cc_oci_vm_launch (struct cc_oci_config *config);
 
 gboolean cc_run_hooks(GSList* hooks, const gchar* state_file_path,
-                       gboolean stop_on_failure);
+			gboolean stop_on_failure);
 
 gboolean cc_oci_vm_connect (struct cc_oci_config *config);
 
@@ -33,6 +33,8 @@ gboolean cc_shim_launch (struct cc_oci_config *config,
 			int *shim_args_fd,
 			int *shim_socket_fd,
 			gboolean initial_workload);
+
+void mac_hash_free (void);
 
 GSocketConnection *cc_oci_socket_connection_from_fd (int fd);
 

--- a/src/state.c
+++ b/src/state.c
@@ -41,6 +41,7 @@
 #include "json.h"
 #include "config.h"
 #include "spec_handler.h"
+#include "networking.h"
 
 #define update_subelements_and_strdup(node, data, member) \
 	if (node && node->data) { \
@@ -60,6 +61,7 @@ static void handle_state_status_section(GNode*, struct handler_data*);
 static void handle_state_created_section(GNode*, struct handler_data*);
 static void handle_state_mounts_section(GNode*, struct handler_data*);
 static void handle_state_namespaces_section(GNode*, struct handler_data*);
+static void handle_state_devices_section(GNode*, struct handler_data*);
 static void handle_state_console_section(GNode*, struct handler_data*);
 static void handle_state_vm_section(GNode*, struct handler_data*);
 static void handle_state_proxy_section(GNode*, struct handler_data*);
@@ -96,6 +98,7 @@ static struct state_handler {
 	{ "vm"          , handle_state_vm_section          , 6 , 0 },
 	{ "proxy"       , handle_state_proxy_section       , 2 , 0 },
 	{ "pod"         , handle_state_pod_section         , 0 , 0 },
+	{ "device"	, handle_state_devices_section     , 0 , 0 },
 	{ "annotations" , handle_state_annotations_section , 0 , 0 },
 	{ "namespaces"  , handle_state_namespaces_section  , 0 , 0 },
 
@@ -281,6 +284,48 @@ handle_state_mounts_section(GNode* node, struct handler_data* data) {
 		if (l) {
 			m = (struct cc_oci_mount*)l->data;
 			m->directory_created = g_strdup((char*)node->children->data);
+		}
+	}
+}
+
+/*!
+ * handler for devices section
+ *
+ * \param node \c GNode.
+ * \param data \ref handler_data.
+ */
+static void
+handle_state_devices_section(GNode* node, struct handler_data* data) {
+		struct cc_oci_device* d;
+
+	if (! (node && node->data)) {
+		return;
+	}
+
+	if (! data) {
+		return;
+	}
+
+	if (! (node->children && node->children->data)) {
+		g_critical("%s missing value", (char*)node->data);
+		return;
+	}
+
+	if (! g_strcmp0(node->data, "bdf")) {
+		d = g_new0 (struct cc_oci_device, 1);
+		d->bdf = g_strdup ((char *)node->children->data);
+		data->state->devices = g_slist_append(data->state->devices, d);
+	} else if (! g_strcmp0(node->data, "vd_id")) {
+		GSList *l = g_slist_last(data->state->devices);
+		if (l) {
+			d = (struct cc_oci_device*)l->data;
+			d->vd_id = g_strdup((char*)node->children->data);
+		}
+	} else if (! g_strcmp0(node->data, "driver")) {
+		GSList *l = g_slist_last(data->state->devices);
+		if (l) {
+			d = (struct cc_oci_device*)l->data;
+			d->driver = g_strdup((char*)node->children->data);
 		}
 	}
 }
@@ -540,27 +585,27 @@ handle_state_pod_section(GNode* node, struct handler_data* data) {
 static void
 handle_state_annotations_section(GNode* node, struct handler_data* data)
 {
-        struct oci_cfg_annotation *ann = NULL;
+	struct oci_cfg_annotation *ann = NULL;
 
-        if (! (node && node->data)) {
-                return;
-        }
+	if (! (node && node->data)) {
+		return;
+	}
 
-        if (! (node->children && node->children->data)) {
-                g_critical("%s missing value", (char*)node->data);
-                return;
-        }
+	if (! (node->children && node->children->data)) {
+		g_critical("%s missing value", (char*)node->data);
+		return;
+	}
 
-        g_assert(data->state);
+	g_assert(data->state);
 
-        ann = g_new0 (struct oci_cfg_annotation, 1);
-        ann->key = g_strdup ((gchar *)node->data);
-        if (node->children->data) {
-                ann->value = g_strdup ((gchar *)node->children->data);
-        }
+	ann = g_new0 (struct oci_cfg_annotation, 1);
+	ann->key = g_strdup ((gchar *)node->data);
+	if (node->children->data) {
+		ann->value = g_strdup ((gchar *)node->children->data);
+	}
 
-        data->state->annotations = g_slist_prepend(data->state->annotations,
-                                                        ann);
+	data->state->annotations = g_slist_prepend(data->state->annotations,
+					ann);
 }
 
 /*!
@@ -782,9 +827,9 @@ cc_oci_state_free (struct oci_state *state)
 		g_free (state->vm);
 	}
 
-        if (state->annotations) {
-                cc_oci_annotations_free_all(state->annotations);
-        }
+	if (state->annotations) {
+		cc_oci_annotations_free_all(state->annotations);
+	}
 
 	if (state->proxy) {
 		g_free_if_set(state->proxy->agent_ctl_socket);
@@ -802,6 +847,40 @@ cc_oci_state_free (struct oci_state *state)
 	}
 
 	g_free (state);
+}
+
+
+
+/*!
+ * Add devices to state JSON file
+ *
+ * \param config \ref cc_oci_config
+ *
+ * \return \c JsonObject for network device
+ */
+static JsonObject *
+cc_oci_devices_to_json (const struct cc_oci_config *config)
+{
+	JsonObject *device = NULL;
+	guint i;
+	struct cc_oci_device *d_info = NULL;
+
+	if (! config) {
+		return NULL;
+	}
+
+	for (i=0; i < g_slist_length(config->devices); i++) {
+		d_info = (struct cc_oci_device *)
+		g_slist_nth_data(config->devices, i);
+
+		if (d_info->bdf) {
+			device = json_object_new ();
+			json_object_set_string_member (device, "bdf", d_info->bdf);
+			json_object_set_string_member (device, "driver", d_info->driver);
+			json_object_set_string_member (device, "vd_id", d_info->vd_id);
+	}
+	}
+	return device;
 }
 
 /*!
@@ -827,6 +906,7 @@ cc_oci_state_file_create (struct cc_oci_config *config,
 	JsonArray   *namespaces = NULL;
 	JsonObject  *process = NULL;
 	JsonObject  *pod = NULL;
+	JsonObject  *device = NULL;
 	gchar       *str = NULL;
 	gsize        str_len = 0;
 	GError      *err = NULL;
@@ -924,6 +1004,18 @@ cc_oci_state_file_create (struct cc_oci_config *config,
 	}
 
 	json_object_set_array_member (obj, "namespaces", namespaces);
+
+	/*Add an array of devices to allow "delete" to recreate network
+	 interfaces*/
+	device = cc_oci_network_devices_to_json (config);
+	if (device) {
+		json_object_set_object_member (obj, "device", device);
+	}
+
+	device = cc_oci_devices_to_json (config);
+	if (device) {
+		json_object_set_object_member (obj, "device", device);
+ }
 
 	/* Add an process object to allow "start" command  what workload
 	 * will be used


### PR DESCRIPTION
Testing and debug of an issue with the CNM plugin for SRIO-V is still underway, but since this adds a substantial amount of code, I wanted to be more proactive on posting it for feedback.

This could be squashed later, but for now I wanted to preserve the history so you can see what was being taken from 1.x COR versus what needed to be cleaned up.  I also wanted to make sure original author is credited.  