### PR TITLE
docs: Update instructions to install latest Docker

### DIFF
--- a/documentation/Installing-Clear-Containers-on-Centos-7.md
+++ b/documentation/Installing-Clear-Containers-on-Centos-7.md
@@ -1,11 +1,17 @@
 # Install the Clear Containers runtime on Centos 7
 
-
 ## Introduction
 
-Installing Clear Containers on CentOS is slightly more difficult than on other distributions mainly due to the fact that it does not provide current versions of gcc and glibc.
+Installing Clear Containers on CentOS is slightly more difficult than on other
+distributions mainly due to the fact that it does not provide current versions
+of gcc and glibc.
 
-Hence, this guide explains how to install updated packages in `/usr/local`, to avoid conflicting with the base packages.
+Hence, this guide explains how to install updated packages in `/usr/local`,
+to avoid conflicting with the base packages.
+
+Clear Containers supports the latest version of Docker CE (currently 17.05), with
+the exception of Swarm. If you want to use Swarm, you must install Docker
+version 1.12.1.
 
 ## Warning
 
@@ -137,7 +143,14 @@ $ popd
 
 ```
 
-## Install docker 1.12
+## Install docker
+
+This step is optional and required only in the case where docker is not installed
+on the system, or the explicitly supported version of docker is required.
+
+Follow one of the two options below:
+
+### Option 1) Docker 1.12.1 (for compatibility with Swarm)
 
 ```
 $ sudo tee /etc/yum.repos.d/docker.repo <<EOF
@@ -153,9 +166,21 @@ $ sudo yum install docker-engine-1.12.1-1.el7.centos.x86_64 docker-engine-selinu
 
 ```
 
-For more information on docker installation, see:
-- https://docs.docker.com/engine/installation/linux/centos/
+### Option 2) Docker 17
 
+**Warning:** Clear Containers 2.1 and Swarm will not work correctly on Docker 17.
+
+```
+$ sudo yum install -y yum-utils
+$ sudo yum-config-manager \
+    --add-repo \
+    https://download.docker.com/linux/centos/docker-ce.repo
+$ sudo yum makecache fast
+$ sudo yum install docker-ce
+```
+
+For more information on installing Docker please refer to the
+[Docker Guide](https://docs.docker.com/engine/installation/linux/centos)
 
 ## Configure docker to use Clear Containers by default
 

--- a/documentation/Installing-Clear-Containers-on-Centos-7.md
+++ b/documentation/Installing-Clear-Containers-on-Centos-7.md
@@ -2,16 +2,16 @@
 
 ## Introduction
 
-Installing Clear Containers on CentOS is slightly more difficult than on other
-distributions mainly due to the fact that it does not provide current versions
-of gcc and glibc.
+Installing Clear Containers on CentOS\* is slightly more difficult than on
+other distributions. The cause is, mainly, its lack of current versions of gcc
+and glibc.
 
-Hence, this guide explains how to install updated packages in `/usr/local`,
+Hence, this guide explains how to install the updated packages in `/usr/local`,
 to avoid conflicting with the base packages.
 
-Clear Containers supports the latest version of Docker CE (currently 17.05), with
-the exception of Swarm. If you want to use Swarm, you must install Docker
-version 1.12.1.
+Clear Containers supports the latest version of Docker\* CE, currently 17.05,
+with the exception of Swarm\*. If you require Swarm, install Docker version
+1.12.1.
 
 ## Warning
 
@@ -143,14 +143,15 @@ $ popd
 
 ```
 
-## Install docker
+## Install Docker
 
-This step is optional and required only in the case where docker is not installed
-on the system, or the explicitly supported version of docker is required.
+This step is optional and only required in case Docker is not
+installed on the system or an specific version of Docker is
+required.
 
-Follow one of the two options below:
+Execute the commands for only one of the two following options.
 
-### Option 1) Docker 1.12.1 (for compatibility with Swarm)
+### Option 1) Docker 1.12.1 compatible with Swarm
 
 ```
 $ sudo tee /etc/yum.repos.d/docker.repo <<EOF
@@ -168,7 +169,7 @@ $ sudo yum install docker-engine-1.12.1-1.el7.centos.x86_64 docker-engine-selinu
 
 ### Option 2) Docker 17
 
-**Warning:** Clear Containers 2.1 and Swarm will not work correctly on Docker 17.
+**Caution:** Clear Containers 2.1 and Swarm will not work correctly on Docker 17.
 
 ```
 $ sudo yum install -y yum-utils

