### PR TITLE
pullapprove: Don't require doc team sign-off for vendor docs.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -43,9 +43,12 @@ groups:
   docs-team:
     conditions:
       files:
-        - "documentation/*"
-        - "*.md"
-        - "*.rst"
+        include:
+          - "documentation/*"
+          - "*.md"
+          - "*.rst"
+        exclude:
+          - "vendor/*"
     required: 1
     users:
       - rcaballeromx


### PR DESCRIPTION
Change the pullapprove config to ignore vendored documentation files.

Fixes #990.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>