### PR TITLE
Fix OBS variables

### DIFF
--- a/data/obs-packaging/cc-oci-runtime/debian.changelog
+++ b/data/obs-packaging/cc-oci-runtime/debian.changelog
@@ -1,3 +1,9 @@
+cc-oci-runtime (2.1.10) stable; urgency=medium
+
+  * Update cc-oci-runtime 2.1.10 edebf40
+
+ -- Geronimo Orozco <geronimo.orozco@intel.com>  Mon, 05 Jun 2017 10:52:21 -0500
+
 cc-oci-runtime (2.1.9) stable; urgency=medium
 
   * Update cc-oci-runtime 2.1.9 2b6b95b

--- a/data/obs-packaging/clear-containers-image/update_image.sh
+++ b/data/obs-packaging/clear-containers-image/update_image.sh
@@ -14,7 +14,7 @@ source "$CC_VERSIONS_FILE"
 VERSION=${1:-$clear_vm_image_version}
 
 OBS_PUSH=${OBS_PUSH:-false}
-OBS_CC_IMAGE_REPO=${OBS_RUNTIME_REPO:-home:clearlinux:preview:clear-containers-staging/clear-containers-image}
+OBS_CC_IMAGE_REPO=${OBS_CC_IMAGE_REPO:-home:clearlinux:preview:clear-containers-staging/clear-containers-image}
 
 git checkout wd/debian/changelog
 last_release=`cat wd/debian/changelog | head -1 | awk '{print $2}' | cut -d'-' -f2 | tr -d ')'`
@@ -54,8 +54,8 @@ then
     TMPDIR=$(mktemp -d -t ${temp}.XXXXXXXXXXX) || exit 1
     cd ..
     cc_image_dir=$(pwd)
-    rm clear-containers-image_$VERSION-${next_release}_source.build \
-    clear-containers-image_$VERSION-${next_release}_source.changes
+    rm clear-containers-image_*_source.build \
+    clear-containers-image_*_source.changes
     osc co "$OBS_CC_IMAGE_REPO" -o $TMPDIR
     cd $TMPDIR
     osc rm clear-*-containers.img.xz

--- a/data/obs-packaging/linux-container/update_kernel.sh
+++ b/data/obs-packaging/linux-container/update_kernel.sh
@@ -15,7 +15,7 @@ clear_vm_kernel_version=$(echo $clear_vm_kernel_version | cut -d'-' -f1)
 VERSION=${1:-$clear_vm_kernel_version}
 
 OBS_PUSH=${OBS_PUSH:-false}
-OBS_CC_KERNEL_REPO=${OBS_RUNTIME_REPO:-home:clearlinux:preview:clear-containers-staging/linux-container}
+OBS_CC_KERNEL_REPO=${OBS_CC_KERNEL_REPO:-home:clearlinux:preview:clear-containers-staging/linux-container}
 
 git checkout wd/debian/changelog
 last_release=`cat wd/debian/changelog | head -1 | awk '{print $2}' | cut -d'-' -f2 | tr -d ')'`


### PR DESCRIPTION
build: Fix OBS variables in package helper scripts

There is a bug on the repo variables to use. 

``OBS_CC_IMAGE_REPO``
``OBS_KERNEL_REPO``

Update changelog to package cc-oci-runtime in OBS