--- a/documentation/Installing-Clear-Containers-on-Fedora.md
+++ b/documentation/Installing-Clear-Containers-on-Fedora.md
@@ -2,10 +2,10 @@
 
 ## Introduction
 
-Clear Containers 2.1 is available for Fedora versions **24** and **25**.
-Clear Containers supports the latest version of Docker CE (currently 17.05), with
-the exception of Swarm. If you want to use Swarm, you must install Docker
-version 1.12.1.
+Clear Containers 2.1 is available for Fedora\* versions **24** and **25**.
+Clear Containers supports the latest version of Docker\* CE, currently 17.05,
+with the exception of Swarm\*. If you require Swarm, install Docker version
+1.12.1.
 
 
 ## Install the Clear Containers runtime
@@ -15,16 +15,17 @@ http://download.opensuse.org/repositories/home:clearlinux:preview:clear-containe
 $ sudo dnf install cc-oci-runtime linux-container
 ```
 
-## Install docker
+## Install Docker
 
-This step is optional and required only in the case where docker is not installed
-on the system, or the explicitly supported version of docker is required.
+This step is optional and only required in case Docker is not
+installed on the system or an specific version of Docker is
+required.
 
-Follow one of the two options below:
+Execute the commands for only one of the two following options.
 
-### Option 1) Docker 1.12.1 (for compatibility with Swarm)
+### Option 1) Docker 1.12.1 compatible with Swarm
 
-Docker 1.12.1 is not available in Fedora 25, so we will pull from the Fedora 24 repository:
+Docker 1.12.1 is not available in Fedora 25. Therefore, pull from the Fedora 24 repository:
 
 ```
 $ sudo dnf config-manager --add-repo \
@@ -43,7 +44,7 @@ $ sudo dnf install docker-engine-1.12.1-1.fc24
 
 ### Option 2) Docker 17
 
-**Warning:** Clear Containers 2.1 and Swarm will not work correctly on Docker 17.
+**Caution:** Clear Containers 2.1 and Swarm will not work correctly on Docker 17.
 
 ```
 $ sudo dnf -y install dnf-plugins-core

--- a/documentation/Installing-Clear-Containers-on-Fedora.md
+++ b/documentation/Installing-Clear-Containers-on-Fedora.md
@@ -1,4 +1,12 @@
-# Install the Clear Containers runtime on Fedora 25
+# Install the Clear Containers runtime on Fedora
+
+## Introduction
+
+Clear Containers 2.1 is available for Fedora versions **24** and **25**.
+Clear Containers supports the latest version of Docker CE (currently 17.05), with
+the exception of Swarm. If you want to use Swarm, you must install Docker
+version 1.12.1.
+
 
 ## Install the Clear Containers runtime
 ```
@@ -7,10 +15,16 @@ http://download.opensuse.org/repositories/home:clearlinux:preview:clear-containe
 $ sudo dnf install cc-oci-runtime linux-container
 ```
 
-## Install docker 1.12
+## Install docker
 
-For compatibility reasons, docker 1.12.1 is required. This is not available
-in Fedora 25, so we will pull from the Fedora 24 repository:
+This step is optional and required only in the case where docker is not installed
+on the system, or the explicitly supported version of docker is required.
+
+Follow one of the two options below:
+
+### Option 1) Docker 1.12.1 (for compatibility with Swarm)
+
+Docker 1.12.1 is not available in Fedora 25, so we will pull from the Fedora 24 repository:
 
 ```
 $ sudo dnf config-manager --add-repo \
@@ -26,6 +40,22 @@ Install docker engine:
 ```
 $ sudo dnf install docker-engine-1.12.1-1.fc24
 ```
