### PR TITLE
release: 2.2.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.2.0])
+AC_INIT([cc-oci-runtime], [2.2.1])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
# Release 2.2.1

## Changes
- versions: update kernel to linux-container-4.9.34-75
- shim: Add command line option to show version information
- storage: Perform sync operation before vm is shutdown
- tests: Use nginx:1.13.0 for swarm tests
- proxy: Lift the numbers of opened file descriptors limit
- CI: Enforce checkcommits.
- Fix unnecessary bash-isms in installation script

## Shortlog
3eeda89 versions: update kernel to linux-container-4.9.34-75
4e8f155 version: Add command line option to show version information
21b874a storage: Perform sync operation before vm is shutdown
191e9f8 tests: Use nginx:1.13.0 for swarm tests
2f22de2 proxy: Lift the numbers of opened file descriptors limit
55eba02 CI: Enforce checkcommits.
6566262 Fix unnecessary bash-isms in installation script

## Compatibility with Docker
Clear Containers 2.2.1 is compatible with Docker v17.05.0-ce
## OCI Runtime Specification
Clear Containers 2.2.1 support the OCI Runtime Specification
[1.0.0-rc5][ocispec]
## Clear Linux Containers image
Clear Containers 2.2.1 requires at least Clear Linux containers image
[16160][clearlinuximage]
## Clear Linux Containers Kernel
Clear Containers 2.2.1 requires at least Clear Linux Containers  kernel
4.9.34-75

# Installation
- [Centos][centos]
- [Ubuntu][ubuntu]
- [Fedora][fedora]
- [Clear Linux][clearlinux]

# Issues & limitations
- Qemu segfault (free(): invalid pointer) running dnf install #669
- DNS Resolution in Swarm #854
- docker rm -f reports 'Driver devicemapper failed to remove root
filesystem' #795

[centos]:
https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Centos-7.md
[ubuntu]:
https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Ubuntu.md
[fedora]:
https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Fedora.md
[clearlinux]:
https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-ClearLinux.md
[clearlinuximage]:
https://download.clearlinux.org/releases/16160/clear/clear-16160-containers.img.xz
[ocispec]:
https://github.com/opencontainers/runtime-spec/releases/tag/v1.0.0-rc5

Fixes: #1022

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>