### PR TITLE
build: Update cc-oci-runtime obs builds with master

### DIFF
--- a/data/obs-packaging/cc-oci-runtime/README.md
+++ b/data/obs-packaging/cc-oci-runtime/README.md
@@ -8,10 +8,13 @@ With these files we generated Fedora and Ubuntu packages for this component.
 
 ``./update_runtime.sh [VERSION]``
 
+The ``VERSION`` parameter is optional. The parameter can be a tag, a branch,
+or a GIT hash.
+
+If the ``VERSION`` parameter is not specified, the top-level ``configure.ac``
+file will determine its value automatically.
+
 This script will update the sources to create ``cc-oci-runtime`` packages.
 
   * cc-oci-runtime.dsc
   * cc-oci-runtime.spec
-
-By default, the script will get VERSION specified in the ``versions.txt`` file
-found at the the repository's root.

--- a/data/obs-packaging/cc-oci-runtime/debian.changelog
+++ b/data/obs-packaging/cc-oci-runtime/debian.changelog
@@ -1,3 +1,15 @@
+cc-oci-runtime (f57a266) stable; urgency=medium
+
+  * Update cc-oci-runtime f57a266 f57a266
+
+ -- Geronimo Orozco <geronimo.orozco@intel.com>  Fri, 19 May 2017 13:39:58 -0600
+
+cc-oci-runtime (2.1.8) stable; urgency=medium
+
+  * Update cc-oci-runtime 2.1.8 33f88c8
+
+ -- Geronimo Orozco <geronimo.orozco@intel.com>  Mon, 15 May 2017 14:57:15 -0600
+
 cc-oci-runtime (2.1.7) stable; urgency=medium
 
   * Update cc-oci-runtime 2.1.7 a1005b9


### PR DESCRIPTION
Tis commit adds improvements to the OBS automation tooling for cc-oci-runtime, and the updated changelog sent to the OBS builds.

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>