### PR TITLE
Add missing slashes in key URL

### DIFF
--- a/documentation/Installing-Clear-Containers-on-Ubuntu.md
+++ b/documentation/Installing-Clear-Containers-on-Ubuntu.md
@@ -58,7 +58,7 @@ For more information on installing Docker please refer to the
 
 ```
 sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearlinux:/preview:/clear-containers-2.1/xUbuntu_$(lsb_release -rs)/ /' >> /etc/apt/sources.list.d/cc-oci-runtime.list"
-curl -fsSL http://download.opensuse.org/repositories/home:clearlinux:preview:clear-containers-2.1/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
+curl -fsSL http://download.opensuse.org/repositories/home:/clearlinux:/preview:/clear-containers-2.1/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
 ```
 
 ## Install Clear Containers 2.1


### PR DESCRIPTION
The URL in the `curl` command for fetching the Release key is missing
the directory slashes.  This commit corrects this.

Fixes: #1051

Signed-off-by: dan pittman <danielscottt@gmail.com>