### PR TITLE
Tests: Common file for networking tests

### DIFF
--- a/tests/metrics/network/lib/network-test-common.bash
+++ b/tests/metrics/network/lib/network-test-common.bash
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2017 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+# This file contains functions that are shared among the networking
+# tests that are using nuttcp and iperf
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../../lib/test-common.bash"
+
+# This function will setup cor as a runtime, clean up the
+# environment and create a temporary file where networking
+# results will be stored
+function setup {
+	runtime_docker
+	kill_processes_before_start
+	result=$(mktemp)
+}
+
+# This function can be used in iperf and nuttcp networking tests
+function start_server {
+	local server_name="$1"
+	local image="$2"
+	local server_command="$3"
+	$DOCKER_EXE run -d --name=${server_name} ${image} sh -c "${server_command}" > /dev/null
+	local server_address=$($DOCKER_EXE inspect --format "{{.NetworkSettings.IPAddress}}" ${server_name})
+	echo "$server_address"
+}
+
+# This function is mainly required in iperf and nuttcp networking tests
+# and for PSS measurements it requires to run in detached mode
+function start_client {
+	local extra_args="$1"
+	local client_name="$2"
+	local image="$3"
+	local client_command="$4"
+	$DOCKER_EXE run ${extra_args} --name=${client_name} ${image} sh -c "${client_command}"
+}
+
+# This function will remove the server and the temporary file where
+# networking results are stored
+function clean_environment {
+	local server_name="$1"
+	$DOCKER_EXE rm -f ${server_name} > /dev/null
+	rm -f "$result"
+}

--- a/tests/metrics/network/network-metrics-cpu-consumption.sh.in
+++ b/tests/metrics/network/network-metrics-cpu-consumption.sh.in
@@ -25,26 +25,7 @@
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 
 source "${SCRIPT_PATH}/../../lib/test-common.bash"
-
-# Port number where the server will run
-port=5001:5001
-# Using this image as iperf is not working
-# see (https://github.com/01org/cc-oci-runtime/issues/152)
-# Image name
-image=gabyct/network
-# Total measurement time (seconds)
-# This is required in order to reduce standard deviation
-total_time=16
-# This time (seconds) is required when
-# server and client are more stable, we need to 
-# have server and client running for sometime and we
-# need to avoid to measure at the beginning of the running
-middle_time=8
-
-function setup {
-	runtime_docker
-	kill_processes_before_start
-}
+source "${SCRIPT_PATH}/lib/network-test-common.bash"
 
 # This script will perform all the measurements using a local setup
 
