### PR TITLE
build: remove requeriment to have a recent autoconf-archive

### DIFF
--- a/.ci/ci-configure.sh
+++ b/.ci/ci-configure.sh
@@ -57,6 +57,7 @@ configure_opts+=" --enable-valgrind"
 configure_opts+=" --disable-valgrind-helgrind"
 configure_opts+=" --disable-valgrind-drd"
 configure_opts+=" --disable-silent-rules"
+configure_opts+=" --disable-valgrind-sgcheck"
 
 if [ "$nested" = "Y" ]
 then

--- a/Makefile.am
+++ b/Makefile.am
@@ -156,6 +156,7 @@ DISTCHECK_CONFIGURE_FLAGS = \
 	--enable-valgrind \
 	--disable-valgrind-helgrind \
 	--disable-valgrind-drd \
+	--disable-valgrind-sgcheck \
 	--enable-code-coverage \
 	--enable-functional-tests \
 	--with-systemdsystemunitdir=/tmp/cc-distcheck/systemdunitdir/

--- a/README.rst
+++ b/README.rst
@@ -198,7 +198,7 @@ installed on your system:
 - json-glib
 - libmnl
 - uuid
-- autoconf-archive - version 2017.03.21 or above
+- autoconf-archive
 
 Configure Stage
 ~~~~~~~~~~~~~~~

--- a/autogen.sh
+++ b/autogen.sh
@@ -29,7 +29,8 @@ autoreconf --force --install --symlink --warnings=all
 args="\
 --sysconfdir=/etc \
 --localstatedir=/var \
---prefix=/usr"
+--prefix=/usr \
+--disable-valgrind-sgcheck"
 
 set -x
 ./configure $args "$@"

--- a/configure.ac
+++ b/configure.ac
@@ -32,12 +32,10 @@ AC_LANG(C)
 
 LT_INIT
 
-source $srcdir/versions.txt
-
 # Check for macros
 AC_DEFUN_ONCE([MACRO_CHECK],
 [
-	ifdef([$1], true, [AC_FATAL([Please install autoconf-archive version ${autoconf_archive_version}],)])
+	ifdef([$1], true, [AC_FATAL([Please install autoconf-archive],)])
 ])
 
 MACRO_CHECK([AX_VALGRIND_DFLT])
@@ -156,6 +154,8 @@ AS_IF([test x"$run_crio_tests" = x"yes"],
 AM_CONDITIONAL([CRIO_TESTS], [test x"$run_crio_tests" = x"yes"])
 
 # Checks for libraries.
+source $srcdir/versions.txt
+
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= "$glib_version"], have_required_glib=yes, have_required_glib=no)
 AS_IF([test "$have_required_glib" != "yes"], AC_MSG_ERROR([ERROR: need glib ${glib_version}+ for the `G_FILE_MONITOR_WATCH_MOVES' flag]))
 

--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,6 @@ AC_DEFUN_ONCE([MACRO_CHECK],
 	ifdef([$1], true, [AC_FATAL([Please install autoconf-archive],)])
 ])
 
-MACRO_CHECK([AX_VALGRIND_DFLT])
 MACRO_CHECK([AX_VALGRIND_CHECK])
 MACRO_CHECK([AX_CODE_COVERAGE])
 
@@ -375,7 +374,6 @@ AC_ARG_ENABLE([autogopath],
 )
 AM_CONDITIONAL([AUTOGOPATH], [test x$autogopath = xtrue])
 
-AX_VALGRIND_DFLT([sgcheck], [off])
 AX_VALGRIND_CHECK
 AX_CODE_COVERAGE
 

--- a/versions.txt
+++ b/versions.txt
@@ -14,4 +14,3 @@ qemu_lite_version=741f430a960b5b67745670e8270db91aeb083c5f
 mpfr_version=3.1.4
 gmp_version=6.1.0
 mpc_version=1.0.3
-autoconf_archive_version=2017.03.21


### PR DESCRIPTION
Asking for a recent autoconf-archive makes it extra difficult  to build cc-oci-runtime in older distros: Ubuntu 16.04, Ubuntu 16.10 Fedora 24.

With this patch I am removing the requeriment for a recent autoconf-archive as well as references to AX_VALGRIND_DFLT.

Added --disable-valgrind-sgcheck to default build options

Fixes #888 and #887