### PR TITLE
CI: Ignore checkcommits

### DIFF
--- a/.ci/ci-pre-checks.sh
+++ b/.ci/ci-pre-checks.sh
@@ -31,4 +31,4 @@ checkcommits \
     --need-sign-offs \
     --body-length 72 \
     --subject-length 75 \
-    --verbose
+    --verbose || true


### PR DESCRIPTION
Lets ignore checkcommits errors by know. This will allow
to know missing cases.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>