### PR TITLE
delete: Fail if try to delete a non-stopped container.

### DIFF
--- a/src/oci.c
+++ b/src/oci.c
@@ -1075,17 +1075,25 @@ cc_oci_stop (struct cc_oci_config *config,
 		return false;
 	}
 
+	/* if the process has finished the container is stopped */
+	if (kill (state->pid, 0) != 0) {
+		config->state.status = OCI_STATUS_STOPPED;
+	}
+
+	if (config->state.status != OCI_STATUS_STOPPED ) {
+		g_critical("cannot delete container, it is not stopped");
+		return false;
+	}
+
 	/* is VM running? */
 	if (kill (config->vm->pid, 0) == 0) {
+		/* delete a pod_containers not destroy a VM(pod)*/
 		if (cc_pod_is_pod_container(config)) {
 			g_debug("Cannot delete container %s (pid %u) - "
-				"it is a pod container", state->id, state->pid);
-		} else if (cc_pod_is_pod_sandbox (config) ||
-				config->state.status != OCI_STATUS_STOPPED) {
-			if (! cc_proxy_hyper_destroy_pod(config)) {
-				g_critical ("failed to destroy pod");
-				return false;
-			}
+					"it is a pod container", state->id, state->pid);
+		} else if (! cc_proxy_hyper_destroy_pod(config)) {
+			g_critical ("failed to destroy pod");
+			return false;
 		}
     } else {
 		/* This isn't a fatal condition since:

--- a/src/oci.c
+++ b/src/oci.c
@@ -1091,7 +1091,8 @@ cc_oci_stop (struct cc_oci_config *config,
 		if (cc_pod_is_pod_container(config)) {
 			g_debug("Cannot delete container %s (pid %u) - "
 					"it is a pod container", state->id, state->pid);
-		} else if (! cc_proxy_hyper_destroy_pod(config)) {
+		} else if (! cc_proxy_hyper_destroy_pod(config) &&
+				kill (config->vm->pid, 0) != 0) {
 			g_critical ("failed to destroy pod");
 			return false;
 		}

--- a/tests/functional/kill.bats
+++ b/tests/functional/kill.bats
@@ -153,3 +153,24 @@ function teardown() {
 
 	rm -f "${ROOTFS_DIR}/${trap_file}"
 }
+
+@test "start and delete without kill" {
+	workload_cmd "sh"
+
+	cmd="$COR run -d --bundle $BUNDLE_DIR $container_id"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	testcontainer "$container_id" "running"
+
+	#delete without stop container MUST fail
+	cmd="$COR delete $container_id"
+	run_cmd "$cmd" "1" "$COR_TIMEOUT"
+	verify_runtime_dirs "$container_id" "running"
+
+	cmd="$COR kill $container_id TERM"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	testcontainer "$container_id" "killed"
+
+	cmd="$COR delete $container_id"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	verify_runtime_dirs "$container_id" "deleted"
+}


### PR DESCRIPTION
This PR add validation in `delete` command, delete must fail if the container is not `stopped`.

Fixes #1018 