### PR TITLE
CI: Enforce checkcommits.

### DIFF
--- a/.ci/ci-pre-checks.sh
+++ b/.ci/ci-pre-checks.sh
@@ -23,12 +23,15 @@
 #   will be aborted.
 #---------------------------------------------------------------------
 
-repo="github.com/clearcontainers/tests/cmd/checkcommits"
-go get -d "$repo"
-(cd "$GOPATH/src/$repo" && make)
-checkcommits \
-    --need-fixes \
-    --need-sign-offs \
-    --body-length 72 \
-    --subject-length 75 \
-    --verbose || true
+if [ "$TRAVIS" = true ]
+then
+    repo="github.com/clearcontainers/tests/cmd/checkcommits"
+    go get -d "$repo"
+    (cd "$GOPATH/src/$repo" && make)
+    checkcommits \
+        --need-fixes \
+        --need-sign-offs \
+        --body-length 72 \
+        --subject-length 75 \
+        --verbose
+fi


### PR DESCRIPTION
checkcommits has been running successfuly for a while now, so disallow
it failing in a CI environment.

Additionally, only run it in a TravisCI environment since it cannot
currently work under SemaphoreCI (due to its restrictive environment).

Fixes #967 (but actually fixed by https://github.com/clearcontainers/tests/pull/64).

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>