### PR TITLE
documentation: ciao-down prepare is now ciao-down create

### DIFF
--- a/documentation/Quickstart-Clear-Containers-in-a-Ubuntu-VM.md
+++ b/documentation/Quickstart-Clear-Containers-in-a-Ubuntu-VM.md
@@ -48,7 +48,7 @@ All you need to do to use ``ciao-down`` on your machine is:
 * Install ``ciao-down``:
 
    ```
-   $ go get github.com/01org/ciao/testutil/ciao-down
+   $ go get -u github.com/01org/ciao/testutil/ciao-down
    ```
 
 * Create a Clear Containers VM:

--- a/documentation/Quickstart-Clear-Containers-in-a-Ubuntu-VM.md
+++ b/documentation/Quickstart-Clear-Containers-in-a-Ubuntu-VM.md
@@ -55,7 +55,7 @@ All you need to do to use ``ciao-down`` on your machine is:
 
 
    ```
-   $ $GOPATH/bin/ciao-down prepare -vmtype clearcontainers
+   $ $GOPATH/bin/ciao-down create clearcontainers
    $ $GOPATH/bin/ciao-down connect
    ```
 
@@ -63,9 +63,9 @@ All you need to do to use ``ciao-down`` on your machine is:
 
 
 ```
-$ ciao-down [prepare|start|stop|quit|status|connect|delete]
+$ ciao-down [create|start|stop|quit|status|connect|delete]
 
-- prepare : creates a new VM for ciao or clear containers
+- create : creates a new VM
 - start : boots a stopped VM
 - stop : cleanly powers down a running VM
 - quit : quits a running VM


### PR DESCRIPTION
We've changed a bit how ciao-down creates new VMs so it's not tied to
ciao as much as before. See:

  https://github.com/01org/ciao/pull/1362

Update the documentation to follow that change.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>