### PR TITLE
cc-oci-runtime.sh: Enable debug by default

### DIFF
--- a/data/cc-oci-runtime.sh.in
+++ b/data/cc-oci-runtime.sh.in
@@ -61,9 +61,9 @@ fi
 
 # Uncomment to enable the global log which will persist after a Clear
 # Container is destroyed.
-## runtime_args="$runtime_args --global-log=\"$global_log\""
+runtime_args="$runtime_args --global-log=\"$global_log\""
 
 # Uncomment to supplement the log with debug information
-## runtime_args="$runtime_args --debug"
+runtime_args="$runtime_args --debug"
 
 eval exec "$runtime" "$runtime_args" $@


### PR DESCRIPTION
We can assume that most of the time using
cc-oci-runtime.sh means we're looking for some debug information.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>