### PR TITLE
storage: Perform sync operation before vm is shutdown

### DIFF
--- a/data/cc-agent.service
+++ b/data/cc-agent.service
@@ -5,5 +5,5 @@ Description=Clear Container Agent
 StandardOutput=tty
 Type=simple
 ExecStart=/bin/hyperstart
-ExecStop=/usr/bin/systemctl --force poweroff
+ExecStop=/bin/sync ; /usr/bin/systemctl --force poweroff
 FailureAction=poweroff


### PR DESCRIPTION
In case we are using a block device for storage,
perform sync so that cached files are written to storage
before VM is shutdown.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>