### PR TITLE
build: Makefile: Add generate-files rule

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,6 +96,11 @@ $(GENERATED_FILES): %: %.in Makefile
 		abs_builddir="$(abs_builddir)" \
 		$(top_srcdir)/data/genfile.sh "$<" "$@"
 
+# Sometimes you just want to generate the generated files without having
+# to do a full build or run some tests - so add a simple target rule
+# to allow that.
+generate-files: $(GENERATED_FILES)
+
 if FUNCTIONAL_TESTS
 if AUTO_BUNDLE_CREATION
 


### PR DESCRIPTION
Sometimes you just want to generate the generated files without
doing a full build or a further test run (for instance, if we want
to run the tests on an already installed runtime).
Add a rule to allow that.

(turns out we don't need to split the metrics-tests and other rules down,
just add a simple extra rule to nudge the file generation - nice and simple)

Fixes: #945

Signed-off-by: Graham Whaley <graham.whaley@intel.com>