### PR TITLE
Release 2.1.10

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.9])
+AC_INIT([cc-oci-runtime], [2.1.10])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
release: version 2.1.10

- Removed old dockerfiles, clear containers dockerfiles live in
 github.com/clearcontainers/dockerfiles
- Installation Documentation updated for Centos 7
- Prevented race condition in proxy client ID assignment
- Added metrics to measure RSS memory for 1Gb transfer
- OBS packaging scripts support  set user's OBS HOME

Short log:

a923745 Changes to installation documentation for Centos
06ea638 build: Add extra variable for OBS builds
41a405c #927 from GabyCT/topic/rssmemory
87ca55a Metrics: Measure RSS memory for 1Gb transfer
197e8d4 Copy client ID locally to prevent race condition
a923745 Changes to installation documentation for Centos
3c54712 Tests: Common file for networking tests
ac90d7d remove unused files
06ea638 build: Add extra variable for OBS builds
ac90d7d remove unused files
3c54712 Tests: Common file for networking tests

Fixes #940

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>