### PR TITLE
configure: Add warning when kernel or image is not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -321,6 +321,14 @@ AS_IF([test x"$with_tests_bundle_path" != x""],
 
 #Kernel path for Clear Containers
 DEFAULT_KERNEL_PATH=$localstatedir/lib/$PACKAGE_NAME/data/kernel/vmlinux.container
+
+# Verify container kernel is installed by package.
+OBS_PKG_KERNEL_PATH="/usr/share/clear-containers/vmlinux.container"
+if  [ ! -f "$DEFAULT_KERNEL_PATH" -a -f "$OBS_PKG_KERNEL_PATH" ] ; then
+	DEFAULT_KERNEL_PATH="$OBS_PKG_KERNEL_PATH"
+	AC_MSG_WARN($DEFAULT_KERNEL_PATH detected using as default kernel path)
+fi
+
 AC_ARG_WITH([cc-kernel],
     [AS_HELP_STRING([--with-cc-kernel=[[KERNEL-PATH]]],
         [clear container kernel path])
@@ -334,8 +342,24 @@ AC_ARG_WITH([cc-kernel],
     ]
 )
 
+if test -f "$CONTAINER_KERNEL"; then
+	KERNEL_FOUND=yes
+else
+	KERNEL_HELP="Could not find $CONTAINER_KERNEL kernel file. Use --with-cc-kernel to specify the correct path to container kernel."
+	AC_MSG_WARN([$KERNEL_HELP])
+	KERNEL_FOUND=no
+fi
+
+
 #Container image path for Clear Containers
 DEFAULT_CONTAINER_IMG=$localstatedir/lib/$PACKAGE_NAME/data/image/clear-containers.img
+
+# Verify container image is installed by package.
+OBS_PKG_IMAGE_PATH="/usr/share/clear-containers/clear-containers.img"
+if  [ ! -f "$DEFAULT_CONTAINER_IMG" -a -f "$OBS_PKG_IMAGE_PATH" ] ; then
+	DEFAULT_CONTAINER_IMG="$OBS_PKG_IMAGE_PATH"
+	AC_MSG_WARN($DEFAULT_CONTAINER_IMG detected using as default kernel path)
+fi
 AC_ARG_WITH([cc-image],
     [AS_HELP_STRING([--with-cc-image=[[IMAGE-PATH]]],
         [clear container image path])
@@ -348,6 +372,14 @@ AC_ARG_WITH([cc-image],
         AC_SUBST([CONTAINERS_IMG],[$DEFAULT_CONTAINER_IMG])
     ]
 )
+
+if test -f "$CONTAINERS_IMG"; then
+	IMAGE_FOUND=yes
+else
+	IMAGE_HELP="Could not find $CONTAINERS_IMG image file. Use --with-cc-image to specify the correct path to container image."
+	AC_MSG_WARN([$IMAGE_HELP])
+	IMAGE_FOUND=no
+fi
 
 # CRI-O artifacts
 DEFAULT_CRIO_CACHE=$localstatedir/lib/$PACKAGE_NAME/cri-o/cache
@@ -395,8 +427,10 @@ cc-oci-runtime - $VERSION
 
        QEMU                     : $ac_cv_path_QEMU
        QEMU pc-lite             : $has_pc_lite
-       Container kernel         : $CONTAINER_KERNEL
-       Container image          : $CONTAINERS_IMG
+       Container kernel         : $CONTAINER_KERNEL (found: $KERNEL_FOUND)
+                                  $KERNEL_HELP
+       Container image          : $CONTAINERS_IMG (found: $IMAGE_FOUND)
+                                  $IMAGE_HELP
        Container image services : $CC_IMAGE_SYSTEMDSYSTEMUNIT_PATH
        Debug build              : $enable_debug
 

--- a/tests/functional/run-functional-tests.sh.in
+++ b/tests/functional/run-functional-tests.sh.in
@@ -18,7 +18,8 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-export PROXY_SOCKET_PATH="@ABS_BUILDDIR@/tests/functional/proxy.sock"
+set -e
+export PROXY_SOCKET_PATH="$(mktemp -d --suffix=-cor-test)/proxy.sock"
 export SHIM_PATH="@ABS_BUILDDIR@/cc-shim"
 echo 'Running a new instance of cc-proxy'
 @ABS_BUILDDIR@/cc-proxy -socket-path="${PROXY_SOCKET_PATH}" &


### PR DESCRIPTION
This patch adds a warnings at configuration time, it will
show a warning message when either clear containers kernel
or image are not found.

It also check if a kernel or image was installed by clear containers
packages. If they are installed it will use them as default paths. This
is useful for people that want to use `cc-oci-runtime` compiled from
source but had a previous installation from packages.
Fixes: #769

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>