### PR TITLE
Tests: Change nginx image for swarm tests

### DIFF
--- a/tests/lib/test-common.bash.in
+++ b/tests/lib/test-common.bash.in
@@ -30,7 +30,7 @@ number_of_attempts=5
 # Using Tag 1.13.0 for nginx image beause latest one does not 
 # provide 'ip' command used in swarm tests.
 # See https://github.com/01org/cc-oci-runtime/issues/1014 for more information
-nginx_image="nginx:1.13.0"
+nginx_image="gabyct/nginx"
 
 # Checking that default runtime is cor
 function runtime_docker(){


### PR DESCRIPTION
Use the docker hub image gabyct/nginx for our swarm tests.

Fixes #1027

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>