### PR TITLE
tests: Use nginx:1.13.0 for swarm tests

### DIFF
--- a/tests/integration/docker/dns.bats
+++ b/tests/integration/docker/dns.bats
@@ -54,14 +54,14 @@ setup() {
 	$DOCKER_EXE service create \
 	--name "${SERVICE1_NAME}" \
 	--replicas $number_of_replicas \
-	--publish 8080:80 nginx /bin/bash \
+	--publish 8080:80 "${nginx_image}" /bin/bash \
 	-c "hostname > /usr/share/nginx/html/hostname; nginx -g \"daemon off;\""
 
 	info "create service ${SERVICE2_NAME}"
 	$DOCKER_EXE service create \
 	--name "${SERVICE2_NAME}" \
 	--replicas $number_of_replicas \
-	--publish 8082:80 nginx /bin/bash \
+	--publish 8082:80 "${nginx_image}" /bin/bash \
 	-c "hostname > /usr/share/nginx/html/hostname; nginx -g \"daemon off;\""
 
 	info "create service ${DNS_TEST_SERVICE_NAME}"

--- a/tests/integration/docker/swarm.bats
+++ b/tests/integration/docker/swarm.bats
@@ -59,7 +59,7 @@ setup() {
 	$DOCKER_EXE service create \
 	--name "${SERVICE_NAME}" \
 	--replicas $number_of_replicas \
-	--publish 8080:80 nginx /bin/bash \
+	--publish 8080:80 "${nginx_image}" /bin/bash \
 	-c "hostname > /usr/share/nginx/html/hostname; nginx -g \"daemon off;\""
 	check_swarm_replicas "$number_of_replicas" "${SERVICE_NAME}" "$timeout"
 }

--- a/tests/lib/test-common.bash.in
+++ b/tests/lib/test-common.bash.in
@@ -27,6 +27,11 @@ HYPERVISOR_PATH="@QEMU_PATH@"
 CC_SHIM_PATH="/usr/libexec/cc-shim"
 number_of_attempts=5
 
+# Using Tag 1.13.0 for nginx image beause latest one does not 
+# provide 'ip' command used in swarm tests.
+# See https://github.com/01org/cc-oci-runtime/issues/1014 for more information
+nginx_image="nginx:1.13.0"
+
 # Checking that default runtime is cor
 function runtime_docker(){
 	default_runtime=`$DOCKER_EXE info 2>/dev/null | grep "^Default Runtime" | cut -d: -f2 | tr -d '[[:space:]]'`


### PR DESCRIPTION
Newest nginx docker image (1.13.1) does not contain `ip`
command by default, which we use in our swarm tests. This
commit specifies to use 1.13.0 which contains `ip`.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>