@@ -52,30 +33,44 @@ function setup {
 # using iperf2
 
 function cpu_consumption {
+	# Port number where the server will run
+	local port=5001:5001
+	# Using this image as iperf is not working
+	# see (https://github.com/01org/cc-oci-runtime/issues/152)
+	# Image name
+	local image=gabyct/network
+	# Total measurement time (seconds)
+	# This is required in order to reduce standard deviation
+	local total_time=16
+	# This time (seconds) is required when
+	# server and client are more stable, we need to
+	# have server and client running for sometime and we
+	# need to avoid to measure at the beginning of the running
+	local middle_time=8
+	# Name of the containers
+	local server_name="network-server"
+	local client_name="network-client"
+	# Arguments to run the client
+	local extra_args="-d"
+
 	setup
-	total_cpu=$(mktemp)
-	server_name="iperf-server"
-	client_name="iperf-client"
+	local server_command="iperf -p ${port} -s"
+	local server_address=$(start_server "$server_name" "$image" "$server_command")
 
-	server_command="iperf -p ${port} -s"
-	$DOCKER_EXE run -d --name=${server_name} ${image} bash -c "${server_command}" > /dev/null
-	server_address=$($DOCKER_EXE inspect --format "{{.NetworkSettings.IPAddress}}" $($DOCKER_EXE ps -ql))
-
-	client_command="iperf -c ${server_address} -t ${total_time}"
-	$DOCKER_EXE run -d --name=${client_name} ${image} bash -c "${client_command}" > /dev/null
+	local client_command="iperf -c ${server_address} -t ${total_time}"
+	start_client "$extra_args" "$client_name" "$image" "$client_command" > /dev/null
 
 	# Measurement after client and server are more stable
 	echo >&2 "WARNING: sleeping for $middle_time seconds in order to have server and client stable"
 	sleep ${middle_time}
 	qemu_pids=$(pidof @QEMU_PATH@)
-	ps --no-headers -o %cpu -p "$qemu_pids" > "$total_cpu"
-	sed -i 's/ //g' "$total_cpu"
-	total_cpu_consumption=$(awk '{ total += $1 } END { print total/NR }' "$total_cpu")
-	
-	$DOCKER_EXE rm -f ${server_name} > /dev/null
+	ps --no-headers -o %cpu -p "$qemu_pids" > "$result"
+	sed -i 's/ //g' "$result"
+	local total_cpu_consumption=$(awk '{ total += $1 } END { print total/NR }' "$result")
+	echo "The cpu % consumption is : $total_cpu_consumption"
+
+	clean_environment "$server_name"
 	$DOCKER_EXE rm -f ${client_name} > /dev/null
-	rm -f "$total_cpu"
 }
 
 cpu_consumption
-echo "The cpu % consumption is : $total_cpu_consumption"

--- a/tests/metrics/network/network-metrics-memory-pss.sh.in
+++ b/tests/metrics/network/network-metrics-memory-pss.sh.in
@@ -25,26 +25,7 @@
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 
 source "${SCRIPT_PATH}/../../lib/test-common.bash"
-
-# Port number where the server will run
-port=5001:5001
-# Using this image as iperf is not working
-# see (https://github.com/01org/cc-oci-runtime/issues/152)
-# Image name
-image=gabyct/network
-# Total measurement time (seconds)
-# This is required in order to reduce standard deviation
-total_time=10
-# This time (seconds) is required when
-# server and client are more stable, we need to
-# have server and client running for sometime and we
-# need to avoid to measure at the beginning of the running
-middle_time=5
-
-function setup {
-	runtime_docker
-	kill_processes_before_start
-}
+source "${SCRIPT_PATH}/lib/network-test-common.bash"
 
 # This script will perform all the measurements using a local setup
 
@@ -52,28 +33,42 @@ function setup {
 # using iperf2
 
 function pss_memory {
+	# Port number where the server will run
+	local port=5001:5001
+	# Using this image as iperf is not working
+	# see (https://github.com/01org/cc-oci-runtime/issues/152)
+	# Image name
+	local image=gabyct/network
+	# Total measurement time (seconds)
+	# This is required in order to reduce standard deviation
+	local total_time=10
+	# This time (seconds) is required when
+	# server and client are more stable, we need to
+	# have server and client running for sometime and we
+	# need to avoid to measure at the beginning of the running
+	local middle_time=5
+	# Name of the containers
+	local server_name="network-server"
+	local client_name="network-client"
+	# Arguments to run the client
+	local extra_args="-d"
+
 	setup
-	total_memory=$(mktemp)
-	server_name="iperf-server"
-	client_name="iperf-client"
+	local server_command="iperf -p ${port} -s"
+	local server_address=$(start_server "$server_name" "$image" "$server_command")
 
-	server_command="iperf -p ${port} -s"
-	$DOCKER_EXE run -d --name=${server_name} ${image} bash -c "${server_command}" > /dev/null
-	server_address=$($DOCKER_EXE inspect --format "{{.NetworkSettings.IPAddress}}" $($DOCKER_EXE ps -ql))
-
-	client_command="iperf -c ${server_address} -t ${total_time}"
-	$DOCKER_EXE run -d --name=${client_name} ${image} bash -c "${client_command}" > /dev/null
+	local client_command="iperf -c ${server_address} -t ${total_time}"
+	start_client "$extra_args" "$client_name" "$image" "$client_command" > /dev/null
 
 	# Measurement after client and server are more stable
 	echo >&2 "WARNING: sleeping for $middle_time seconds in order to have server and client stable"
 	sleep ${middle_time}
-	smem -c "pss" -P @QEMU_PATH@ | tail -n 2 > "$total_memory"
-	total_pss_memory=$(awk '{ total += $1 } END { print total/NR }' "$total_memory")
+	smem -c "pss" -P @QEMU_PATH@ | tail -n 2 > "$result"
+	local total_pss_memory=$(awk '{ total += $1 } END { print total/NR }' "$result")
+	echo "The PSS memory is : $total_pss_memory Kb"
 
-	$DOCKER_EXE rm -f ${server_name} > /dev/null
+	clean_environment "$server_name"
 	$DOCKER_EXE rm -f ${client_name} > /dev/null
-	rm -f "$total_memory"
 }
 
 pss_memory
-echo "The PSS memory is : $total_pss_memory Kb"


### PR DESCRIPTION
Add common file of functions that are shared among networking
tests that are using iperf and nuttcp. These functions include
setup the environment, start a server, start a client and
clean up the environment.

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>