### PR TITLE
obs: Update packaging to include kernel config changes for xfs

### DIFF
--- a/data/obs-packaging/linux-container/config
+++ b/data/obs-packaging/linux-container/config
@@ -1859,6 +1859,7 @@ CONFIG_FIRMWARE_MEMMAP=y
 # File systems
 #
 CONFIG_DCACHE_WORD_ACCESS=y
+CONFIG_FS_IOMAP=y
 # CONFIG_EXT2_FS is not set
 # CONFIG_EXT3_FS is not set
 CONFIG_EXT4_FS=y
@@ -1872,7 +1873,12 @@ CONFIG_JBD2=y
 CONFIG_FS_MBCACHE=y
 # CONFIG_REISERFS_FS is not set
 # CONFIG_JFS_FS is not set
-# CONFIG_XFS_FS is not set
+CONFIG_XFS_FS=y
+# CONFIG_XFS_QUOTA is not set
+# CONFIG_XFS_POSIX_ACL is not set
+# CONFIG_XFS_RT is not set
+# CONFIG_XFS_WARN is not set
+# CONFIG_XFS_DEBUG is not set
 # CONFIG_GFS2_FS is not set
 # CONFIG_BTRFS_FS is not set
 # CONFIG_NILFS2_FS is not set


### PR DESCRIPTION
Kernel config has been updated to enable xfs file system support.

This is required for mounting block devices that have xfs file
system type.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>