### PR TITLE
Release 2.2.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([cc-oci-runtime], [2.2.3])
+AC_INIT([cc-oci-runtime], [2.2.4])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
# Release 2.2.4                                            

## Changes                                                 
- versions: Update image to version 16670                  
- OBS: add dependencies' versions                          
- documentation: ciao-down prepare is now ciao-down create 

## Shortlog                                                
cbdfd1d versions: Update image to version 16670                                  
2c13fb1 OBS: add dependencies' versions                    
68d00dc documentation: Add the -u flag when go getting ciao-down                                                       
0c9d6bb documentation: ciao-down prepare is now ciao-down create                                                       

## Compatibility with Docker                               
Clear Containers 2.2.4 is compatible with Docker v17.05.0-ce                                                           
## OCI Runtime Specification                               
Clear Containers 2.2.4 support the OCI Runtime Specification [1.0.0-rc5][ocispec]                                      
## Clear Linux Containers image                            
Clear Containers 2.2.4 requires at least Clear Linux containers image [16670][clearlinuximage]                         
## Clear Linux Containers Kernel                           
Clear Containers 2.2.4 requires at least Clear Linux Containers  kernel 4.9.35-76                                      

# Installation                                             
- [Centos][centos]                                         
- [Ubuntu][ubuntu]                                         
- [Fedora][fedora]                                         
- [Clear Linux][clearlinux]                                

# Issues & limitations                                     
- Qemu segfault (free(): invalid pointer) running dnf install #669                                                     
- DNS Resolution in Swarm #854                             
- docker rm -f reports 'Driver devicemapper failed to remove root filesystem' #795                                     

[centos]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Centos-7.md 
[ubuntu]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Ubuntu.md   
[fedora]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-Fedora.md   
[clearlinux]: https://github.com/01org/cc-oci-runtime/blob/master/documentation/Installing-Clear-Containers-on-ClearLinux.md                                                                                                                  
[clearlinuximage]: https://download.clearlinux.org/releases/16670/clear/clear-16670-containers.img.xz                  
[ocispec]: https://github.com/opencontainers/runtime-spec/releases/tag/v1.0.0-rc5      