### PR TITLE
Release: 2.1.11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.10])
+AC_INIT([cc-oci-runtime], [2.1.11])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
# Release 2.1.11

## Changes
- kernel: Update kernel  and image versions
- pod: Support new CRI-O namespaces
- CI: Ignore checkcommits
- CI: Perform basic checks on PR commits.
- proxy/protocol: Add checks on header length and flags
- Metrics: PSS for a transfer rate of 1Gb
- Fix OBS variables
- Docs: metrics: network: Clarify pre-process and running

## Shortlog
cc9e174 obs: fix patch automation updates for kernel.
7d538ba (origin/update-kernel, update-kernel) kernel: Update kernel version
da039db pod_test: Add a pod namespace unit test
7799fdc pod: Support new CRI-O namespaces
3cfe847 (origin/ignore-checkcommits) CI: Ignore checkcommits
cc7ece4 CI: Perform basic checks on PR commits.
e97073b proxy/protocol: Add checks on header length and flags
1589937 proxy: Add api to the list of packages to test
128d629 Metrics: PSS for a transfer rate of 1Gb
9d0bbb1 OBS: Update changelog used in OBS to package the runtime
d9bb4dd build: Fix OBS variables in package helper scripts
cdf5cf1 Docs: metrics: network: Clarify pre-process and running

## Compatibility with Docker
Clear Containers 2.1.11 is compatible with Docker v17.05.0-ce
## OCI Runtime Specification
Clear Containers 2.1.11 support the OCI Runtime Specification [1.0.0-rc5][ocispec]

# Installation
- [Centos][centos]
- [Ubuntu][ubuntu]
- [Fedora][fedora]
- [Clear Linux][clearlinux]

# Issues & limitations
- Qemu segfault (free(): invalid pointer) running dnf install #669
- DNS Resolution in Swarm #854
- docker rm -f reports 'Driver devicemapper failed to remove root filesystem' #795

[centos]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Centos-7.md
[ubuntu]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Ubuntu.md
[fedora]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Fedora-25.md
[clearlinux]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-ClearLinux.md
[clearlinuximage]: https://download.clearlinux.org/releases/15800/clear/clear-15800-containers.img.xz
[ocispec]: https://github.com/opencontainers/runtime-spec/releases/tag/v1.0.0-rc5