### PR TITLE
release: 2.2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.1.12])
+AC_INIT([cc-oci-runtime], [2.2.0])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
# Release 2.2.0

## Changes
- Devicemapper storage: Added support to use device mapper volumes  as storage devices instead mount a shared rootfs with 9pfs.
  - This allow to use a compatible posix file system and fix issues like #669
- version: Update container image to 16020
- obs: Update packaging to include kernel config changes for xfs
- cc-oci-runtime.sh: Enable debug by default
- configure: Add warning when kernel or image is not found
- proxy: Better error message for too long socket path
- tests: metrics: formalise the metrics reporting methods
- build: Add option to install kernel and image

## Shortlog
271223a tests: Skip docker cp integration test for devicemapper storage
9b91166 tests: Fix functional tests to include workload directory
66cbd66 tests: Fix state tests and add check for workload_dir.
b8ffdb1 tests: Fix mounts test for unmounting volume.
97922b5 storage: Pass drive name to hyperstart with the newcontainer command
dd13e32 storage: Pass block device to qemu if found.
b95748f state: Store the block storage device file system type and index
2d783ae storage: Add function to check the storage for container rootfs
e05e368 mount: Add function to return the device name and file system type
b1768e8 mount: Add function to get the mount point given a path
f9c0d36 storage: Add function to check if device is a devicemapper device
2c8374d mount: Add function to get underlying device for a path.
69abef6 state: Update the rootfs and workload dir config from state
f202ba4 namespace: Do not join mount namespace while unmounting.
9d8a083 mounts: Unmount the container rootfs
61b8b8b proxy: Pass hyperstart fsmap array with newcontainer command.
27f25fc proxy: Pass shared directory to hyperstart.
0af8583 state: Store the workload dir and rootfs mount to state.
53dc5ff state: Add the host_path and mnt_dir field to state.
4bb2d17 mounts: Bind mount container rootfs to workload directory
65d5eb4 config: Add a new field "workload_dir" to config for the worload path
fb9f94e mounts: Factorise the pod function for bind-mouting rootfs
5249cb4 9pfs: Dynamically add 9pfs options to qemu.
0ef2f8c version: Update container image to version 16020
b1fcd2a obs: Update packaging to include kernel config changes for xfs
567127f  cc-oci-runtime.sh: Enable debug by default
053ea8e tests: Fix make discheck running proxy
d10dc46 configure: Add warning when kernel or image is not found
c543dcb  proxy: Better error message for too long socket path
5b83071 tests: metrics: density: Use the new metrics reporting function
35de59e tests: metrics: Update README with details of new infra
9a4daf9 tests: metrics: Add script to save results into csv
827347d tests: common: Add new method for saving results
68c2673 build: Adds option to install kernel and image

## Compatibility with Docker
Clear Containers 2.2.0 is compatible with Docker v17.05.0-ce
## OCI Runtime Specification
Clear Containers 2.2.0 support the OCI Runtime Specification [1.0.0-rc5][ocispec]
## Clear Linux Containers image
Clear Containers 2.2.0 requires at least Clear Linux containers image [16020][clearlinuximage]
## Clear Linux Containers Kernel
Clear Containers 2.2.0 requires at least Clear Linux Containers  kernel 4.9.33-74

# Installation
- [Centos][centos]
- [Ubuntu][ubuntu]
- [Fedora][fedora]
- [Clear Linux][clearlinux]

# Issues & limitations
- Qemu segfault (free(): invalid pointer) running dnf install in non-devicemapper storage driver #669
- DNS Resolution in Swarm #854
- docker rm -f reports 'Driver devicemapper failed to remove root filesystem' #795
- Docker cp does not work with devicemapper storage driver #1004

[centos]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Centos-7.md
[ubuntu]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Ubuntu.md
[fedora]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Fedora.md
[clearlinux]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-ClearLinux.md
[clearlinuximage]: https://download.clearlinux.org/releases/16020/clear/clear-16020-containers.img.xz
[ocispec]: https://github.com/opencontainers/runtime-spec/releases/tag/v1.0.0-rc5
