### PR TITLE
build: Adds option to install kernel and image

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -818,6 +818,26 @@ endif
 
 check: $(CHECK_DEPS)
 
+artifacts: | install-image install-kernel
+
+# Get clear containers image path
+IMAGE_PATH := $(shell dirname $(CONTAINERS_IMG))
+install-image:
+	@if [ $(shell id -u) -ne 0 ]; then \
+		$(srcdir)/installation/install_clear_image.sh $(CLEAR_VM_IMAGE_VERSION) $(IMAGE_PATH) ; \
+	else \
+		>&2 echo "ERROR: do not run $@ as root" ; \
+	fi
+
+# Get clear containers kernel path
+KERNEL_PATH := $(shell dirname $(CONTAINER_KERNEL))
+install-kernel:
+	@if [ $(shell id -u) -ne 0 ]; then \
+		$(srcdir)/installation/install_clear_kernel.sh $(CLEAR_VM_IMAGE_VERSION) $(CLEAR_VM_KERNEL_VERSION) $(KERNEL_PATH) ; \
+	else \
+		>&2 echo "ERROR: do not run $@ as root" ; \
+	fi
+
 clean-local:
 	rm -f commit_id
 if AUTOGOPATH

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Overview
 --------
 
 ``cc-oci-runtime`` is an Open Containers Initiative (OCI_) "runtime"
-that launches an Intel_ VT-x secured Clear Containers 2.0 hypervisor,
+that launches an Intel_ VT-x secured Clear Containers 2.1 hypervisor,
 rather than a standard Linux container. It leverages the highly
 optimised `Clear Linux`_ technology to achieve this goal.
 
@@ -214,6 +214,16 @@ If you have specific requirements, run::
 ... then add the extra "``configure``" flags you want to use::
 
   $ ./autogen.sh --enable-foo --disable-bar && make
+
+Artifacts
+---------
+
+- clear-containers-image
+- clear-containers-kernel
+
+To download and install artifacts for Clear Containers, run::
+
+  $ make artifacts
 
 Tests
 -----

--- a/configure.ac
+++ b/configure.ac
@@ -155,6 +155,9 @@ AM_CONDITIONAL([CRIO_TESTS], [test x"$run_crio_tests" = x"yes"])
 # Checks for libraries.
 source $srcdir/versions.txt
 
+AC_SUBST([CLEAR_VM_IMAGE_VERSION], [$clear_vm_image_version])
+AC_SUBST([CLEAR_VM_KERNEL_VERSION], [$clear_vm_kernel_version])
+
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= "$glib_version"], have_required_glib=yes, have_required_glib=no)
 AS_IF([test "$have_required_glib" != "yes"], AC_MSG_ERROR([ERROR: need glib ${glib_version}+ for the `G_FILE_MONITOR_WATCH_MOVES' flag]))
 

--- a/installation/install_clear_image.sh
+++ b/installation/install_clear_image.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2017 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+set -x
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 CLEAR_RELEASE PATH"
+    echo "       Install the clear rootfs image from clear CLEAR_RELEASE in PATH."
+    exit 1
+fi
+
+clear_release="$1"
+install_path="$2"
+image=clear-${clear_release}-containers.img
+cc_img_link_name="clear-containers.img"
+base_url="https://download.clearlinux.org/releases/${clear_release}/clear"
+tmpdir=$(mktemp -d -t $(basename $0).XXXXXXXXXXX) || exit 1
+pushd $tmpdir
+
+echo "Download clear containers image"
+curl -LO "${base_url}/${image}.xz"
+
+echo "Validate clear containers image checksum"
+curl -LO "${base_url}/${image}.xz-SHA512SUMS"
+sha512sum -c ${image}.xz-SHA512SUMS
+
+echo "Extract clear containers image"
+unxz ${image}.xz
+
+sudo mkdir -p ${install_path}
+echo "Install clear containers image"
+sudo install -D --owner root --group root --mode 0755 ${image} ${install_path}/${image}
+
+echo -e "Create symbolic link ${install_path}/${cc_img_link_name}"
+sudo ln -fs ${install_path}/${image} ${install_path}/${cc_img_link_name}
+
+# clean up
+rm -f ${image} ${image}.xz-SHA512SUMS
+popd

--- a/installation/install_clear_kernel.sh
+++ b/installation/install_clear_kernel.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2017 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+set -x
+set -e
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 CLEAR_RELEASE KERNEL_VERSION PATH"
+    echo "       Install the clear kernel image KERNEL_VERSION from clear CLEAR_RELEASE in PATH."
+    exit 1
+fi
+
+clear_release="$1"
+kernel_version="$2"
+install_path="$3"
+clear_install_path="/usr/share/clear-containers"
+kernel_raw=vmlinux-${kernel_version}.container
+kernel_zip=vmlinuz-${kernel_version}.container
+cc_kernel_raw_link_name="vmlinux.container"
+cc_kernel_zip_link_name="vmlinuz.container"
+tmpdir=$(mktemp -d -t $(basename $0).XXXXXXXXXXX) || exit 1
+pushd $tmpdir
+
+echo -e "Install clear containers kernel ${kernel_version}"
+
+curl -LO "https://download.clearlinux.org/releases/${clear_release}/clear/x86_64/os/Packages/linux-container-${kernel_version}.x86_64.rpm"
+rpm2cpio linux-container-${kernel_version}.x86_64.rpm | cpio -ivdm
+sudo install -D --owner root --group root --mode 0700 .${clear_install_path}/${kernel_raw} ${install_path}/${kernel_raw}
+sudo install -D --owner root --group root --mode 0700 .${clear_install_path}/${kernel_zip} ${install_path}/${kernel_zip}
+
+echo -e "Create symbolic link ${install_path}/${cc_kernel_raw_link_name}"
+sudo ln -fs ${install_path}/${kernel_raw} ${install_path}/${cc_kernel_raw_link_name}
+echo -e "Create symbolic link ${install_path}/${cc_kernel_zip_link_name}"
+sudo ln -fs ${install_path}/${kernel_zip} ${install_path}/${cc_kernel_zip_link_name}
+
+# cleanup
+rm -f linux-container-${kernel_version}.x86_64.rpm
+# be careful here, we don't want to rm something silly, note the leading .
+rm -r .${clear_install_path}
+rmdir ./usr/share
+rmdir ./usr
+popd


### PR DESCRIPTION
If a user pulls down cc-oci-runtime and does a make install, Clear
Containers will not work. It is assumed that binary artifacts are
already installed.

This adds `make artifacts` as an option to download and install `clear-containers-kernel` and `clear-containers-image.`

Fixes: #912

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>