### PR TITLE
release: 2.1.9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.8])
+AC_INIT([cc-oci-runtime], [2.1.9])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
2.1.9 changes:

- Fixed CentOS build issues
- Removed autoarchive-conf dependency for newest version
- Prevent race condition in cc-proxy.

4591c57 proxy: Avoid shadowing type "header" with variable "header"
161aa5c configure: Remove AX_VALGRIND_DFLT references
faa84b1 tests: updated user.bats to check group id with a regex
7ff8e07 CI: Update Coverity Scan token used by TravisCI.
61e9dbc Revert "versions: Specifies a version of autoconf-archive"
c2c1853 docs: Edit the updated instructions to install Docker.
4fdc46f docs: Update instructions to install latest Docker
78689d1 Prevent race condition with the per-client ID
3615fd0 shim: Fix debug messgage
aa3d951 shim: Compare errno with EINTR instead of return value of write
043bb40 shim: Make the shim exit in case of erroneous stream lengths
6f82ef7 networking: Fix compile for bridge networking code
9599217 build: Fix the dash problem on kernel version
e715c59 documentation: Clarify README files
3a0278a shim: If we receive a very long message from the proxy, log to
stderr
606f96f networking: Fix compilation issue on Centos.
c75de17 build: Updated linux-kernel to 4.9.27
3489f5e documentation: Edit documentation files.
b557b46 build: update_kernel.sh add obs variable
3741035 build: update_image.sh add obs variable
891398c build: update_runtime.sh templates and readme
1a88623 build: remove missplaced .gitignore files
4c7a047 obs: update_kernel: add cosmetics to the script
226657a kernel: Add the latest configuration for kernel 4.9.24-60.
6875562 packaging: Update qemu-lite requires
d833eea build: Update/Fix Readme and spec files
08102cc qemu-lite: Update base files to latest in OBS
05bd794 build: Updated linux-container
c4c39da build: clear-containers-image cleanup
2d797ce build: Add cc-oci-runtime spec/dsc automation
f39c908 build: specs to create clear-containers packages
bac0af9 docs: Update Clear Containers installation in Clear Linux
b339ca4 Add README about how to build the network image
1cbcdc0 Dockerfile for network image

Fixes #922

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>