### PR TITLE
proxy/protocol: Add checks on header length and flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -298,7 +298,7 @@ cc_proxy_extra_dist =			\
 CHECK_DEPS += check-proxy
 
 check-proxy: $(cc_proxy_sources) | $(PROXY_DEPS)
-	$(AM_V_GEN)proxy_test_common_args="-v -timeout 2s $(srcdir)/proxy" ; \
+	$(AM_V_GEN)proxy_test_common_args="-v -timeout 2s $(srcdir)/proxy $(srcdir)/proxy/api" ; \
 	go test -race $$proxy_test_common_args || go test $$proxy_test_common_args
 
 check-go:

--- a/proxy/api/protocol_test.go
+++ b/proxy/api/protocol_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeaderValidate(t *testing.T) {
+	tests := []struct {
+		hdr   header
+		valid bool
+	}{
+		{
+			hdr:   header{length: 64},
+			valid: true,
+		},
+		{
+			hdr:   header{length: maxPayloadLength + 1},
+			valid: false,
+		},
+		{
+			hdr:   header{length: 64, flags: 0x1},
+			valid: false,
+		},
+	}
+
+	for i := range tests {
+		test := &tests[i]
+		err := test.hdr.validate()
+		assert.Equal(t, test.valid, err == nil)
+	}
+}


### PR DESCRIPTION
We can check better the header we receive from clients. This time, make
sure the payload length is within reasonable limits and that the flags
are 0 (we don't have any at the moment).

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>