### PR TITLE
tests: updated user.bats to check group id with a regex

### DIFF
--- a/tests/integration/docker/user.bats
+++ b/tests/integration/docker/user.bats
@@ -60,7 +60,7 @@ teardown() {
 @test "Run with additional groups" {
 	run $DOCKER_EXE run --rm --group-add audio --group-add nogroup busybox id
 	[ "${status}" -eq 0 ]
-	echo "${output}" | grep "uid=0(root) gid=0(root) groups=[wheel10,()]*29(audio),99(nogroup)"
+	echo "${output}" | egrep "uid=0\(root\) gid=0\(root\) groups=[wheel10,()]*29\(audio\),[0-9]+\(nogroup\)"
 }
 
 @test "Run with non-existing numeric gid" {


### PR DESCRIPTION
The test 'Running with additional groups' uses busybox image
which previously used id 99 for nogroup. In its latest
update, busybox now uses id 65534 as other distros do.

The test now uses a regex for verifying this id.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>