### PR TITLE
Metrics: Measure RSS memory for 1Gb transfer

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,7 @@ GENERATED_FILES = \
 	tests/metrics/workload_time/cor_create_time.sh \
 	tests/metrics/network/network-metrics-cpu-consumption.sh \
 	tests/metrics/network/network-metrics-memory-pss.sh \
+	tests/metrics/network/network-metrics-memory-rss-1g.sh \
 	tests/lib/test-common.bash
 
 $(GENERATED_FILES): %: %.in Makefile
@@ -369,6 +370,7 @@ EXTRA_DIST = \
 	tests/metrics/density/docker_memory_usage.sh.in \
 	tests/metrics/workload_time/cor_create_time.sh.in \
 	tests/metrics/network/network-metrics-cpu-consumption.sh.in \
+	tests/metrics/network/network-metrics-memory-rss-1g.sh.in \
 	tests/metrics/network/network-metrics-memory-pss.sh.in \
 	vendor \
 	data/genfile.sh \

--- a/tests/metrics/network/network-metrics-memory-rss-1g.sh.in
+++ b/tests/metrics/network/network-metrics-memory-rss-1g.sh.in
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2017 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Description:
+#  Measures Resident Set Size memory while running an
+#  inter (docker<->docker) 1 Gb tranfer rate using nuttcp.
+#  The selection of 1 Gb as a tranfer rate is because that is 
+#  the maximum that we can be handle in our testing infrastructure.
+
+set -e
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+
+source "${SCRIPT_PATH}/../../lib/test-common.bash"
+source "${SCRIPT_PATH}/lib/network-test-common.bash"
+
+function rss_memory {
+	# Currently default nuttcp has a bug
+	# see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=745051
+	# Image name
+	local image=gabyct/nuttcp
+	# We wait for the test system to settle into a steady mode before we
+	# measure the RSS. Thus, we have two times - the length of the time the 
+	# test runs for, and the time after which we sample the RSS
+	# Time for the test to run (seconds)
+	local total_time=6
+	# Time in which we sample the PSS (seconds)
+	local middle_time=3
+	# Rate limit (speed at which transmitter send data, megabytes)
+	# We will measure RSS with a specific transfer rate
+	local rate_limit=1000
+	# Name of the containers
+ 	local server_name="network-server"
+ 	local client_name="network-client"
+ 	# Arguments to run the client
+ 	local extra_args="-d"
+
+	setup
+	local server_command="sleep 30"
+	local server_address=$(start_server "$server_name" "$image" "$server_command")
+
+	local client_command="/root/nuttcp -R${rate_limit}m -T${total_time} ${server_address}"
+	local server_command="/root/nuttcp -S"
+	$DOCKER_EXE exec ${server_name} sh -c "${server_command}"
+	start_client "$extra_args" "$client_name" "$image" "$client_command" > /dev/null
+
+	# Time when we are taking our RSS measurement
+	echo >&2 "WARNING: sleeping for $middle_time seconds in order to sample the RSS"
+	sleep ${middle_time}
+
+	local memory_command="smem -c rss"
+	${memory_command} -P @QEMU_PATH@ | tail -n 2 > "$result"
+	local memory=$(awk '{ total += $1 } END { print total/NR }' "$result")
+	echo "The RSS memory is : $memory Kb"
+	
+	echo >&2 "WARNING: This test is being affected by https://github.com/01org/cc-oci-runtime/issues/795"
+	clean_environment "$server_name"
+	$DOCKER_EXE rm -f ${client_name} > /dev/null
+}
+
+rss_memory


### PR DESCRIPTION
Resident Set Size (RSS) memory while running a nuttcp 1 Gb transfer rate.
The RSS measurement is taken by using smem.
Fixes #925.

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>