### PR TITLE
build: obs: Update post release changelog

### DIFF
--- a/data/obs-packaging/cc-oci-runtime/debian.changelog
+++ b/data/obs-packaging/cc-oci-runtime/debian.changelog
@@ -1,3 +1,9 @@
+cc-oci-runtime (2.1.11) stable; urgency=medium
+
+  * Update cc-oci-runtime 2.1.11 1d8a1b9
+
+ -- Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>  Fri, 09 Jun 2017 13:15:05 -0500
+
 cc-oci-runtime (2.1.10) stable; urgency=medium
 
   * Update cc-oci-runtime 2.1.10 edebf40

--- a/data/obs-packaging/clear-containers-image/wd/debian/changelog
+++ b/data/obs-packaging/clear-containers-image/wd/debian/changelog
@@ -1,3 +1,9 @@
+clear-containers-image (15800-20) stable; urgency=medium
+
+  * Update clear-containers-image 15800.
+
+ -- Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>  Fri, 09 Jun 2017 13:05:17 -0500
+
 clear-containers-image (15550-19) stable; urgency=medium
 
   * Update clear-containers-image 15550.

--- a/data/obs-packaging/linux-container/wd/debian/changelog
+++ b/data/obs-packaging/linux-container/wd/debian/changelog
@@ -1,3 +1,9 @@
+linux-container (4.9.31-61) stable; urgency=medium
+
+  * Update kernel 4.9.31
+
+ -- Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>  Fri, 09 Jun 2017 13:00:29 -0500
+
 linux-container (4.9.30-60) stable; urgency=medium
 
   * Update kernel 4.9.30


### PR DESCRIPTION
This patch updates the changelog generated after build 2.1.11
in OBS:

http://download.opensuse.org/repositories/home:clearlinux:preview:clear-containers-2.1/Fedora_25/

Fixes: #974

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>