+
+### Option 2) Docker 17
+
+**Warning:** Clear Containers 2.1 and Swarm will not work correctly on Docker 17.
+
+```
+$ sudo dnf -y install dnf-plugins-core
+$ sudo dnf config-manager \
+    --add-repo \
+    https://download.docker.com/linux/fedora/docker-ce.repo
+$ sudo dnf makecache fast
+$ sudo dnf install docker-ce
+```
+
+For more information on installing Docker please refer to the
+[Docker Guide](https://docs.docker.com/engine/installation/linux/fedora)
 
 ## Configure docker to use Clear Containers by default
 ```

--- a/documentation/Installing-Clear-Containers-on-Ubuntu.md
+++ b/documentation/Installing-Clear-Containers-on-Ubuntu.md
@@ -2,19 +2,19 @@
 
 ## Introduction
 
-Clear Containers 2.1 is available for Ubuntu for versions **16.04**, **16.10**
-and **17.04**.
-Clear Containers supports the latest version of Docker CE (currently 17.05), with
-the exception of Swarm. If you want to use Swarm, you must install Docker
-version 1.12.1.
+Clear Containers 2.1 is available for Ubuntu\* for versions **16.04**,
+**16.10** and **17.04**. Clear Containers supports the latest version of
+Docker\* CE, currently 17.05, with the exception of Swarm\*. If you require
+Swarm, install Docker version 1.12.1.
 
 ## Install the supported version of Docker
-This step is optional and required only in the case where docker is not installed
-on the system, or the explicitly supported version of docker is required.
+This step is optional and only required in case Docker is not
+installed on the system or an specific version of Docker is
+required.
 
-Follow one of the two options below:
+Execute the commands for only one of the two following options.
 
-### Option 1) Docker 1.12.1 (for compatibility with Swarm)
+### Option 1) Docker 1.12.1 compatible with Swarm
 
 The `add-apt-repository` and `apt-get` commands below reference
 `ubuntu-xenial`. Both Ubuntu 16.04 and 16.10 require this reference
@@ -34,7 +34,7 @@ sudo apt-mark hold docker-engine
 
 ### Option 2) Docker 17
 
-**Warning:** Clear Containers 2.1 and Swarm will not work correctly on Docker 17.
+**Caution:** Clear Containers 2.1 and Swarm will not work correctly on Docker 17.
 
 ```
 sudo apt-get install \

--- a/documentation/Installing-Clear-Containers-on-Ubuntu.md
+++ b/documentation/Installing-Clear-Containers-on-Ubuntu.md
@@ -2,14 +2,19 @@
 
 ## Introduction
 
-Clear Containers 2.1 is available for Ubuntu for versions **16.04** and **16.10**.
-Clear containers explicitly supports Docker 1.12.1. Later versions of Docker may be
-used but some issues may exist.
-
+Clear Containers 2.1 is available for Ubuntu for versions **16.04**, **16.10**
+and **17.04**.
+Clear Containers supports the latest version of Docker CE (currently 17.05), with
+the exception of Swarm. If you want to use Swarm, you must install Docker
+version 1.12.1.
 
 ## Install the supported version of Docker
 This step is optional and required only in the case where docker is not installed
 on the system, or the explicitly supported version of docker is required.
+
+Follow one of the two options below:
+
+### Option 1) Docker 1.12.1 (for compatibility with Swarm)
 
 The `add-apt-repository` and `apt-get` commands below reference
 `ubuntu-xenial`. Both Ubuntu 16.04 and 16.10 require this reference
@@ -26,6 +31,28 @@ sudo apt-get update
 sudo apt-get install -y --allow-downgrades docker-engine=1.12.1-0~xenial
 sudo apt-mark hold docker-engine
 ```
+
+### Option 2) Docker 17
+
+**Warning:** Clear Containers 2.1 and Swarm will not work correctly on Docker 17.
+
+```
+sudo apt-get install \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+	software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository \
+	"deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+	$(lsb_release -cs) \
+	stable"
+sudo apt-get update
+sudo apt-get install docker-ce
+```
+
+For more information on installing Docker please refer to the
+[Docker Guide](https://docs.docker.com/engine/installation/linux/ubuntu)
 
 ## Setup the repository for Clear Container
 


### PR DESCRIPTION
This commit adds instructions on how to install Docker 17
It also specifies to the user that Swarm only works with
Docker 1.12.1.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>