### PR TITLE
Release 2.1.12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.11])
+AC_INIT([cc-oci-runtime], [2.1.12])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
## Changes                                                          
- kernel: update to version 4.9.32                                  
- build: obs: Update obs changelog for clear-containers-image       
- misc: Remove NEWS file.                                           
- artifacts: Update kernel and image for clear-containers           
- Fix docker swarm tests in docker 17                               
- build: obs: Update post release changelog                         
- docs: Update Clear Containers 2.1 Fedora docs                     
- build: Makefile: Add generate-files rule                          

## Shortlog                                                         
c0200a3 kernel: update to version 4.9.32                            
b395ad0 build: obs: Update obs changelog for clear-containers-image 
d09d4fc misc: Remove NEWS file.                                     
71d4ec2 artifacts: Update kernel and image for clear-containers     
f9b300f tests: skip flaky swarm test                                        
9c34a01 tests: replace harcoded service names to variables          
3b9fffb tests: don't wait forever for swarm replicas                
974184f tests: Add function to check when a swarm service is ready  
74683fe build: obs: Update post release changelog                   
bb492c8 docs: Update Clear Containers 2.1 Fedora docs               
eed89de build: Makefile: Add generate-files rule                    

## Compatibility with Docker                                        
Clear Containers 2.1.11 is compatible with Docker v17.05.0-ce       
## OCI Runtime Specification                                        
Clear Containers 2.1.11 support the OCI Runtime Specification [1.0.0-rc5][ocispec]                                                      

# Installation                                                      
- [Centos][centos]                                                  
- [Ubuntu][ubuntu]                                                  
- [Fedora][fedora]                                                  
- [Clear Linux][clearlinux]                                         

# Issues & limitations                                              
- Qemu segfault (free(): invalid pointer) running dnf install #669  
- DNS Resolution in Swarm #854                                      
- docker rm -f reports 'Driver devicemapper failed to remove root filesystem' #795                                                      

[centos]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Centos-7.md                  
[ubuntu]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Ubuntu.md                    
[fedora]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Fedora-25.md
[clearlinux]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-ClearLinux.md
[clearlinuximage]: https://download.clearlinux.org/releases/15900/clear/clear-15900-containers.img.xz                                   
[ocispec]: https://github.com/opencontainers/runtime-spec/releases/tag/v1.0.0-rc5 
Fixes: #992

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>